### PR TITLE
Refactor databas_core error types to use thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ version = "0.1.0"
 dependencies = [
  "fastrand",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -278,6 +279,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ version = '0.1.0'
 authors = ['writemorecode']
 edition = '2024'
 repository = 'https://github.com/writemorecode/databas'
+
+[workspace.dependencies]
+thiserror = "2.0.18"

--- a/crates/databas_core/Cargo.toml
+++ b/crates/databas_core/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [dependencies]
 fastrand = "2.3.0"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -1,26 +1,35 @@
-use std::{error::Error as StdError, fmt};
+use std::fmt;
+use thiserror::Error;
 
 use crate::{
     page::{CellCorruption, PageCorruption, PageError},
     types::{PAGE_SIZE, PageId, RowId},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum StorageError {
-    Io(std::io::Error),
-    Corruption(CorruptionError),
-    Constraint(ConstraintError),
-    InvalidArgument(InvalidArgumentError),
-    LimitExceeded(LimitExceededError),
-    Internal(InternalError),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("corruption: {0}")]
+    Corruption(#[source] CorruptionError),
+    #[error("constraint violation: {0}")]
+    Constraint(#[source] ConstraintError),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(#[source] InvalidArgumentError),
+    #[error("limit exceeded: {0}")]
+    LimitExceeded(#[source] LimitExceededError),
+    #[error("internal error: {0}")]
+    Internal(#[source] InternalError),
 }
 
 pub type StorageResult<T> = Result<T, StorageError>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{}", format_corruption_error(*component, *page_id, kind))]
 pub struct CorruptionError {
     pub component: CorruptionComponent,
     pub page_id: Option<PageId>,
+    #[source]
     pub kind: CorruptionKind,
 }
 
@@ -34,98 +43,123 @@ pub enum CorruptionComponent {
     Cell,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CorruptionKind {
+    #[error("invalid file size {size} for page size {page_size}")]
     InvalidFileSize { size: u64, page_size: usize },
+    #[error("unknown page kind: raw tag {actual}")]
     UnknownPageKind { actual: u8 },
+    #[error("invalid page kind: expected {expected}, got raw tag {actual}")]
     InvalidPageKind { expected: &'static str, actual: u8 },
+    #[error("invalid page version: expected {expected}, got {actual}")]
     InvalidPageVersion { expected: u8, actual: u8 },
+    #[error("slot directory exceeds usable page space")]
     SlotDirectoryExceedsUsableSpace,
+    #[error("content start is outside usable page space")]
     ContentStartOutOfBounds,
+    #[error("slot directory overlaps the cell-content region")]
     SlotDirectoryOverlapsContent,
+    #[error("reserved footer is not zeroed")]
     ReservedFooterNotZero,
+    #[error("fragmented free byte count exceeds the supported maximum")]
     FragmentedFreeBytesTooLarge,
+    #[error("freeblock offset points outside the content region")]
     FreeblockOffsetOutOfBounds,
+    #[error("freeblock is smaller than the minimum header size")]
     FreeblockTooSmall,
+    #[error("freeblock runs past the usable page bounds")]
     FreeblockOutOfBounds,
+    #[error("slot offset points outside the cell-content region")]
     SlotOffsetOutOfBounds,
+    #[error("cell length prefix runs past the usable page bounds")]
     CellLengthPrefixOutOfBounds,
+    #[error("interior cell runs past the usable page bounds")]
     InteriorCellOutOfBounds,
+    #[error("cell length is smaller than the minimum header")]
     CellLengthTooSmall,
+    #[error("cell length runs past the usable page bounds")]
     CellLengthOutOfBounds,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ConstraintError {
+    #[error("duplicate row id: {row_id}")]
     DuplicateRowId { row_id: RowId },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum InvalidArgumentError {
+    #[error("invalid page id: {page_id}")]
     InvalidPageId { page_id: PageId },
+    #[error("row id not found: {row_id}")]
     RowIdNotFound { row_id: RowId },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum LimitExceededError {
+    #[error("page full: need {needed} bytes, only {available} available")]
     PageFull { needed: usize, available: usize },
+    #[error("cell too large: {len} bytes exceeds max {max}")]
     CellTooLarge { len: usize, max: usize },
+    #[error("cache capacity exhausted")]
     CacheCapacityExhausted,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum InternalError {
-    InvariantViolation(InvariantViolation),
+    #[error("{0}")]
+    InvariantViolation(#[source] InvariantViolation),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum InvariantViolation {
+    #[error("pinned page during flush: {page_id}")]
     PinnedPageDuringFlush { page_id: PageId },
+    #[error("page {page_id} cannot be borrowed due to an active conflicting borrow")]
     PageBorrowConflict { page_id: PageId },
+    #[error("invalid frame count: {frame_count}")]
     InvalidFrameCount { frame_count: usize },
+    #[error(
+        "corrupt page table entry: page {page_id} maps to invalid frame {frame_id} (frame count: {frame_count})"
+    )]
     CorruptPageTableEntry { page_id: PageId, frame_id: usize, frame_count: usize },
+    #[error("invalid slot index {slot_index} for {slot_count} slots")]
     InvalidSlotIndex { slot_index: u16, slot_count: u16 },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum DiskManagerError {
-    Io(std::io::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid page id: {page_id}")]
     InvalidPageId { page_id: PageId },
+    #[error("invalid file size (not multiple of page size): {size}")]
     InvalidFileSize { size: u64 },
 }
 
 pub(crate) type DiskManagerResult<T> = Result<T, DiskManagerError>;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum PageCacheError {
-    Disk(DiskManagerError),
+    #[error("disk manager error: {0}")]
+    Disk(#[from] DiskManagerError),
+    #[error("no evictable frame available")]
     NoEvictableFrame,
+    #[error("page {page_id} is pinned")]
     PinnedPage { page_id: PageId },
+    #[error("page {page_id} cannot be borrowed immutably while a mutable borrow is active")]
     PageImmutableBorrowConflict { page_id: PageId },
+    #[error("page {page_id} cannot be borrowed mutably while another borrow is active")]
     PageMutableBorrowConflict { page_id: PageId },
+    #[error("invalid frame count: {frame_count}")]
     InvalidFrameCount { frame_count: usize },
+    #[error(
+        "corrupt page table entry: page {page_id} maps to invalid frame {frame_id} (frame count: {frame_count})"
+    )]
     CorruptPageTableEntry { page_id: PageId, frame_id: usize, frame_count: usize },
 }
 
 pub(crate) type PageCacheResult<T> = Result<T, PageCacheError>;
-
-impl From<std::io::Error> for StorageError {
-    fn from(err: std::io::Error) -> Self {
-        Self::Io(err)
-    }
-}
-
-impl From<std::io::Error> for DiskManagerError {
-    fn from(err: std::io::Error) -> Self {
-        Self::Io(err)
-    }
-}
-
-impl From<DiskManagerError> for PageCacheError {
-    fn from(err: DiskManagerError) -> Self {
-        Self::Disk(err)
-    }
-}
 
 impl From<DiskManagerError> for StorageError {
     fn from(err: DiskManagerError) -> Self {
@@ -269,47 +303,6 @@ fn map_cell_corruption(kind: CellCorruption) -> CorruptionKind {
     }
 }
 
-impl fmt::Display for StorageError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io(err) => write!(f, "I/O error: {err}"),
-            Self::Corruption(err) => write!(f, "corruption: {err}"),
-            Self::Constraint(err) => write!(f, "constraint violation: {err}"),
-            Self::InvalidArgument(err) => write!(f, "invalid argument: {err}"),
-            Self::LimitExceeded(err) => write!(f, "limit exceeded: {err}"),
-            Self::Internal(err) => write!(f, "internal error: {err}"),
-        }
-    }
-}
-
-impl StdError for StorageError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::Io(err) => Some(err),
-            Self::Corruption(err) => Some(err),
-            Self::Constraint(err) => Some(err),
-            Self::InvalidArgument(err) => Some(err),
-            Self::LimitExceeded(err) => Some(err),
-            Self::Internal(err) => Some(err),
-        }
-    }
-}
-
-impl fmt::Display for CorruptionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.page_id {
-            Some(page_id) => write!(f, "{} (page {page_id}): {}", self.component, self.kind),
-            None => write!(f, "{}: {}", self.component, self.kind),
-        }
-    }
-}
-
-impl StdError for CorruptionError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(&self.kind)
-    }
-}
-
 impl fmt::Display for CorruptionComponent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -323,200 +316,13 @@ impl fmt::Display for CorruptionComponent {
     }
 }
 
-impl fmt::Display for CorruptionKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidFileSize { size, page_size } => {
-                write!(f, "invalid file size {size} for page size {page_size}")
-            }
-            Self::UnknownPageKind { actual } => write!(f, "unknown page kind: raw tag {actual}"),
-            Self::InvalidPageKind { expected, actual } => {
-                write!(f, "invalid page kind: expected {expected}, got raw tag {actual}")
-            }
-            Self::InvalidPageVersion { expected, actual } => {
-                write!(f, "invalid page version: expected {expected}, got {actual}")
-            }
-            Self::SlotDirectoryExceedsUsableSpace => {
-                write!(f, "slot directory exceeds usable page space")
-            }
-            Self::ContentStartOutOfBounds => {
-                write!(f, "content start is outside usable page space")
-            }
-            Self::SlotDirectoryOverlapsContent => {
-                write!(f, "slot directory overlaps the cell-content region")
-            }
-            Self::ReservedFooterNotZero => write!(f, "reserved footer is not zeroed"),
-            Self::FragmentedFreeBytesTooLarge => {
-                write!(f, "fragmented free byte count exceeds the supported maximum")
-            }
-            Self::FreeblockOffsetOutOfBounds => {
-                write!(f, "freeblock offset points outside the content region")
-            }
-            Self::FreeblockTooSmall => {
-                write!(f, "freeblock is smaller than the minimum header size")
-            }
-            Self::FreeblockOutOfBounds => {
-                write!(f, "freeblock runs past the usable page bounds")
-            }
-            Self::SlotOffsetOutOfBounds => {
-                write!(f, "slot offset points outside the cell-content region")
-            }
-            Self::CellLengthPrefixOutOfBounds => {
-                write!(f, "cell length prefix runs past the usable page bounds")
-            }
-            Self::InteriorCellOutOfBounds => {
-                write!(f, "interior cell runs past the usable page bounds")
-            }
-            Self::CellLengthTooSmall => {
-                write!(f, "cell length is smaller than the minimum header")
-            }
-            Self::CellLengthOutOfBounds => {
-                write!(f, "cell length runs past the usable page bounds")
-            }
-        }
-    }
-}
-
-impl StdError for CorruptionKind {}
-
-impl fmt::Display for ConstraintError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::DuplicateRowId { row_id } => write!(f, "duplicate row id: {row_id}"),
-        }
-    }
-}
-
-impl StdError for ConstraintError {}
-
-impl fmt::Display for InvalidArgumentError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidPageId { page_id } => write!(f, "invalid page id: {page_id}"),
-            Self::RowIdNotFound { row_id } => write!(f, "row id not found: {row_id}"),
-        }
-    }
-}
-
-impl StdError for InvalidArgumentError {}
-
-impl fmt::Display for LimitExceededError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::PageFull { needed, available } => {
-                write!(f, "page full: need {needed} bytes, only {available} available")
-            }
-            Self::CellTooLarge { len, max } => {
-                write!(f, "cell too large: {len} bytes exceeds max {max}")
-            }
-            Self::CacheCapacityExhausted => write!(f, "cache capacity exhausted"),
-        }
-    }
-}
-
-impl StdError for LimitExceededError {}
-
-impl fmt::Display for InternalError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvariantViolation(inner) => write!(f, "{inner}"),
-        }
-    }
-}
-
-impl StdError for InternalError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::InvariantViolation(inner) => Some(inner),
-        }
-    }
-}
-
-impl fmt::Display for InvariantViolation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::PinnedPageDuringFlush { page_id } => {
-                write!(f, "pinned page during flush: {page_id}")
-            }
-            Self::PageBorrowConflict { page_id } => {
-                write!(f, "page {page_id} cannot be borrowed due to an active conflicting borrow")
-            }
-            Self::InvalidFrameCount { frame_count } => {
-                write!(f, "invalid frame count: {frame_count}")
-            }
-            Self::CorruptPageTableEntry { page_id, frame_id, frame_count } => write!(
-                f,
-                "corrupt page table entry: page {page_id} maps to invalid frame {frame_id} (frame count: {frame_count})"
-            ),
-            Self::InvalidSlotIndex { slot_index, slot_count } => {
-                write!(f, "invalid slot index {slot_index} for {slot_count} slots")
-            }
-        }
-    }
-}
-
-impl StdError for InvariantViolation {}
-
-impl fmt::Display for DiskManagerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io(err) => write!(f, "I/O error: {err}"),
-            Self::InvalidPageId { page_id } => write!(f, "invalid page id: {page_id}"),
-            Self::InvalidFileSize { size } => {
-                write!(f, "invalid file size (not multiple of page size): {size}")
-            }
-        }
-    }
-}
-
-impl StdError for DiskManagerError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::Io(err) => Some(err),
-            Self::InvalidPageId { .. } | Self::InvalidFileSize { .. } => None,
-        }
-    }
-}
-
-impl fmt::Display for PageCacheError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Disk(err) => write!(f, "disk manager error: {err}"),
-            Self::NoEvictableFrame => write!(f, "no evictable frame available"),
-            Self::PinnedPage { page_id } => write!(f, "page {page_id} is pinned"),
-            Self::PageImmutableBorrowConflict { page_id } => {
-                write!(
-                    f,
-                    "page {page_id} cannot be borrowed immutably while a mutable borrow is active"
-                )
-            }
-            Self::PageMutableBorrowConflict { page_id } => {
-                write!(
-                    f,
-                    "page {page_id} cannot be borrowed mutably while another borrow is active"
-                )
-            }
-            Self::InvalidFrameCount { frame_count } => {
-                write!(f, "invalid frame count: {frame_count}")
-            }
-            Self::CorruptPageTableEntry { page_id, frame_id, frame_count } => write!(
-                f,
-                "corrupt page table entry: page {page_id} maps to invalid frame {frame_id} (frame count: {frame_count})"
-            ),
-        }
-    }
-}
-
-impl StdError for PageCacheError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::Disk(err) => Some(err),
-            Self::NoEvictableFrame
-            | Self::PinnedPage { .. }
-            | Self::PageImmutableBorrowConflict { .. }
-            | Self::PageMutableBorrowConflict { .. }
-            | Self::InvalidFrameCount { .. }
-            | Self::CorruptPageTableEntry { .. } => None,
-        }
+fn format_corruption_error(
+    component: CorruptionComponent,
+    page_id: Option<PageId>,
+    kind: &CorruptionKind,
+) -> String {
+    match page_id {
+        Some(page_id) => format!("{component} (page {page_id}): {kind}"),
+        None => format!("{component}: {kind}"),
     }
 }

--- a/crates/databas_core/src/page/error.rs
+++ b/crates/databas_core/src/page/error.rs
@@ -1,31 +1,44 @@
-use std::{error::Error as StdError, fmt};
-
 use crate::types::{RowId, SlotId};
+use thiserror::Error;
 
 use super::format::PageKind;
 
 /// Errors returned while validating or modifying encoded pages.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum PageError {
     /// The encoded page kind tag is not recognized by this format version.
+    #[error("unknown page kind: raw tag {actual}")]
     UnknownPageKind { actual: u8 },
     /// The encoded page kind tag does not match the expected page kind.
+    #[error("invalid page kind: expected {expected:?}, got raw tag {actual}")]
     InvalidPageKind { expected: PageKind, actual: u8 },
     /// The encoded page version does not match [`super::FORMAT_VERSION`].
+    #[error("invalid page version: expected {expected}, got {actual}")]
     InvalidPageVersion { expected: u8, actual: u8 },
     /// A requested slot index is out of bounds for the current slot count.
+    #[error("invalid slot index {slot_index} for {slot_count} slots")]
     InvalidSlotIndex { slot_index: SlotId, slot_count: u16 },
     /// The page header or slot directory is structurally invalid.
-    MalformedPage(PageCorruption),
+    #[error("malformed page: {0}")]
+    MalformedPage(#[source] PageCorruption),
     /// A specific cell failed validation.
-    CorruptCell { slot_index: SlotId, kind: CellCorruption },
+    #[error("corrupt cell at slot {slot_index}: {kind}")]
+    CorruptCell {
+        slot_index: SlotId,
+        #[source]
+        kind: CellCorruption,
+    },
     /// An insert attempted to reuse an existing row id.
+    #[error("duplicate row id: {row_id}")]
     DuplicateRowId { row_id: RowId },
     /// An update targeted a row id that is not present.
+    #[error("row id not found: {row_id}")]
     RowIdNotFound { row_id: RowId },
     /// The page has insufficient free space for the requested operation.
+    #[error("page full: need {needed} bytes, only {available} available")]
     PageFull { needed: usize, available: usize },
     /// A cell encoding is larger than what the page format can represent.
+    #[error("cell too large: {len} bytes exceeds max {max}")]
     CellTooLarge { len: usize, max: usize },
 }
 
@@ -33,136 +46,50 @@ pub enum PageError {
 pub type PageResult<T> = Result<T, PageError>;
 
 /// Structural page corruption detected before or during page access.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum PageCorruption {
     /// The slot directory would extend past the usable page region.
+    #[error("slot directory exceeds usable page space")]
     SlotDirectoryExceedsUsableSpace,
     /// The content-start offset points beyond usable page space.
+    #[error("content start is outside usable page space")]
     ContentStartOutOfBounds,
     /// The slot directory and cell-content region overlap.
+    #[error("slot directory overlaps the cell-content region")]
     SlotDirectoryOverlapsContent,
     /// The reserved footer contains non-zero bytes.
+    #[error("reserved footer is not zeroed")]
     ReservedFooterNotZero,
     /// The fragmented free byte count exceeds the supported maximum.
+    #[error("fragmented free byte count exceeds the supported maximum")]
     FragmentedFreeBytesTooLarge,
     /// A freeblock header does not begin within the live content region.
+    #[error("freeblock offset points outside the content region")]
     FreeblockOffsetOutOfBounds,
     /// A freeblock span is too small to hold its own header.
+    #[error("freeblock is smaller than the minimum header size")]
     FreeblockTooSmall,
     /// A freeblock span runs past the usable page region.
+    #[error("freeblock runs past the usable page bounds")]
     FreeblockOutOfBounds,
     /// A slot entry points outside the live cell-content region.
+    #[error("slot offset points outside the cell-content region")]
     SlotOffsetOutOfBounds,
     /// A cell's length prefix would read past page bounds.
+    #[error("cell length prefix runs past the usable page bounds")]
     CellLengthPrefixOutOfBounds,
     /// A fixed-size interior cell would read past page bounds.
+    #[error("interior cell runs past the usable page bounds")]
     InteriorCellOutOfBounds,
 }
 
 /// Cell-level corruption detected while decoding a page cell.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum CellCorruption {
     /// The encoded cell length is too small for the minimum required prefix.
+    #[error("cell length is smaller than the minimum header")]
     LengthTooSmall,
     /// The encoded cell length runs past the usable page region.
+    #[error("cell length runs past the usable page bounds")]
     LengthOutOfBounds,
 }
-
-impl fmt::Display for PageError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::UnknownPageKind { actual } => {
-                write!(f, "unknown page kind: raw tag {actual}")
-            }
-            Self::InvalidPageKind { expected, actual } => {
-                write!(f, "invalid page kind: expected {expected:?}, got raw tag {actual}")
-            }
-            Self::InvalidPageVersion { expected, actual } => {
-                write!(f, "invalid page version: expected {expected}, got {actual}")
-            }
-            Self::InvalidSlotIndex { slot_index, slot_count } => {
-                write!(f, "invalid slot index {slot_index} for {slot_count} slots")
-            }
-            Self::MalformedPage(kind) => write!(f, "malformed page: {kind}"),
-            Self::CorruptCell { slot_index, kind } => {
-                write!(f, "corrupt cell at slot {slot_index}: {kind}")
-            }
-            Self::DuplicateRowId { row_id } => write!(f, "duplicate row id: {row_id}"),
-            Self::RowIdNotFound { row_id } => write!(f, "row id not found: {row_id}"),
-            Self::PageFull { needed, available } => {
-                write!(f, "page full: need {needed} bytes, only {available} available")
-            }
-            Self::CellTooLarge { len, max } => {
-                write!(f, "cell too large: {len} bytes exceeds max {max}")
-            }
-        }
-    }
-}
-
-impl StdError for PageError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::MalformedPage(kind) => Some(kind),
-            Self::CorruptCell { kind, .. } => Some(kind),
-            Self::UnknownPageKind { .. }
-            | Self::InvalidPageKind { .. }
-            | Self::InvalidPageVersion { .. }
-            | Self::InvalidSlotIndex { .. }
-            | Self::DuplicateRowId { .. }
-            | Self::RowIdNotFound { .. }
-            | Self::PageFull { .. }
-            | Self::CellTooLarge { .. } => None,
-        }
-    }
-}
-
-impl fmt::Display for PageCorruption {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::SlotDirectoryExceedsUsableSpace => {
-                write!(f, "slot directory exceeds usable page space")
-            }
-            Self::ContentStartOutOfBounds => {
-                write!(f, "content start is outside usable page space")
-            }
-            Self::SlotDirectoryOverlapsContent => {
-                write!(f, "slot directory overlaps the cell-content region")
-            }
-            Self::ReservedFooterNotZero => write!(f, "reserved footer is not zeroed"),
-            Self::FragmentedFreeBytesTooLarge => {
-                write!(f, "fragmented free byte count exceeds the supported maximum")
-            }
-            Self::FreeblockOffsetOutOfBounds => {
-                write!(f, "freeblock offset points outside the content region")
-            }
-            Self::FreeblockTooSmall => {
-                write!(f, "freeblock is smaller than the minimum header size")
-            }
-            Self::FreeblockOutOfBounds => {
-                write!(f, "freeblock runs past the usable page bounds")
-            }
-            Self::SlotOffsetOutOfBounds => {
-                write!(f, "slot offset points outside the cell-content region")
-            }
-            Self::CellLengthPrefixOutOfBounds => {
-                write!(f, "cell length prefix runs past the usable page bounds")
-            }
-            Self::InteriorCellOutOfBounds => {
-                write!(f, "interior cell runs past the usable page bounds")
-            }
-        }
-    }
-}
-
-impl fmt::Display for CellCorruption {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::LengthTooSmall => write!(f, "cell length is smaller than the minimum header"),
-            Self::LengthOutOfBounds => write!(f, "cell length runs past the usable page bounds"),
-        }
-    }
-}
-
-impl StdError for PageCorruption {}
-
-impl StdError for CellCorruption {}


### PR DESCRIPTION
## Summary
- add `thiserror` to `databas_core` and update the lockfile
- replace handwritten `Display` and `StdError` impls in storage and page error modules with `thiserror::Error` derives
- preserve the existing manual `From` conversions that normalize lower-level errors into `StorageError`
- keep the existing corruption error message shape with a small helper formatter

## Testing
- `cargo test`