### PR TITLE
Add support for index pages

### DIFF
--- a/crates/databas_core/src/disk_manager.rs
+++ b/crates/databas_core/src/disk_manager.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     error::{DiskManagerError, DiskManagerResult},
-    types::{PAGE_SIZE, PageId},
+    {PAGE_SIZE, PageId},
 };
 
 /// Reads and writes pages to and from a database file.

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::{
     page::{CellCorruption, PageCorruption, PageError},
-    types::{PAGE_SIZE, PageId, RowId},
+    {PAGE_SIZE, PageId, RowId},
 };
 
 #[derive(Debug, Error)]

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::{
     page::{CellCorruption, PageCorruption, PageError},
-    {PAGE_SIZE, PageId, RowId},
+    {PAGE_SIZE, PageId},
 };
 
 #[derive(Debug, Error)]
@@ -83,16 +83,16 @@ pub enum CorruptionKind {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ConstraintError {
-    #[error("duplicate row id: {row_id}")]
-    DuplicateRowId { row_id: RowId },
+    #[error("duplicate key")]
+    DuplicateKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum InvalidArgumentError {
     #[error("invalid page id: {page_id}")]
     InvalidPageId { page_id: PageId },
-    #[error("row id not found: {row_id}")]
-    RowIdNotFound { row_id: RowId },
+    #[error("key not found")]
+    KeyNotFound,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -253,12 +253,8 @@ impl From<PageError> for StorageError {
                 page_id: None,
                 kind: map_cell_corruption(kind),
             }),
-            PageError::DuplicateRowId { row_id } => {
-                Self::Constraint(ConstraintError::DuplicateRowId { row_id })
-            }
-            PageError::RowIdNotFound { row_id } => {
-                Self::InvalidArgument(InvalidArgumentError::RowIdNotFound { row_id })
-            }
+            PageError::DuplicateKey => Self::Constraint(ConstraintError::DuplicateKey),
+            PageError::KeyNotFound => Self::InvalidArgument(InvalidArgumentError::KeyNotFound),
             PageError::PageFull { needed, available } => {
                 Self::LimitExceeded(LimitExceededError::PageFull { needed, available })
             }

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -218,9 +218,9 @@ impl From<PageError> for StorageError {
                 kind: CorruptionKind::UnknownPageKind { actual },
             }),
             PageError::InvalidPageKind { expected, actual } => Self::Corruption(CorruptionError {
-                component: match expected {
-                    crate::page::format::PageKind::Leaf => CorruptionComponent::LeafPage,
-                    crate::page::format::PageKind::Interior => CorruptionComponent::InteriorPage,
+                component: match expected.node_kind() {
+                    crate::page::format::NodeKind::Leaf => CorruptionComponent::LeafPage,
+                    crate::page::format::NodeKind::Interior => CorruptionComponent::InteriorPage,
                 },
                 page_id: None,
                 kind: CorruptionKind::InvalidPageKind {
@@ -271,8 +271,10 @@ impl From<PageError> for StorageError {
 
 fn page_kind_name(kind: crate::page::format::PageKind) -> &'static str {
     match kind {
-        crate::page::format::PageKind::Leaf => "leaf",
-        crate::page::format::PageKind::Interior => "interior",
+        crate::page::format::PageKind::TableLeaf => "table leaf",
+        crate::page::format::PageKind::TableInterior => "table interior",
+        crate::page::format::PageKind::IndexLeaf => "index leaf",
+        crate::page::format::PageKind::IndexInterior => "index interior",
     }
 }
 

--- a/crates/databas_core/src/lib.rs
+++ b/crates/databas_core/src/lib.rs
@@ -4,4 +4,8 @@ pub(crate) mod page;
 pub(crate) mod page_cache;
 pub(crate) mod page_replacement;
 
-pub mod types;
+pub(crate) const PAGE_SIZE: usize = 4096;
+
+pub type PageId = u64;
+pub type RowId = u64;
+pub(crate) type SlotId = u16;

--- a/crates/databas_core/src/page/cell.rs
+++ b/crates/databas_core/src/page/cell.rs
@@ -5,7 +5,7 @@ use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 use super::{
     PageResult,
     core::{Index, Interior, Leaf, Page, PageAccess, PageAccessMut, Read, Table, Write},
-    index_leaf, interior, leaf,
+    index_interior, index_leaf, interior, leaf,
 };
 
 /// A typed view over a single slot entry within a page.
@@ -126,6 +126,37 @@ where
         let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
         let parts = interior::cell_parts(&page, self.slot_index)?;
         interior::write_left_child(self.bytes_mut(), parts.cell_offset, page_id);
+        Ok(())
+    }
+}
+
+impl<A> Cell<A, Interior, Index>
+where
+    A: PageAccess,
+{
+    /// Returns the separator key stored in this interior cell.
+    pub fn key(&self) -> PageResult<&[u8]> {
+        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
+        let parts = index_interior::cell_parts(&page, self.slot_index)?;
+        Ok(&self.bytes()[parts.key_start..parts.key_end])
+    }
+
+    /// Returns the left-child page id referenced by this interior cell.
+    pub fn left_child(&self) -> PageResult<PageId> {
+        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
+        Ok(index_interior::cell_parts(&page, self.slot_index)?.left_child)
+    }
+}
+
+impl<A> Cell<A, Interior, Index>
+where
+    A: PageAccessMut,
+{
+    /// Updates the left-child page id stored in this interior cell.
+    pub fn set_left_child(&mut self, page_id: PageId) -> PageResult<()> {
+        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
+        let parts = index_interior::cell_parts(&page, self.slot_index)?;
+        index_interior::write_left_child(self.bytes_mut(), parts.cell_offset, page_id);
         Ok(())
     }
 }

--- a/crates/databas_core/src/page/cell.rs
+++ b/crates/databas_core/src/page/cell.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::types::{PAGE_SIZE, PageId, RowId, SlotId};
+use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 
 use super::{
     PageResult,

--- a/crates/databas_core/src/page/cell.rs
+++ b/crates/databas_core/src/page/cell.rs
@@ -4,8 +4,8 @@ use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 
 use super::{
     PageResult,
-    core::{Interior, Leaf, Page, PageAccess, PageAccessMut, Read, Table, Write},
-    interior, leaf,
+    core::{Index, Interior, Leaf, Page, PageAccess, PageAccessMut, Read, Table, Write},
+    index_leaf, interior, leaf,
 };
 
 /// A typed view over a single slot entry within a page.
@@ -79,6 +79,24 @@ where
         let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
         let parts = leaf::cell_parts(&page, self.slot_index)?;
         Ok(&mut self.bytes_mut()[parts.payload_start..parts.payload_end])
+    }
+}
+
+impl<A> Cell<A, Leaf, Index>
+where
+    A: PageAccess,
+{
+    /// Returns the indexed key stored in this leaf cell.
+    pub fn key(&self) -> PageResult<&[u8]> {
+        let page = Page::<Read<'_>, Leaf, Index>::open(self.bytes())?;
+        let parts = index_leaf::cell_parts(&page, self.slot_index)?;
+        Ok(&self.bytes()[parts.key_start..parts.key_end])
+    }
+
+    /// Returns the row reference stored alongside this index key.
+    pub fn row_id(&self) -> PageResult<RowId> {
+        let page = Page::<Read<'_>, Leaf, Index>::open(self.bytes())?;
+        Ok(index_leaf::cell_parts(&page, self.slot_index)?.row_id)
     }
 }
 

--- a/crates/databas_core/src/page/cell.rs
+++ b/crates/databas_core/src/page/cell.rs
@@ -4,19 +4,19 @@ use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 
 use super::{
     PageResult,
-    core::{Interior, Leaf, Page, PageAccess, PageAccessMut, Read, Write},
+    core::{Interior, Leaf, Page, PageAccess, PageAccessMut, Read, Table, Write},
     interior, leaf,
 };
 
 /// A typed view over a single slot entry within a page.
 #[derive(Debug)]
-pub struct Cell<A, N> {
+pub struct Cell<A, N, T = Table> {
     access: A,
     slot_index: SlotId,
-    _marker: PhantomData<N>,
+    _marker: PhantomData<(N, T)>,
 }
 
-impl<A, N> Cell<A, N> {
+impl<A, N, T> Cell<A, N, T> {
     pub(crate) fn new(access: A, slot_index: SlotId) -> Self {
         Self { access, slot_index, _marker: PhantomData }
     }
@@ -27,7 +27,7 @@ impl<A, N> Cell<A, N> {
     }
 }
 
-impl<A, N> Cell<A, N>
+impl<A, N, T> Cell<A, N, T>
 where
     A: PageAccess,
 {
@@ -36,7 +36,7 @@ where
     }
 }
 
-impl<A, N> Cell<A, N>
+impl<A, N, T> Cell<A, N, T>
 where
     A: PageAccessMut,
 {
@@ -45,67 +45,67 @@ where
     }
 }
 
-impl<'a, N> Cell<Write<'a>, N> {
+impl<'a, N, T> Cell<Write<'a>, N, T> {
     /// Borrows this mutable cell as an immutable cell view.
-    pub fn as_ref(&self) -> Cell<Read<'_>, N> {
+    pub fn as_ref(&self) -> Cell<Read<'_>, N, T> {
         Cell::new(Read { bytes: self.bytes() }, self.slot_index)
     }
 }
 
-impl<A> Cell<A, Leaf>
+impl<A> Cell<A, Leaf, Table>
 where
     A: PageAccess,
 {
     /// Returns the row id stored in this leaf cell.
     pub fn row_id(&self) -> PageResult<RowId> {
-        let page = Page::<Read<'_>, Leaf>::open(self.bytes())?;
+        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
         Ok(leaf::cell_parts(&page, self.slot_index)?.row_id)
     }
 
     /// Returns the payload bytes stored in this leaf cell.
     pub fn payload(&self) -> PageResult<&[u8]> {
-        let page = Page::<Read<'_>, Leaf>::open(self.bytes())?;
+        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
         let parts = leaf::cell_parts(&page, self.slot_index)?;
         Ok(&self.bytes()[parts.payload_start..parts.payload_end])
     }
 }
 
-impl<A> Cell<A, Leaf>
+impl<A> Cell<A, Leaf, Table>
 where
     A: PageAccessMut,
 {
     /// Returns the payload bytes stored in this leaf cell mutably.
     pub fn payload_mut(&mut self) -> PageResult<&mut [u8]> {
-        let page = Page::<Read<'_>, Leaf>::open(self.bytes())?;
+        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
         let parts = leaf::cell_parts(&page, self.slot_index)?;
         Ok(&mut self.bytes_mut()[parts.payload_start..parts.payload_end])
     }
 }
 
-impl<A> Cell<A, Interior>
+impl<A> Cell<A, Interior, Table>
 where
     A: PageAccess,
 {
     /// Returns the separator row id stored in this interior cell.
     pub fn row_id(&self) -> PageResult<RowId> {
-        let page = Page::<Read<'_>, Interior>::open(self.bytes())?;
+        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
         Ok(interior::cell_parts(&page, self.slot_index)?.row_id)
     }
 
     /// Returns the left-child page id referenced by this interior cell.
     pub fn left_child(&self) -> PageResult<PageId> {
-        let page = Page::<Read<'_>, Interior>::open(self.bytes())?;
+        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
         Ok(interior::cell_parts(&page, self.slot_index)?.left_child)
     }
 }
 
-impl<A> Cell<A, Interior>
+impl<A> Cell<A, Interior, Table>
 where
     A: PageAccessMut,
 {
     /// Updates the left-child page id stored in this interior cell.
     pub fn set_left_child(&mut self, page_id: PageId) -> PageResult<()> {
-        let page = Page::<Read<'_>, Interior>::open(self.bytes())?;
+        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
         let parts = interior::cell_parts(&page, self.slot_index)?;
         interior::write_left_child(self.bytes_mut(), parts.cell_offset, page_id);
         Ok(())

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -21,18 +21,40 @@ pub enum Leaf {}
 #[derive(Debug)]
 pub enum Interior {}
 
+/// Marker type for pages that belong to a table b-tree.
+#[derive(Debug)]
+pub enum Table {}
+
+/// Marker type for pages that belong to an index b-tree.
+#[derive(Debug)]
+pub enum Index {}
+
 /// Associates a typed page marker with its encoded [`format::PageKind`].
 pub trait NodeMarker {
-    /// The page kind represented by this marker.
-    const KIND: format::PageKind;
+    /// The structural node kind represented by this marker.
+    const KIND: format::NodeKind;
+}
+
+/// Associates a typed tree marker with its encoded [`format::TreeKind`].
+pub trait TreeMarker {
+    /// The tree kind represented by this marker.
+    const KIND: format::TreeKind;
 }
 
 impl NodeMarker for Leaf {
-    const KIND: format::PageKind = format::PageKind::Leaf;
+    const KIND: format::NodeKind = format::NodeKind::Leaf;
 }
 
 impl NodeMarker for Interior {
-    const KIND: format::PageKind = format::PageKind::Interior;
+    const KIND: format::NodeKind = format::NodeKind::Interior;
+}
+
+impl TreeMarker for Table {
+    const KIND: format::TreeKind = format::TreeKind::Table;
+}
+
+impl TreeMarker for Index {
+    const KIND: format::TreeKind = format::TreeKind::Index;
 }
 
 /// Shared immutable access to a page-sized byte buffer.
@@ -79,21 +101,26 @@ impl PageAccessMut for Write<'_> {
 
 /// A typed view over an encoded page.
 ///
-/// `A` controls the access mode ([`Read`] or [`Write`]), while `N` controls the
-/// logical page kind ([`Leaf`] or [`Interior`]).
+/// `A` controls the access mode ([`Read`] or [`Write`]), `N` controls the node
+/// kind ([`Leaf`] or [`Interior`]), and `T` controls the tree kind
+/// ([`Table`] or [`Index`]).
 #[derive(Debug)]
-pub struct Page<A, N> {
+pub struct Page<A, N, T = Table> {
     access: A,
-    _marker: PhantomData<N>,
+    _marker: PhantomData<(N, T)>,
 }
 
 /// A page whose concrete node kind is determined by the encoded page header.
 #[derive(Debug)]
 pub enum AnyPage<A> {
-    /// A leaf page.
-    Leaf(Page<A, Leaf>),
-    /// An interior page.
-    Interior(Page<A, Interior>),
+    /// A table leaf page.
+    TableLeaf(Page<A, Leaf, Table>),
+    /// A table interior page.
+    TableInterior(Page<A, Interior, Table>),
+    /// An index leaf page.
+    IndexLeaf(Page<A, Leaf, Index>),
+    /// An index interior page.
+    IndexInterior(Page<A, Interior, Index>),
 }
 
 /// Result of searching a sorted slot directory by key.
@@ -179,13 +206,21 @@ fn read_freeblock(
     Ok(Freeblock { offset: offset as u16, size, next: format::read_optional_u16(bytes, offset) })
 }
 
-impl<A, N> Page<A, N> {
+fn page_kind<N, T>() -> format::PageKind
+where
+    N: NodeMarker,
+    T: TreeMarker,
+{
+    format::PageKind::from_parts(N::KIND, T::KIND)
+}
+
+impl<A, N, T> Page<A, N, T> {
     fn new(access: A) -> Self {
         Self { access, _marker: PhantomData }
     }
 }
 
-impl<A, N> Page<A, N>
+impl<A, N, T> Page<A, N, T>
 where
     A: PageAccess,
 {
@@ -198,8 +233,25 @@ where
     pub fn kind(&self) -> format::PageKind
     where
         N: NodeMarker,
+        T: TreeMarker,
+    {
+        page_kind::<N, T>()
+    }
+
+    /// Returns the statically known node kind of this page.
+    pub fn node_kind(&self) -> format::NodeKind
+    where
+        N: NodeMarker,
     {
         N::KIND
+    }
+
+    /// Returns the statically known tree kind of this page.
+    pub fn tree_kind(&self) -> format::TreeKind
+    where
+        T: TreeMarker,
+    {
+        T::KIND
     }
 
     /// Returns the encoded page-format version.
@@ -350,7 +402,7 @@ where
     {
         let cell_offset = self.slot_offset(slot_index)? as usize;
         match N::KIND {
-            format::PageKind::Leaf => {
+            format::NodeKind::Leaf => {
                 let cell_len = format::read_u16(self.bytes(), cell_offset) as usize;
                 if cell_len < CELL_LENGTH_SIZE {
                     return Err(PageError::CorruptCell {
@@ -366,12 +418,12 @@ where
                 }
                 Ok(cell_len)
             }
-            format::PageKind::Interior => Ok(super::interior::INTERIOR_CELL_SIZE),
+            format::NodeKind::Interior => Ok(super::interior::INTERIOR_CELL_SIZE),
         }
     }
 }
 
-impl<A, N> Page<A, N>
+impl<A, N, T> Page<A, N, T>
 where
     A: PageAccessMut,
     N: NodeMarker,
@@ -685,35 +737,37 @@ where
     }
 }
 
-impl<'a, N> Page<Read<'a>, N>
+impl<'a, N, T> Page<Read<'a>, N, T>
 where
     N: NodeMarker,
+    T: TreeMarker,
 {
     /// Validates and opens an immutable typed page view over an initialized buffer.
     pub fn open(bytes: &'a [u8; PAGE_SIZE]) -> PageResult<Self> {
-        validate_page(bytes, N::KIND)?;
+        validate_page(bytes, page_kind::<N, T>())?;
         Ok(Self::new(Read { bytes }))
     }
 }
 
-impl<'a, N> Page<Write<'a>, N>
+impl<'a, N, T> Page<Write<'a>, N, T>
 where
     N: NodeMarker,
+    T: TreeMarker,
 {
     /// Validates and opens a mutable typed page view over an initialized buffer.
     pub fn open(bytes: &'a mut [u8; PAGE_SIZE]) -> PageResult<Self> {
-        validate_page(bytes, N::KIND)?;
+        validate_page(bytes, page_kind::<N, T>())?;
         Ok(Self::new(Write { bytes }))
     }
 
     /// Borrows this mutable page as an immutable page view.
-    pub fn as_ref(&self) -> Page<Read<'_>, N> {
+    pub fn as_ref(&self) -> Page<Read<'_>, N, T> {
         Page::new(Read { bytes: self.bytes() })
     }
 
     pub(crate) fn initialize(bytes: &'a mut [u8; PAGE_SIZE]) -> Self {
         bytes.fill(0);
-        bytes[KIND_OFFSET] = N::KIND as u8;
+        bytes[KIND_OFFSET] = page_kind::<N, T>() as u8;
         bytes[VERSION_OFFSET] = FORMAT_VERSION;
         format::write_u16(bytes, SLOT_COUNT_OFFSET, 0);
         format::write_u16(bytes, CONTENT_START_OFFSET, USABLE_SPACE_END as u16);
@@ -725,14 +779,14 @@ where
     }
 }
 
-impl<'a> Page<Write<'a>, Leaf> {
+impl<'a> Page<Write<'a>, Leaf, Table> {
     /// Initializes a fresh empty leaf page in-place.
     pub fn init(bytes: &'a mut [u8; PAGE_SIZE]) -> Self {
         Self::initialize(bytes)
     }
 }
 
-impl<'a> Page<Write<'a>, Interior> {
+impl<'a> Page<Write<'a>, Interior, Table> {
     /// Initializes a fresh empty interior page with its rightmost child pointer set.
     pub fn init(bytes: &'a mut [u8; PAGE_SIZE], rightmost_child: PageId) -> Self {
         Self::initialize_with_rightmost(bytes, rightmost_child)
@@ -753,9 +807,17 @@ impl<'a> TryFrom<&'a [u8; PAGE_SIZE]> for AnyPage<Read<'a>> {
 
     fn try_from(bytes: &'a [u8; PAGE_SIZE]) -> Result<Self, Self::Error> {
         match format::PageKind::from_raw(bytes[KIND_OFFSET]) {
-            Some(format::PageKind::Leaf) => Ok(Self::Leaf(Page::<Read<'a>, Leaf>::open(bytes)?)),
-            Some(format::PageKind::Interior) => {
-                Ok(Self::Interior(Page::<Read<'a>, Interior>::open(bytes)?))
+            Some(format::PageKind::TableLeaf) => {
+                Ok(Self::TableLeaf(Page::<Read<'a>, Leaf, Table>::open(bytes)?))
+            }
+            Some(format::PageKind::TableInterior) => {
+                Ok(Self::TableInterior(Page::<Read<'a>, Interior, Table>::open(bytes)?))
+            }
+            Some(format::PageKind::IndexLeaf) => {
+                Ok(Self::IndexLeaf(Page::<Read<'a>, Leaf, Index>::open(bytes)?))
+            }
+            Some(format::PageKind::IndexInterior) => {
+                Ok(Self::IndexInterior(Page::<Read<'a>, Interior, Index>::open(bytes)?))
             }
             None => Err(PageError::UnknownPageKind { actual: bytes[KIND_OFFSET] }),
         }
@@ -767,9 +829,17 @@ impl<'a> TryFrom<&'a mut [u8; PAGE_SIZE]> for AnyPage<Write<'a>> {
 
     fn try_from(bytes: &'a mut [u8; PAGE_SIZE]) -> Result<Self, Self::Error> {
         match format::PageKind::from_raw(bytes[KIND_OFFSET]) {
-            Some(format::PageKind::Leaf) => Ok(Self::Leaf(Page::<Write<'a>, Leaf>::open(bytes)?)),
-            Some(format::PageKind::Interior) => {
-                Ok(Self::Interior(Page::<Write<'a>, Interior>::open(bytes)?))
+            Some(format::PageKind::TableLeaf) => {
+                Ok(Self::TableLeaf(Page::<Write<'a>, Leaf, Table>::open(bytes)?))
+            }
+            Some(format::PageKind::TableInterior) => {
+                Ok(Self::TableInterior(Page::<Write<'a>, Interior, Table>::open(bytes)?))
+            }
+            Some(format::PageKind::IndexLeaf) => {
+                Ok(Self::IndexLeaf(Page::<Write<'a>, Leaf, Index>::open(bytes)?))
+            }
+            Some(format::PageKind::IndexInterior) => {
+                Ok(Self::IndexInterior(Page::<Write<'a>, Interior, Index>::open(bytes)?))
             }
             None => Err(PageError::UnknownPageKind { actual: bytes[KIND_OFFSET] }),
         }
@@ -831,7 +901,7 @@ fn validate_page(bytes: &[u8; PAGE_SIZE], expected_kind: format::PageKind) -> Pa
         if slot_offset < content_start || slot_offset >= USABLE_SPACE_END {
             return Err(PageError::MalformedPage(PageCorruption::SlotOffsetOutOfBounds));
         }
-        if expected_kind == format::PageKind::Leaf {
+        if expected_kind.node_kind() == format::NodeKind::Leaf {
             if slot_offset + CELL_LENGTH_SIZE > USABLE_SPACE_END {
                 return Err(PageError::MalformedPage(PageCorruption::CellLengthPrefixOutOfBounds));
             }

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -399,26 +399,20 @@ where
     pub(crate) fn cell_len(&self, slot_index: SlotId) -> PageResult<usize>
     where
         N: NodeMarker,
+        T: TreeMarker,
     {
         let cell_offset = self.slot_offset(slot_index)? as usize;
-        match N::KIND {
-            format::NodeKind::Leaf => {
-                let cell_len = format::read_u16(self.bytes(), cell_offset) as usize;
-                if cell_len < CELL_LENGTH_SIZE {
-                    return Err(PageError::CorruptCell {
-                        slot_index,
-                        kind: super::CellCorruption::LengthTooSmall,
-                    });
-                }
-                if cell_offset + cell_len > USABLE_SPACE_END {
-                    return Err(PageError::CorruptCell {
-                        slot_index,
-                        kind: super::CellCorruption::LengthOutOfBounds,
-                    });
-                }
-                Ok(cell_len)
+        match page_kind::<N, T>() {
+            format::PageKind::TableLeaf => {
+                super::leaf::cell_len_at(self.bytes(), slot_index, cell_offset)
             }
-            format::NodeKind::Interior => Ok(super::interior::INTERIOR_CELL_SIZE),
+            format::PageKind::TableInterior => Ok(super::interior::INTERIOR_CELL_SIZE),
+            format::PageKind::IndexLeaf => {
+                super::index_leaf::cell_len_at(self.bytes(), slot_index, cell_offset)
+            }
+            format::PageKind::IndexInterior => {
+                super::index_interior::cell_len_at(self.bytes(), slot_index, cell_offset)
+            }
         }
     }
 }
@@ -427,6 +421,7 @@ impl<A, N, T> Page<A, N, T>
 where
     A: PageAccessMut,
     N: NodeMarker,
+    T: TreeMarker,
 {
     pub(crate) fn bytes_mut(&mut self) -> &mut [u8; PAGE_SIZE] {
         self.access.bytes_mut()
@@ -901,12 +896,32 @@ fn validate_page(bytes: &[u8; PAGE_SIZE], expected_kind: format::PageKind) -> Pa
         if slot_offset < content_start || slot_offset >= USABLE_SPACE_END {
             return Err(PageError::MalformedPage(PageCorruption::SlotOffsetOutOfBounds));
         }
-        if expected_kind.node_kind() == format::NodeKind::Leaf {
-            if slot_offset + CELL_LENGTH_SIZE > USABLE_SPACE_END {
-                return Err(PageError::MalformedPage(PageCorruption::CellLengthPrefixOutOfBounds));
+        match expected_kind {
+            format::PageKind::TableLeaf | format::PageKind::IndexLeaf => {
+                if slot_offset + CELL_LENGTH_SIZE > USABLE_SPACE_END {
+                    return Err(PageError::MalformedPage(
+                        PageCorruption::CellLengthPrefixOutOfBounds,
+                    ));
+                }
             }
-        } else if slot_offset + super::interior::INTERIOR_CELL_SIZE > USABLE_SPACE_END {
-            return Err(PageError::MalformedPage(PageCorruption::InteriorCellOutOfBounds));
+            format::PageKind::TableInterior => {
+                if slot_offset + super::interior::INTERIOR_CELL_SIZE > USABLE_SPACE_END {
+                    return Err(PageError::MalformedPage(PageCorruption::InteriorCellOutOfBounds));
+                }
+            }
+            format::PageKind::IndexInterior => {
+                if slot_offset + CELL_LENGTH_SIZE > USABLE_SPACE_END {
+                    return Err(PageError::MalformedPage(
+                        PageCorruption::CellLengthPrefixOutOfBounds,
+                    ));
+                }
+                let cell_len = format::read_u16(bytes, slot_offset) as usize;
+                if cell_len < super::index_interior::INDEX_INTERIOR_CELL_PREFIX_SIZE
+                    || slot_offset + cell_len > USABLE_SPACE_END
+                {
+                    return Err(PageError::MalformedPage(PageCorruption::InteriorCellOutOfBounds));
+                }
+            }
         }
     }
 

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -13,7 +13,7 @@ use super::{
     },
 };
 
-/// Marker type for leaf pages that store `(row_id, payload)` records.
+/// Marker type for leaf pages that store payload-bearing records.
 #[derive(Debug)]
 pub enum Leaf {}
 
@@ -110,7 +110,7 @@ pub struct Page<A, N, T = Table> {
     _marker: PhantomData<(N, T)>,
 }
 
-/// A page whose concrete node kind is determined by the encoded page header.
+/// A page whose concrete node kind and tree kind are determined by the encoded page header.
 #[derive(Debug)]
 pub enum AnyPage<A> {
     /// A table leaf page.

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use std::cmp::Ordering;
 
-use crate::{PAGE_SIZE, PageId, RowId, SlotId};
+use crate::{PAGE_SIZE, PageId, SlotId};
 
 use super::{
     error::{PageCorruption, PageError, PageResult},
@@ -275,23 +275,20 @@ where
         Ok(format::read_u16(self.bytes(), offset))
     }
 
-    pub(crate) fn search_slots_by<F>(&self, key: RowId, mut read_key: F) -> PageResult<SearchResult>
+    pub(crate) fn search_slots_by<F>(&self, mut compare_slot: F) -> PageResult<SearchResult>
     where
         N: NodeMarker,
-        F: FnMut(&Self, SlotId) -> PageResult<RowId>,
+        F: FnMut(&Self, SlotId) -> PageResult<Ordering>,
     {
         let mut low: SlotId = 0;
         let mut high = self.slot_count();
 
         while low < high {
             let mid = low + (high - low) / 2;
-            let mid_key = read_key(self, mid)?;
-            if mid_key < key {
-                low = mid + 1;
-            } else if mid_key > key {
-                high = mid;
-            } else {
-                return Ok(SearchResult::Found(mid));
+            match compare_slot(self, mid)? {
+                Ordering::Less => low = mid + 1,
+                Ordering::Greater => high = mid,
+                Ordering::Equal => return Ok(SearchResult::Found(mid)),
             }
         }
 
@@ -300,13 +297,12 @@ where
 
     pub(crate) fn bound_slots_by<F, P>(
         &self,
-        key: RowId,
-        mut read_key: F,
+        mut compare_slot: F,
         mut go_right: P,
     ) -> PageResult<BoundResult>
     where
         N: NodeMarker,
-        F: FnMut(&Self, SlotId) -> PageResult<RowId>,
+        F: FnMut(&Self, SlotId) -> PageResult<Ordering>,
         P: FnMut(Ordering) -> bool,
     {
         let mut low: SlotId = 0;
@@ -314,8 +310,7 @@ where
 
         while low < high {
             let mid = low + (high - low) / 2;
-            let mid_key = read_key(self, mid)?;
-            if go_right(mid_key.cmp(&key)) {
+            if go_right(compare_slot(self, mid)?) {
                 low = mid + 1;
             } else {
                 high = mid;
@@ -325,20 +320,20 @@ where
         if low == self.slot_count() { Ok(BoundResult::PastEnd) } else { Ok(BoundResult::At(low)) }
     }
 
-    pub(crate) fn lower_bound_slots_by<F>(&self, key: RowId, read_key: F) -> PageResult<BoundResult>
+    pub(crate) fn lower_bound_slots_by<F>(&self, compare_slot: F) -> PageResult<BoundResult>
     where
         N: NodeMarker,
-        F: FnMut(&Self, SlotId) -> PageResult<RowId>,
+        F: FnMut(&Self, SlotId) -> PageResult<Ordering>,
     {
-        self.bound_slots_by(key, read_key, |ordering| ordering == Ordering::Less)
+        self.bound_slots_by(compare_slot, |ordering| ordering == Ordering::Less)
     }
 
-    pub(crate) fn upper_bound_slots_by<F>(&self, key: RowId, read_key: F) -> PageResult<BoundResult>
+    pub(crate) fn upper_bound_slots_by<F>(&self, compare_slot: F) -> PageResult<BoundResult>
     where
         N: NodeMarker,
-        F: FnMut(&Self, SlotId) -> PageResult<RowId>,
+        F: FnMut(&Self, SlotId) -> PageResult<Ordering>,
     {
-        self.bound_slots_by(key, read_key, |ordering| ordering != Ordering::Greater)
+        self.bound_slots_by(compare_slot, |ordering| ordering != Ordering::Greater)
     }
 
     pub(crate) fn validate_slot_index(&self, slot_index: SlotId) -> PageResult<()> {

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -804,6 +804,22 @@ impl<'a> Page<Write<'a>, Interior, Table> {
     }
 }
 
+impl<'a> Page<Write<'a>, Interior, Index> {
+    /// Initializes a fresh empty index interior page with its rightmost child pointer set.
+    pub fn init(bytes: &'a mut [u8; PAGE_SIZE], rightmost_child: PageId) -> Self {
+        Self::initialize_with_rightmost(bytes, rightmost_child)
+    }
+
+    pub(crate) fn initialize_with_rightmost(
+        bytes: &'a mut [u8; PAGE_SIZE],
+        page_id: PageId,
+    ) -> Self {
+        let mut page = Self::initialize(bytes);
+        format::write_u64(page.bytes_mut(), format::RIGHTMOST_CHILD_OFFSET, page_id);
+        page
+    }
+}
+
 impl<'a> TryFrom<&'a [u8; PAGE_SIZE]> for AnyPage<Read<'a>> {
     type Error = PageError;
 

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -781,6 +781,13 @@ impl<'a> Page<Write<'a>, Leaf, Table> {
     }
 }
 
+impl<'a> Page<Write<'a>, Leaf, Index> {
+    /// Initializes a fresh empty index leaf page in-place.
+    pub fn init(bytes: &'a mut [u8; PAGE_SIZE]) -> Self {
+        Self::initialize(bytes)
+    }
+}
+
 impl<'a> Page<Write<'a>, Interior, Table> {
     /// Initializes a fresh empty interior page with its rightmost child pointer set.
     pub fn init(bytes: &'a mut [u8; PAGE_SIZE], rightmost_child: PageId) -> Self {

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -967,6 +967,18 @@ mod tests {
         bytes
     }
 
+    fn initialized_index_leaf_page() -> [u8; PAGE_SIZE] {
+        let mut bytes = [0_u8; PAGE_SIZE];
+        let _ = Page::<Write<'_>, Leaf, Index>::initialize(&mut bytes);
+        bytes
+    }
+
+    fn initialized_index_interior_page() -> [u8; PAGE_SIZE] {
+        let mut bytes = [0_u8; PAGE_SIZE];
+        let _ = Page::<Write<'_>, Interior, Index>::initialize_with_rightmost(&mut bytes, 17);
+        bytes
+    }
+
     #[test]
     fn initialize_sets_header_and_zero_footer() {
         let bytes = initialized_leaf_page();
@@ -979,6 +991,16 @@ mod tests {
         assert_eq!(format::read_optional_u64(&bytes, PREV_PAGE_ID_OFFSET), None);
         assert_eq!(format::read_optional_u64(&bytes, NEXT_PAGE_ID_OFFSET), None);
         assert_eq!(&bytes[USABLE_SPACE_END..], &[0_u8; PAGE_SIZE - USABLE_SPACE_END]);
+    }
+
+    #[test]
+    fn initialize_sets_index_page_kinds() {
+        let leaf = initialized_index_leaf_page();
+        let interior = initialized_index_interior_page();
+
+        assert_eq!(leaf[KIND_OFFSET], format::PageKind::IndexLeaf as u8);
+        assert_eq!(interior[KIND_OFFSET], format::PageKind::IndexInterior as u8);
+        assert_eq!(format::read_u64(&interior, format::RIGHTMOST_CHILD_OFFSET), 17);
     }
 
     #[test]
@@ -1046,6 +1068,24 @@ mod tests {
     }
 
     #[test]
+    fn open_rejects_mismatched_index_kind() {
+        let leaf = initialized_index_leaf_page();
+        let interior = initialized_index_interior_page();
+
+        let leaf_result = Page::<Read<'_>, Leaf>::open(&leaf);
+        assert_eq!(
+            leaf_result.unwrap_err(),
+            PageError::InvalidPageKind { expected: format::PageKind::TableLeaf, actual: 3 }
+        );
+
+        let interior_result = Page::<Read<'_>, Interior>::open(&interior);
+        assert_eq!(
+            interior_result.unwrap_err(),
+            PageError::InvalidPageKind { expected: format::PageKind::TableInterior, actual: 4 }
+        );
+    }
+
+    #[test]
     fn any_page_try_from_rejects_unknown_kind() {
         let mut bytes = [0_u8; PAGE_SIZE];
         bytes[KIND_OFFSET] = 99;
@@ -1054,6 +1094,18 @@ mod tests {
 
         let result = AnyPage::<Read<'_>>::try_from(&bytes);
         assert_eq!(result.unwrap_err(), PageError::UnknownPageKind { actual: 99 });
+    }
+
+    #[test]
+    fn any_page_try_from_opens_index_page_variants() {
+        let leaf = initialized_index_leaf_page();
+        let interior = initialized_index_interior_page();
+
+        assert!(matches!(AnyPage::<Read<'_>>::try_from(&leaf).unwrap(), AnyPage::IndexLeaf(_)));
+        assert!(matches!(
+            AnyPage::<Read<'_>>::try_from(&interior).unwrap(),
+            AnyPage::IndexInterior(_)
+        ));
     }
 
     #[test]

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use std::cmp::Ordering;
 
-use crate::types::{PAGE_SIZE, PageId, RowId, SlotId};
+use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 
 use super::{
     error::{PageCorruption, PageError, PageResult},

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -970,7 +970,7 @@ mod tests {
     #[test]
     fn initialize_sets_header_and_zero_footer() {
         let bytes = initialized_leaf_page();
-        assert_eq!(bytes[KIND_OFFSET], format::PageKind::Leaf as u8);
+        assert_eq!(bytes[KIND_OFFSET], format::PageKind::TableLeaf as u8);
         assert_eq!(bytes[VERSION_OFFSET], FORMAT_VERSION);
         assert_eq!(format::read_u16(&bytes, SLOT_COUNT_OFFSET), 0);
         assert_eq!(format::read_u16(&bytes, CONTENT_START_OFFSET), USABLE_SPACE_END as u16);
@@ -1041,7 +1041,7 @@ mod tests {
         let result = Page::<Read<'_>, Leaf>::open(&bytes);
         assert_eq!(
             result.unwrap_err(),
-            PageError::InvalidPageKind { expected: format::PageKind::Leaf, actual: 2 }
+            PageError::InvalidPageKind { expected: format::PageKind::TableLeaf, actual: 2 }
         );
     }
 
@@ -1251,12 +1251,18 @@ mod tests {
         let page = Page::<Read<'_>, Leaf>::open(&bytes).unwrap();
         let keys = [10_u64, 20, 40, 80];
 
-        let read_key = |_: &Page<Read<'_>, Leaf>, slot_index: SlotId| Ok(keys[slot_index as usize]);
-
-        assert_eq!(page.search_slots_by(5, read_key).unwrap(), SearchResult::InsertAt(0));
-        assert_eq!(page.search_slots_by(10, read_key).unwrap(), SearchResult::Found(0));
-        assert_eq!(page.search_slots_by(30, read_key).unwrap(), SearchResult::InsertAt(2));
-        assert_eq!(page.search_slots_by(40, read_key).unwrap(), SearchResult::Found(2));
-        assert_eq!(page.search_slots_by(90, read_key).unwrap(), SearchResult::InsertAt(4));
+        for (query, expected) in [
+            (5, SearchResult::InsertAt(0)),
+            (10, SearchResult::Found(0)),
+            (30, SearchResult::InsertAt(2)),
+            (40, SearchResult::Found(2)),
+            (90, SearchResult::InsertAt(4)),
+        ] {
+            assert_eq!(
+                page.search_slots_by(|_, slot_index| Ok(keys[slot_index as usize].cmp(&query)))
+                    .unwrap(),
+                expected
+            );
+        }
     }
 }

--- a/crates/databas_core/src/page/error.rs
+++ b/crates/databas_core/src/page/error.rs
@@ -1,4 +1,4 @@
-use crate::{RowId, SlotId};
+use crate::SlotId;
 use thiserror::Error;
 
 use super::format::PageKind;
@@ -28,12 +28,12 @@ pub enum PageError {
         #[source]
         kind: CellCorruption,
     },
-    /// An insert attempted to reuse an existing row id.
-    #[error("duplicate row id: {row_id}")]
-    DuplicateRowId { row_id: RowId },
-    /// An update targeted a row id that is not present.
-    #[error("row id not found: {row_id}")]
-    RowIdNotFound { row_id: RowId },
+    /// An insert attempted to reuse an existing key.
+    #[error("duplicate key")]
+    DuplicateKey,
+    /// An update targeted a key that is not present.
+    #[error("key not found")]
+    KeyNotFound,
     /// The page has insufficient free space for the requested operation.
     #[error("page full: need {needed} bytes, only {available} available")]
     PageFull { needed: usize, available: usize },

--- a/crates/databas_core/src/page/error.rs
+++ b/crates/databas_core/src/page/error.rs
@@ -1,4 +1,4 @@
-use crate::types::{RowId, SlotId};
+use crate::{RowId, SlotId};
 use thiserror::Error;
 
 use super::format::PageKind;

--- a/crates/databas_core/src/page/format.rs
+++ b/crates/databas_core/src/page/format.rs
@@ -46,32 +46,89 @@ pub const LEAF_HEADER_SIZE: usize = SHARED_HEADER_SIZE;
 /// Total header size for an interior page.
 pub const INTERIOR_HEADER_SIZE: usize = SHARED_HEADER_SIZE + 8;
 
+/// Structural node kind carried by a page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    /// A leaf page.
+    Leaf,
+    /// An interior page.
+    Interior,
+}
+
+impl NodeKind {
+    /// Returns the total header size for this node kind.
+    pub const fn header_size(self) -> usize {
+        match self {
+            Self::Leaf => LEAF_HEADER_SIZE,
+            Self::Interior => INTERIOR_HEADER_SIZE,
+        }
+    }
+}
+
+/// Logical tree kind carried by a page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TreeKind {
+    /// A table b-tree page.
+    Table,
+    /// An index b-tree page.
+    Index,
+}
+
 /// Encoded page kind tag stored in the page header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PageKind {
-    /// A leaf page containing row payloads.
-    Leaf = 1,
-    /// An interior page containing separator keys and child pointers.
-    Interior = 2,
+    /// A table leaf page containing row payloads.
+    TableLeaf = 1,
+    /// A table interior page containing separator row ids and child pointers.
+    TableInterior = 2,
+    /// An index leaf page containing index keys and row references.
+    IndexLeaf = 3,
+    /// An index interior page containing separator keys and child pointers.
+    IndexInterior = 4,
 }
 
 impl PageKind {
     /// Decodes a raw page-kind tag.
     pub fn from_raw(raw: u8) -> Option<Self> {
         match raw {
-            1 => Some(Self::Leaf),
-            2 => Some(Self::Interior),
+            1 => Some(Self::TableLeaf),
+            2 => Some(Self::TableInterior),
+            3 => Some(Self::IndexLeaf),
+            4 => Some(Self::IndexInterior),
             _ => None,
+        }
+    }
+
+    /// Returns the encoded page kind for a `(node_kind, tree_kind)` pair.
+    pub const fn from_parts(node_kind: NodeKind, tree_kind: TreeKind) -> Self {
+        match (tree_kind, node_kind) {
+            (TreeKind::Table, NodeKind::Leaf) => Self::TableLeaf,
+            (TreeKind::Table, NodeKind::Interior) => Self::TableInterior,
+            (TreeKind::Index, NodeKind::Leaf) => Self::IndexLeaf,
+            (TreeKind::Index, NodeKind::Interior) => Self::IndexInterior,
+        }
+    }
+
+    /// Returns the node kind encoded in this page kind.
+    pub const fn node_kind(self) -> NodeKind {
+        match self {
+            Self::TableLeaf | Self::IndexLeaf => NodeKind::Leaf,
+            Self::TableInterior | Self::IndexInterior => NodeKind::Interior,
+        }
+    }
+
+    /// Returns the tree kind encoded in this page kind.
+    pub const fn tree_kind(self) -> TreeKind {
+        match self {
+            Self::TableLeaf | Self::TableInterior => TreeKind::Table,
+            Self::IndexLeaf | Self::IndexInterior => TreeKind::Index,
         }
     }
 
     /// Returns the total header size for this page kind.
     pub const fn header_size(self) -> usize {
-        match self {
-            Self::Leaf => LEAF_HEADER_SIZE,
-            Self::Interior => INTERIOR_HEADER_SIZE,
-        }
+        self.node_kind().header_size()
     }
 }
 

--- a/crates/databas_core/src/page/format.rs
+++ b/crates/databas_core/src/page/format.rs
@@ -210,11 +210,11 @@ mod tests {
 
     #[test]
     fn page_kind_helpers_match_layout() {
-        assert_eq!(PageKind::from_raw(1), Some(PageKind::Leaf));
-        assert_eq!(PageKind::from_raw(2), Some(PageKind::Interior));
+        assert_eq!(PageKind::from_raw(1), Some(PageKind::TableLeaf));
+        assert_eq!(PageKind::from_raw(2), Some(PageKind::TableInterior));
         assert_eq!(PageKind::from_raw(0), None);
-        assert_eq!(PageKind::Leaf.header_size(), LEAF_HEADER_SIZE);
-        assert_eq!(PageKind::Interior.header_size(), INTERIOR_HEADER_SIZE);
+        assert_eq!(PageKind::TableLeaf.header_size(), LEAF_HEADER_SIZE);
+        assert_eq!(PageKind::TableInterior.header_size(), INTERIOR_HEADER_SIZE);
     }
 
     #[test]
@@ -231,6 +231,6 @@ mod tests {
 
     #[test]
     fn max_slot_count_uses_kind_specific_header_size() {
-        assert!(max_slot_count(PageKind::Leaf) > max_slot_count(PageKind::Interior));
+        assert!(max_slot_count(PageKind::TableLeaf) > max_slot_count(PageKind::TableInterior));
     }
 }

--- a/crates/databas_core/src/page/format.rs
+++ b/crates/databas_core/src/page/format.rs
@@ -212,9 +212,13 @@ mod tests {
     fn page_kind_helpers_match_layout() {
         assert_eq!(PageKind::from_raw(1), Some(PageKind::TableLeaf));
         assert_eq!(PageKind::from_raw(2), Some(PageKind::TableInterior));
+        assert_eq!(PageKind::from_raw(3), Some(PageKind::IndexLeaf));
+        assert_eq!(PageKind::from_raw(4), Some(PageKind::IndexInterior));
         assert_eq!(PageKind::from_raw(0), None);
         assert_eq!(PageKind::TableLeaf.header_size(), LEAF_HEADER_SIZE);
         assert_eq!(PageKind::TableInterior.header_size(), INTERIOR_HEADER_SIZE);
+        assert_eq!(PageKind::IndexLeaf.header_size(), LEAF_HEADER_SIZE);
+        assert_eq!(PageKind::IndexInterior.header_size(), INTERIOR_HEADER_SIZE);
     }
 
     #[test]
@@ -232,5 +236,10 @@ mod tests {
     #[test]
     fn max_slot_count_uses_kind_specific_header_size() {
         assert!(max_slot_count(PageKind::TableLeaf) > max_slot_count(PageKind::TableInterior));
+        assert_eq!(max_slot_count(PageKind::TableLeaf), max_slot_count(PageKind::IndexLeaf));
+        assert_eq!(
+            max_slot_count(PageKind::TableInterior),
+            max_slot_count(PageKind::IndexInterior)
+        );
     }
 }

--- a/crates/databas_core/src/page/format.rs
+++ b/crates/databas_core/src/page/format.rs
@@ -4,7 +4,7 @@
 //! upward from the header, a packed cell-content region that grows downward
 //! from the end of usable space, and a zeroed reserved footer.
 
-use crate::types::{PAGE_SIZE, SlotId};
+use crate::{PAGE_SIZE, SlotId};
 
 /// Current on-disk page format version.
 pub const FORMAT_VERSION: u8 = 2;

--- a/crates/databas_core/src/page/index_interior.rs
+++ b/crates/databas_core/src/page/index_interior.rs
@@ -153,3 +153,130 @@ where
         Ok(slot_index)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_index_interior_page(rightmost_child: PageId) -> [u8; PAGE_SIZE] {
+        let mut bytes = [0_u8; PAGE_SIZE];
+        let _ = Page::<Write<'_>, Interior, Index>::init(&mut bytes, rightmost_child);
+        bytes
+    }
+
+    #[test]
+    fn parses_valid_index_interior_cell() {
+        let mut bytes = new_index_interior_page(99);
+        let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
+        page.insert(b"mango", 5).unwrap();
+
+        let page = page.as_ref();
+        let cell = page.cell(0).unwrap();
+        assert_eq!(cell.key().unwrap(), b"mango");
+        assert_eq!(cell.left_child().unwrap(), 5);
+        assert_eq!(page.rightmost_child(), 99);
+    }
+
+    #[test]
+    fn rightmost_child_accessors_round_trip() {
+        let mut bytes = new_index_interior_page(7);
+        let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
+        assert_eq!(page.rightmost_child(), 7);
+
+        page.set_rightmost_child(88);
+
+        assert_eq!(page.rightmost_child(), 88);
+        assert_eq!(page.as_ref().rightmost_child(), 88);
+    }
+
+    #[test]
+    fn insert_keeps_separator_order_and_allows_duplicates() {
+        let mut bytes = new_index_interior_page(90);
+        let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
+        page.insert(b"pear", 4).unwrap();
+        page.insert(b"apple", 1).unwrap();
+        page.insert(b"mango", 2).unwrap();
+        page.insert(b"mango", 3).unwrap();
+
+        let page = page.as_ref();
+        assert_eq!(page.cell(0).unwrap().key().unwrap(), b"apple");
+        assert_eq!(page.cell(0).unwrap().left_child().unwrap(), 1);
+        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"mango");
+        assert_eq!(page.cell(1).unwrap().left_child().unwrap(), 2);
+        assert_eq!(page.cell(2).unwrap().key().unwrap(), b"mango");
+        assert_eq!(page.cell(2).unwrap().left_child().unwrap(), 3);
+        assert_eq!(page.cell(3).unwrap().key().unwrap(), b"pear");
+        assert_eq!(page.cell(3).unwrap().left_child().unwrap(), 4);
+    }
+
+    #[test]
+    fn bounds_return_past_end_on_empty_page() {
+        let bytes = new_index_interior_page(7);
+        let page = Page::<Read<'_>, Interior, Index>::open(&bytes).unwrap();
+
+        assert_eq!(page.lower_bound(b"banana").unwrap(), BoundResult::PastEnd);
+        assert_eq!(page.upper_bound(b"banana").unwrap(), BoundResult::PastEnd);
+    }
+
+    #[test]
+    fn bounds_cover_exact_in_between_and_duplicate_separator_positions() {
+        let mut bytes = new_index_interior_page(90);
+        let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
+        page.insert(b"apple", 1).unwrap();
+        page.insert(b"mango", 2).unwrap();
+        page.insert(b"mango", 3).unwrap();
+        page.insert(b"pear", 4).unwrap();
+
+        let page = page.as_ref();
+        assert_eq!(page.lower_bound(b"aardvark").unwrap(), BoundResult::At(0));
+        assert_eq!(page.upper_bound(b"aardvark").unwrap(), BoundResult::At(0));
+        assert_eq!(page.lower_bound(b"mango").unwrap(), BoundResult::At(1));
+        assert_eq!(page.upper_bound(b"mango").unwrap(), BoundResult::At(3));
+        assert_eq!(page.lower_bound(b"orange").unwrap(), BoundResult::At(3));
+        assert_eq!(page.upper_bound(b"orange").unwrap(), BoundResult::At(3));
+        assert_eq!(page.lower_bound(b"zebra").unwrap(), BoundResult::PastEnd);
+        assert_eq!(page.upper_bound(b"zebra").unwrap(), BoundResult::PastEnd);
+    }
+
+    #[test]
+    fn child_for_routes_by_first_separator_greater_than_or_equal_to_key() {
+        let mut bytes = new_index_interior_page(90);
+        let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
+        page.insert(b"apple", 1).unwrap();
+        page.insert(b"mango", 2).unwrap();
+        page.insert(b"mango", 3).unwrap();
+        page.insert(b"pear", 4).unwrap();
+
+        let page = page.as_ref();
+        assert_eq!(page.child_for(b"aardvark").unwrap(), 1);
+        assert_eq!(page.child_for(b"apple").unwrap(), 1);
+        assert_eq!(page.child_for(b"banana").unwrap(), 2);
+        assert_eq!(page.child_for(b"mango").unwrap(), 2);
+        assert_eq!(page.child_for(b"orange").unwrap(), 4);
+        assert_eq!(page.child_for(b"zebra").unwrap(), 90);
+    }
+
+    #[test]
+    fn child_for_returns_rightmost_child_on_empty_page() {
+        let bytes = new_index_interior_page(77);
+        let page = Page::<Read<'_>, Interior, Index>::open(&bytes).unwrap();
+
+        assert_eq!(page.child_for(b"apple").unwrap(), 77);
+        assert_eq!(page.child_for(b"zebra").unwrap(), 77);
+    }
+
+    #[test]
+    fn mutable_cell_view_updates_left_child() {
+        let mut bytes = new_index_interior_page(9);
+        let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
+        page.insert(b"mango", 5).unwrap();
+
+        {
+            let mut cell = page.cell_mut(0).unwrap();
+            cell.set_left_child(66).unwrap();
+        }
+
+        let page = page.as_ref();
+        assert_eq!(page.cell(0).unwrap().left_child().unwrap(), 66);
+    }
+}

--- a/crates/databas_core/src/page/index_interior.rs
+++ b/crates/databas_core/src/page/index_interior.rs
@@ -1,0 +1,59 @@
+use crate::{PAGE_SIZE, PageId, SlotId};
+
+use super::{
+    CellCorruption, PageError, PageResult,
+    core::{Index, Interior, Page, PageAccess},
+    format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
+};
+
+const PAGE_ID_SIZE: usize = 8;
+/// The fixed-size prefix of an index interior cell: encoded length plus left-child page id.
+pub const INDEX_INTERIOR_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + PAGE_ID_SIZE;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct IndexInteriorCellParts {
+    pub(crate) cell_offset: usize,
+    pub(crate) left_child: PageId,
+    pub(crate) key_start: usize,
+    pub(crate) key_end: usize,
+}
+
+pub(crate) fn cell_len_at(
+    bytes: &[u8; PAGE_SIZE],
+    slot_index: SlotId,
+    cell_offset: usize,
+) -> PageResult<usize> {
+    let cell_len = format::read_u16(bytes, cell_offset) as usize;
+    if cell_len < INDEX_INTERIOR_CELL_PREFIX_SIZE {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthTooSmall });
+    }
+    if cell_offset + cell_len > USABLE_SPACE_END {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    }
+    Ok(cell_len)
+}
+
+pub(crate) fn cell_parts<A>(
+    page: &Page<A, Interior, Index>,
+    slot_index: SlotId,
+) -> PageResult<IndexInteriorCellParts>
+where
+    A: PageAccess,
+{
+    page.validate_slot_index(slot_index)?;
+    let cell_offset = page.slot_offset(slot_index)? as usize;
+    let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
+    let key_start = cell_offset + INDEX_INTERIOR_CELL_PREFIX_SIZE;
+    let key_end = cell_offset + cell_len;
+
+    Ok(IndexInteriorCellParts {
+        cell_offset,
+        left_child: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
+        key_start,
+        key_end,
+    })
+}
+
+pub(crate) fn write_left_child(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, page_id: PageId) {
+    format::write_u64(bytes, cell_offset + CELL_LENGTH_SIZE, page_id);
+}

--- a/crates/databas_core/src/page/index_interior.rs
+++ b/crates/databas_core/src/page/index_interior.rs
@@ -1,9 +1,12 @@
+use std::cmp::Ordering;
+
 use crate::{PAGE_SIZE, PageId, SlotId};
 
 use super::{
     CellCorruption, PageError, PageResult,
-    core::{Index, Interior, Page, PageAccess},
-    format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
+    cell::Cell,
+    core::{BoundResult, Index, Interior, Page, PageAccess, PageAccessMut, Read, Write},
+    format::{self, CELL_LENGTH_SIZE, RIGHTMOST_CHILD_OFFSET, USABLE_SPACE_END},
 };
 
 const PAGE_ID_SIZE: usize = 8;
@@ -56,4 +59,97 @@ where
 
 pub(crate) fn write_left_child(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, page_id: PageId) {
     format::write_u64(bytes, cell_offset + CELL_LENGTH_SIZE, page_id);
+}
+
+fn encoded_len(key_len: usize) -> PageResult<usize> {
+    let len = INDEX_INTERIOR_CELL_PREFIX_SIZE + key_len;
+    if len > u16::MAX as usize {
+        return Err(PageError::CellTooLarge { len, max: u16::MAX as usize });
+    }
+    Ok(len)
+}
+
+fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, left_child: PageId, key: &[u8]) {
+    let cell_len = INDEX_INTERIOR_CELL_PREFIX_SIZE + key.len();
+    format::write_u16(bytes, cell_offset, cell_len as u16);
+    write_left_child(bytes, cell_offset, left_child);
+    bytes[cell_offset + INDEX_INTERIOR_CELL_PREFIX_SIZE..cell_offset + cell_len]
+        .copy_from_slice(key);
+}
+
+fn compare_key<A>(
+    page: &Page<A, Interior, Index>,
+    slot_index: SlotId,
+    key: &[u8],
+) -> PageResult<Ordering>
+where
+    A: PageAccess,
+{
+    let parts = cell_parts(page, slot_index)?;
+    Ok(page.bytes()[parts.key_start..parts.key_end].cmp(key))
+}
+
+impl<A> Page<A, Interior, Index>
+where
+    A: PageAccess,
+{
+    /// Returns the page id stored in the rightmost-child header field.
+    pub fn rightmost_child(&self) -> PageId {
+        format::read_u64(self.bytes(), RIGHTMOST_CHILD_OFFSET)
+    }
+
+    /// Returns the first slot whose separator key is greater than or equal to `key`.
+    pub fn lower_bound(&self, key: &[u8]) -> PageResult<BoundResult> {
+        self.lower_bound_slots_by(|page, slot_index| compare_key(page, slot_index, key))
+    }
+
+    /// Returns the first slot whose separator key is strictly greater than `key`.
+    pub fn upper_bound(&self, key: &[u8]) -> PageResult<BoundResult> {
+        self.upper_bound_slots_by(|page, slot_index| compare_key(page, slot_index, key))
+    }
+
+    /// Returns the child page that may contain `key`.
+    pub fn child_for(&self, key: &[u8]) -> PageResult<PageId> {
+        match self.lower_bound(key)? {
+            BoundResult::At(slot_index) => Ok(cell_parts(self, slot_index)?.left_child),
+            BoundResult::PastEnd => Ok(self.rightmost_child()),
+        }
+    }
+
+    /// Returns a typed immutable view of the cell at `slot_index`.
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Interior, Index>> {
+        cell_parts(self, slot_index)?;
+        Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
+    }
+}
+
+impl<A> Page<A, Interior, Index>
+where
+    A: PageAccessMut,
+{
+    /// Updates the page id stored in the rightmost-child header field.
+    pub fn set_rightmost_child(&mut self, page_id: PageId) {
+        format::write_u64(self.bytes_mut(), RIGHTMOST_CHILD_OFFSET, page_id);
+    }
+
+    /// Returns a typed mutable view of the cell at `slot_index`.
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Interior, Index>> {
+        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
+        cell_parts(&page, slot_index)?;
+        Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
+    }
+
+    /// Inserts a new separator key and its left-child pointer while preserving slot order.
+    pub fn insert(&mut self, key: &[u8], left_child: PageId) -> PageResult<SlotId> {
+        let cell_len = encoded_len(key.len())?;
+        let slot_index = match self.upper_bound(key)? {
+            BoundResult::At(slot_index) => slot_index,
+            BoundResult::PastEnd => self.slot_count(),
+        };
+
+        let cell_offset = self.reserve_space_for_insert(cell_len)?;
+        write_cell(self.bytes_mut(), cell_offset as usize, left_child, key);
+        self.insert_slot(slot_index, cell_offset)?;
+        Ok(slot_index)
+    }
 }

--- a/crates/databas_core/src/page/index_leaf.rs
+++ b/crates/databas_core/src/page/index_leaf.rs
@@ -1,0 +1,53 @@
+use crate::{PAGE_SIZE, RowId, SlotId};
+
+use super::{
+    CellCorruption, PageError, PageResult,
+    core::{Index, Leaf, Page, PageAccess},
+    format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
+};
+
+const ROW_ID_SIZE: usize = 8;
+/// The fixed-size prefix of an index leaf cell: encoded length plus row reference.
+pub const INDEX_LEAF_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + ROW_ID_SIZE;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct IndexLeafCellParts {
+    pub(crate) row_id: RowId,
+    pub(crate) key_start: usize,
+    pub(crate) key_end: usize,
+}
+
+pub(crate) fn cell_len_at(
+    bytes: &[u8; PAGE_SIZE],
+    slot_index: SlotId,
+    cell_offset: usize,
+) -> PageResult<usize> {
+    let cell_len = format::read_u16(bytes, cell_offset) as usize;
+    if cell_len < INDEX_LEAF_CELL_PREFIX_SIZE {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthTooSmall });
+    }
+    if cell_offset + cell_len > USABLE_SPACE_END {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    }
+    Ok(cell_len)
+}
+
+pub(crate) fn cell_parts<A>(
+    page: &Page<A, Leaf, Index>,
+    slot_index: SlotId,
+) -> PageResult<IndexLeafCellParts>
+where
+    A: PageAccess,
+{
+    page.validate_slot_index(slot_index)?;
+    let cell_offset = page.slot_offset(slot_index)? as usize;
+    let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
+    let key_start = cell_offset + INDEX_LEAF_CELL_PREFIX_SIZE;
+    let key_end = cell_offset + cell_len;
+
+    Ok(IndexLeafCellParts {
+        row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
+        key_start,
+        key_end,
+    })
+}

--- a/crates/databas_core/src/page/index_leaf.rs
+++ b/crates/databas_core/src/page/index_leaf.rs
@@ -1,8 +1,11 @@
+use std::{cmp::Ordering, ops::Range};
+
 use crate::{PAGE_SIZE, RowId, SlotId};
 
 use super::{
     CellCorruption, PageError, PageResult,
-    core::{Index, Leaf, Page, PageAccess},
+    cell::Cell,
+    core::{BoundResult, Index, Leaf, Page, PageAccess, PageAccessMut, Read, SearchResult, Write},
     format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
 };
 
@@ -50,4 +53,124 @@ where
         key_start,
         key_end,
     })
+}
+
+fn encoded_len(key_len: usize) -> PageResult<usize> {
+    let len = INDEX_LEAF_CELL_PREFIX_SIZE + key_len;
+    if len > u16::MAX as usize {
+        return Err(PageError::CellTooLarge { len, max: u16::MAX as usize });
+    }
+    Ok(len)
+}
+
+fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, row_id: RowId, key: &[u8]) {
+    let cell_len = INDEX_LEAF_CELL_PREFIX_SIZE + key.len();
+    format::write_u16(bytes, cell_offset, cell_len as u16);
+    format::write_u64(bytes, cell_offset + CELL_LENGTH_SIZE, row_id);
+    bytes[cell_offset + INDEX_LEAF_CELL_PREFIX_SIZE..cell_offset + cell_len].copy_from_slice(key);
+}
+
+fn compare_key<A>(
+    page: &Page<A, Leaf, Index>,
+    slot_index: SlotId,
+    key: &[u8],
+) -> PageResult<Ordering>
+where
+    A: PageAccess,
+{
+    let parts = cell_parts(page, slot_index)?;
+    Ok(page.bytes()[parts.key_start..parts.key_end].cmp(key))
+}
+
+fn compare_entry<A>(
+    page: &Page<A, Leaf, Index>,
+    slot_index: SlotId,
+    key: &[u8],
+    row_id: RowId,
+) -> PageResult<Ordering>
+where
+    A: PageAccess,
+{
+    let parts = cell_parts(page, slot_index)?;
+    let ordering = page.bytes()[parts.key_start..parts.key_end].cmp(key);
+    Ok(if ordering == Ordering::Equal { parts.row_id.cmp(&row_id) } else { ordering })
+}
+
+fn bound_to_slot(bound: BoundResult, slot_count: SlotId) -> SlotId {
+    match bound {
+        BoundResult::At(slot_index) => slot_index,
+        BoundResult::PastEnd => slot_count,
+    }
+}
+
+impl<A> Page<A, Leaf, Index>
+where
+    A: PageAccess,
+{
+    /// Returns the first slot whose key is greater than or equal to `key`.
+    pub fn lower_bound(&self, key: &[u8]) -> PageResult<BoundResult> {
+        self.lower_bound_slots_by(|page, slot_index| compare_key(page, slot_index, key))
+    }
+
+    /// Returns the first slot whose key is strictly greater than `key`.
+    pub fn upper_bound(&self, key: &[u8]) -> PageResult<BoundResult> {
+        self.upper_bound_slots_by(|page, slot_index| compare_key(page, slot_index, key))
+    }
+
+    /// Returns the half-open slot range containing all entries for `key`.
+    pub fn equal_range(&self, key: &[u8]) -> PageResult<Range<SlotId>> {
+        let start = bound_to_slot(self.lower_bound(key)?, self.slot_count());
+        let end = bound_to_slot(self.upper_bound(key)?, self.slot_count());
+        Ok(start..end)
+    }
+
+    /// Returns a typed immutable view of the cell at `slot_index`.
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Leaf, Index>> {
+        cell_parts(self, slot_index)?;
+        Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
+    }
+}
+
+impl<A> Page<A, Leaf, Index>
+where
+    A: PageAccessMut,
+{
+    /// Returns a typed mutable view of the cell at `slot_index`.
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Leaf, Index>> {
+        let page = Page::<Read<'_>, Leaf, Index>::open(self.bytes())?;
+        cell_parts(&page, slot_index)?;
+        Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
+    }
+
+    /// Inserts a new `(key, row_id)` entry while preserving lexicographic key order.
+    pub fn insert(&mut self, key: &[u8], row_id: RowId) -> PageResult<SlotId> {
+        let cell_len = encoded_len(key.len())?;
+        let slot_index = match self
+            .search_slots_by(|page, slot_index| compare_entry(page, slot_index, key, row_id))?
+        {
+            SearchResult::Found(_) => return Err(PageError::DuplicateKey),
+            SearchResult::InsertAt(slot_index) => slot_index,
+        };
+
+        let cell_offset = self.reserve_space_for_insert(cell_len)?;
+        write_cell(self.bytes_mut(), cell_offset as usize, row_id, key);
+        self.insert_slot(slot_index, cell_offset)?;
+        Ok(slot_index)
+    }
+
+    /// Deletes an existing `(key, row_id)` entry and re-packs the page.
+    pub fn delete(&mut self, key: &[u8], row_id: RowId) -> PageResult<SlotId> {
+        let slot_index = match self
+            .search_slots_by(|page, slot_index| compare_entry(page, slot_index, key, row_id))?
+        {
+            SearchResult::Found(slot_index) => slot_index,
+            SearchResult::InsertAt(_) => return Err(PageError::KeyNotFound),
+        };
+
+        let cell_offset = self.slot_offset(slot_index)?;
+        let cell_len = self.cell_len(slot_index)?;
+        self.remove_slot(slot_index)?;
+        self.reclaim_space(cell_offset, cell_len)?;
+        Ok(slot_index)
+    }
 }

--- a/crates/databas_core/src/page/index_leaf.rs
+++ b/crates/databas_core/src/page/index_leaf.rs
@@ -174,3 +174,130 @@ where
         Ok(slot_index)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_index_leaf_page() -> [u8; PAGE_SIZE] {
+        let mut bytes = [0_u8; PAGE_SIZE];
+        let _ = Page::<Write<'_>, Leaf, Index>::init(&mut bytes);
+        bytes
+    }
+
+    #[test]
+    fn parses_valid_index_leaf_cell() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"beta", 7).unwrap();
+
+        let page = page.as_ref();
+        let cell = page.cell(0).unwrap();
+        assert_eq!(cell.key().unwrap(), b"beta");
+        assert_eq!(cell.row_id().unwrap(), 7);
+    }
+
+    #[test]
+    fn insert_keeps_entries_sorted_by_key_then_row_id() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"banana", 4).unwrap();
+        page.insert(b"apple", 9).unwrap();
+        page.insert(b"banana", 2).unwrap();
+        page.insert(b"apple", 1).unwrap();
+
+        let page = page.as_ref();
+        assert_eq!(page.cell(0).unwrap().key().unwrap(), b"apple");
+        assert_eq!(page.cell(0).unwrap().row_id().unwrap(), 1);
+        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"apple");
+        assert_eq!(page.cell(1).unwrap().row_id().unwrap(), 9);
+        assert_eq!(page.cell(2).unwrap().key().unwrap(), b"banana");
+        assert_eq!(page.cell(2).unwrap().row_id().unwrap(), 2);
+        assert_eq!(page.cell(3).unwrap().key().unwrap(), b"banana");
+        assert_eq!(page.cell(3).unwrap().row_id().unwrap(), 4);
+    }
+
+    #[test]
+    fn insert_rejects_exact_duplicates_but_allows_duplicate_keys() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"banana", 2).unwrap();
+        page.insert(b"banana", 4).unwrap();
+
+        let err = page.insert(b"banana", 2).unwrap_err();
+        assert_eq!(err, PageError::DuplicateKey);
+        assert_eq!(page.as_ref().equal_range(b"banana").unwrap(), 0..2);
+    }
+
+    #[test]
+    fn bounds_return_past_end_on_empty_page() {
+        let bytes = new_index_leaf_page();
+        let page = Page::<Read<'_>, Leaf, Index>::open(&bytes).unwrap();
+
+        assert_eq!(page.lower_bound(b"banana").unwrap(), BoundResult::PastEnd);
+        assert_eq!(page.upper_bound(b"banana").unwrap(), BoundResult::PastEnd);
+        assert_eq!(page.equal_range(b"banana").unwrap(), 0..0);
+    }
+
+    #[test]
+    fn bounds_and_equal_range_cover_duplicate_keys() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"apple", 1).unwrap();
+        page.insert(b"banana", 2).unwrap();
+        page.insert(b"banana", 4).unwrap();
+        page.insert(b"banana", 8).unwrap();
+        page.insert(b"cherry", 3).unwrap();
+
+        let page = page.as_ref();
+        assert_eq!(page.lower_bound(b"aardvark").unwrap(), BoundResult::At(0));
+        assert_eq!(page.upper_bound(b"aardvark").unwrap(), BoundResult::At(0));
+        assert_eq!(page.lower_bound(b"banana").unwrap(), BoundResult::At(1));
+        assert_eq!(page.upper_bound(b"banana").unwrap(), BoundResult::At(4));
+        assert_eq!(page.equal_range(b"banana").unwrap(), 1..4);
+        assert_eq!(page.lower_bound(b"blueberry").unwrap(), BoundResult::At(4));
+        assert_eq!(page.upper_bound(b"blueberry").unwrap(), BoundResult::At(4));
+        assert_eq!(page.equal_range(b"blueberry").unwrap(), 4..4);
+        assert_eq!(page.lower_bound(b"zebra").unwrap(), BoundResult::PastEnd);
+        assert_eq!(page.upper_bound(b"zebra").unwrap(), BoundResult::PastEnd);
+        assert_eq!(page.equal_range(b"zebra").unwrap(), 5..5);
+    }
+
+    #[test]
+    fn delete_removes_only_matching_entry() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"banana", 2).unwrap();
+        page.insert(b"banana", 4).unwrap();
+        page.insert(b"banana", 8).unwrap();
+
+        assert_eq!(page.delete(b"banana", 4).unwrap(), 1);
+
+        let page = page.as_ref();
+        assert_eq!(page.equal_range(b"banana").unwrap(), 0..2);
+        assert_eq!(page.cell(0).unwrap().row_id().unwrap(), 2);
+        assert_eq!(page.cell(1).unwrap().row_id().unwrap(), 8);
+    }
+
+    #[test]
+    fn delete_returns_not_found_for_missing_entry() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"banana", 2).unwrap();
+
+        let err = page.delete(b"banana", 3).unwrap_err();
+        assert_eq!(err, PageError::KeyNotFound);
+    }
+
+    #[test]
+    fn mutable_cell_view_round_trips_as_ref() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"banana", 2).unwrap();
+
+        let cell = page.cell_mut(0).unwrap();
+        let cell = cell.as_ref();
+        assert_eq!(cell.key().unwrap(), b"banana");
+        assert_eq!(cell.row_id().unwrap(), 2);
+    }
+}

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -60,15 +60,15 @@ where
 
     /// Returns the first slot whose separator row id is greater than or equal to `row_id`.
     pub fn lower_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
-        self.lower_bound_slots_by(row_id, |page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id)
+        self.lower_bound_slots_by(|page, slot_index| {
+            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
         })
     }
 
     /// Returns the first slot whose separator row id is strictly greater than `row_id`.
     pub fn upper_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
-        self.upper_bound_slots_by(row_id, |page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id)
+        self.upper_bound_slots_by(|page, slot_index| {
+            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
         })
     }
 
@@ -82,7 +82,9 @@ where
 
     /// Searches the interior page for `row_id`.
     pub fn search(&self, row_id: RowId) -> PageResult<SearchResult> {
-        self.search_slots_by(row_id, |page, slot_index| Ok(cell_parts(page, slot_index)?.row_id))
+        self.search_slots_by(|page, slot_index| {
+            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+        })
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -334,7 +334,7 @@ mod tests {
         let mut bytes = new_interior_page(1);
         let mut page = Page::<Write<'_>, Interior>::open(&mut bytes).unwrap();
         let err = page.update(77, 9).unwrap_err();
-        assert_eq!(err, PageError::RowIdNotFound { row_id: 77 });
+        assert_eq!(err, PageError::KeyNotFound);
     }
 
     #[test]

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -123,7 +123,7 @@ where
     /// Inserts a new separator key and its left-child pointer while preserving slot order.
     pub fn insert(&mut self, row_id: RowId, left_child: PageId) -> PageResult<SlotId> {
         let slot_index = match self.search(row_id)? {
-            SearchResult::Found(_) => return Err(PageError::DuplicateRowId { row_id }),
+            SearchResult::Found(_) => return Err(PageError::DuplicateKey),
             SearchResult::InsertAt(slot_index) => slot_index,
         };
 
@@ -137,7 +137,7 @@ where
     pub fn update(&mut self, row_id: RowId, left_child: PageId) -> PageResult<()> {
         let slot_index = match self.search(row_id)? {
             SearchResult::Found(slot_index) => slot_index,
-            SearchResult::InsertAt(_) => return Err(PageError::RowIdNotFound { row_id }),
+            SearchResult::InsertAt(_) => return Err(PageError::KeyNotFound),
         };
 
         let cell_offset = self.slot_offset(slot_index)? as usize;

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -1,4 +1,4 @@
-use crate::types::{PAGE_SIZE, PageId, RowId, SlotId};
+use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 
 use super::{
     PageError, PageResult,

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -3,7 +3,9 @@ use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 use super::{
     PageError, PageResult,
     cell::Cell,
-    core::{BoundResult, Interior, Page, PageAccess, PageAccessMut, Read, SearchResult, Write},
+    core::{
+        BoundResult, Interior, Page, PageAccess, PageAccessMut, Read, SearchResult, Table, Write,
+    },
     format::{self, RIGHTMOST_CHILD_OFFSET},
 };
 
@@ -20,7 +22,7 @@ pub(crate) struct InteriorCellParts {
 }
 
 pub(crate) fn cell_parts<A>(
-    page: &Page<A, Interior>,
+    page: &Page<A, Interior, Table>,
     slot_index: SlotId,
 ) -> PageResult<InteriorCellParts>
 where
@@ -49,7 +51,7 @@ pub(crate) fn write_left_child(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, 
     format::write_u64(bytes, cell_offset, page_id);
 }
 
-impl<A> Page<A, Interior>
+impl<A> Page<A, Interior, Table>
 where
     A: PageAccess,
 {
@@ -88,13 +90,13 @@ where
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.
-    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Interior>> {
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Interior, Table>> {
         cell_parts(self, slot_index)?;
         Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
     }
 
     /// Looks up a separator key and returns its cell if present.
-    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<Read<'_>, Interior>>> {
+    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<Read<'_>, Interior, Table>>> {
         match self.search(row_id)? {
             SearchResult::Found(slot_index) => self.cell(slot_index).map(Some),
             SearchResult::InsertAt(_) => Ok(None),
@@ -102,7 +104,7 @@ where
     }
 }
 
-impl<A> Page<A, Interior>
+impl<A> Page<A, Interior, Table>
 where
     A: PageAccessMut,
 {
@@ -112,8 +114,8 @@ where
     }
 
     /// Returns a typed mutable view of the cell at `slot_index`.
-    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Interior>> {
-        let page = Page::<Read<'_>, Interior>::open(self.bytes())?;
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Interior, Table>> {
+        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
         cell_parts(&page, slot_index)?;
         Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
     }

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -63,21 +63,23 @@ where
 {
     /// Returns the first slot whose row id is greater than or equal to `row_id`.
     pub fn lower_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
-        self.lower_bound_slots_by(row_id, |page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id)
+        self.lower_bound_slots_by(|page, slot_index| {
+            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
         })
     }
 
     /// Returns the first slot whose row id is strictly greater than `row_id`.
     pub fn upper_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
-        self.upper_bound_slots_by(row_id, |page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id)
+        self.upper_bound_slots_by(|page, slot_index| {
+            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
         })
     }
 
     /// Searches the leaf page for `row_id`.
     pub fn search(&self, row_id: RowId) -> PageResult<SearchResult> {
-        self.search_slots_by(row_id, |page, slot_index| Ok(cell_parts(page, slot_index)?.row_id))
+        self.search_slots_by(|page, slot_index| {
+            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+        })
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -18,6 +18,21 @@ pub(crate) struct LeafCellParts {
     pub(crate) payload_end: usize,
 }
 
+pub(crate) fn cell_len_at(
+    bytes: &[u8; PAGE_SIZE],
+    slot_index: SlotId,
+    cell_offset: usize,
+) -> PageResult<usize> {
+    let cell_len = format::read_u16(bytes, cell_offset) as usize;
+    if cell_len < LEAF_CELL_PREFIX_SIZE {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthTooSmall });
+    }
+    if cell_offset + cell_len > USABLE_SPACE_END {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    }
+    Ok(cell_len)
+}
+
 pub(crate) fn cell_parts<A>(
     page: &Page<A, Leaf, Table>,
     slot_index: SlotId,
@@ -27,16 +42,10 @@ where
 {
     page.validate_slot_index(slot_index)?;
     let cell_offset = page.slot_offset(slot_index)? as usize;
-    let cell_len = page.cell_len(slot_index)?;
-    if cell_len < LEAF_CELL_PREFIX_SIZE {
-        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthTooSmall });
-    }
+    let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
 
     let payload_start = cell_offset + LEAF_CELL_PREFIX_SIZE;
     let payload_end = cell_offset + cell_len;
-    if payload_end > USABLE_SPACE_END {
-        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
-    }
 
     Ok(LeafCellParts {
         row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -3,7 +3,7 @@ use crate::{PAGE_SIZE, RowId, SlotId};
 use super::{
     CellCorruption, PageError, PageResult,
     cell::Cell,
-    core::{BoundResult, Leaf, Page, PageAccess, PageAccessMut, Read, SearchResult, Write},
+    core::{BoundResult, Leaf, Page, PageAccess, PageAccessMut, Read, SearchResult, Table, Write},
     format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
 };
 
@@ -18,7 +18,10 @@ pub(crate) struct LeafCellParts {
     pub(crate) payload_end: usize,
 }
 
-pub(crate) fn cell_parts<A>(page: &Page<A, Leaf>, slot_index: SlotId) -> PageResult<LeafCellParts>
+pub(crate) fn cell_parts<A>(
+    page: &Page<A, Leaf, Table>,
+    slot_index: SlotId,
+) -> PageResult<LeafCellParts>
 where
     A: PageAccess,
 {
@@ -57,7 +60,7 @@ fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, row_id: RowId, pa
     bytes[cell_offset + LEAF_CELL_PREFIX_SIZE..cell_offset + cell_len].copy_from_slice(payload);
 }
 
-impl<A> Page<A, Leaf>
+impl<A> Page<A, Leaf, Table>
 where
     A: PageAccess,
 {
@@ -83,13 +86,13 @@ where
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.
-    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Leaf>> {
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Leaf, Table>> {
         cell_parts(self, slot_index)?;
         Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
     }
 
     /// Looks up a row id and returns its cell if present.
-    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<Read<'_>, Leaf>>> {
+    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<Read<'_>, Leaf, Table>>> {
         match self.search(row_id)? {
             SearchResult::Found(slot_index) => self.cell(slot_index).map(Some),
             SearchResult::InsertAt(_) => Ok(None),
@@ -97,13 +100,13 @@ where
     }
 }
 
-impl<A> Page<A, Leaf>
+impl<A> Page<A, Leaf, Table>
 where
     A: PageAccessMut,
 {
     /// Returns a typed mutable view of the cell at `slot_index`.
-    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Leaf>> {
-        let page = Page::<Read<'_>, Leaf>::open(self.bytes())?;
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Leaf, Table>> {
+        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
         cell_parts(&page, slot_index)?;
         Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
     }

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -253,7 +253,7 @@ mod tests {
 
         page.insert(10, b"ten").unwrap();
         let err = page.insert(10, b"again").unwrap_err();
-        assert_eq!(err, PageError::DuplicateRowId { row_id: 10 });
+        assert_eq!(err, PageError::DuplicateKey);
     }
 
     #[test]
@@ -418,7 +418,7 @@ mod tests {
         let mut bytes = new_leaf_page();
         let mut page = Page::<Write<'_>, Leaf>::open(&mut bytes).unwrap();
         let err = page.update(88, b"missing").unwrap_err();
-        assert_eq!(err, PageError::RowIdNotFound { row_id: 88 });
+        assert_eq!(err, PageError::KeyNotFound);
     }
 
     #[test]
@@ -458,7 +458,7 @@ mod tests {
 
         let err = page.delete(99).unwrap_err();
 
-        assert_eq!(err, PageError::RowIdNotFound { row_id: 99 });
+        assert_eq!(err, PageError::KeyNotFound);
     }
 
     #[test]

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -1,4 +1,4 @@
-use crate::types::{PAGE_SIZE, RowId, SlotId};
+use crate::{PAGE_SIZE, RowId, SlotId};
 
 use super::{
     CellCorruption, PageError, PageResult,

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -115,7 +115,7 @@ where
     pub fn insert(&mut self, row_id: RowId, payload: &[u8]) -> PageResult<SlotId> {
         let cell_len = encoded_len(payload.len())?;
         let slot_index = match self.search(row_id)? {
-            SearchResult::Found(_) => return Err(PageError::DuplicateRowId { row_id }),
+            SearchResult::Found(_) => return Err(PageError::DuplicateKey),
             SearchResult::InsertAt(slot_index) => slot_index,
         };
 
@@ -129,7 +129,7 @@ where
     pub fn delete(&mut self, row_id: RowId) -> PageResult<SlotId> {
         let slot_index = match self.search(row_id)? {
             SearchResult::Found(slot_index) => slot_index,
-            SearchResult::InsertAt(_) => return Err(PageError::RowIdNotFound { row_id }),
+            SearchResult::InsertAt(_) => return Err(PageError::KeyNotFound),
         };
 
         let cell_offset = self.slot_offset(slot_index)?;
@@ -144,7 +144,7 @@ where
         let cell_len = encoded_len(payload.len())?;
         let slot_index = match self.search(row_id)? {
             SearchResult::Found(slot_index) => slot_index,
-            SearchResult::InsertAt(_) => return Err(PageError::RowIdNotFound { row_id }),
+            SearchResult::InsertAt(_) => return Err(PageError::KeyNotFound),
         };
 
         let old_len = self.cell_len(slot_index)?;

--- a/crates/databas_core/src/page/mod.rs
+++ b/crates/databas_core/src/page/mod.rs
@@ -1,14 +1,15 @@
 //! Slotted B-tree page types and format constants.
 //!
 //! This module exposes the typed page API used by the storage layer to read and
-//! mutate fixed-size on-disk pages. Pages are split into two families:
-//! [`Leaf`] pages store `(row_id, payload)` records, while [`Interior`] pages
-//! store fixed-size separator cells plus child pointers.
+//! mutate fixed-size on-disk pages. Pages are split across two orthogonal axes:
+//! node kind and tree kind. [`Leaf`] pages store payload-bearing records, while
+//! [`Interior`] pages store separators and child pointers. [`Table`] pages use
+//! row ids as keys; [`Index`] pages use byte-slice keys.
 //!
 //! The main entry point is [`Page`]. A page is parameterized both by access mode
-//! ([`Read`] or [`Write`]) and by node kind ([`Leaf`] or [`Interior`]). This
-//! keeps the API zero-copy while still making invalid combinations harder to
-//! express.
+//! ([`Read`] or [`Write`]), node kind ([`Leaf`] or [`Interior`]), and tree kind
+//! ([`Table`] or [`Index`]). This keeps the API zero-copy while still making
+//! invalid combinations harder to express.
 //!
 //! When the concrete page kind is not known ahead of time, use [`AnyPage`] to
 //! inspect an already-initialized byte buffer. [`Cell`] provides typed access to
@@ -29,14 +30,15 @@ mod leaf;
 pub use cell::Cell;
 /// Page handles, marker types, access traits, and search helpers for typed page access.
 pub use core::{
-    AnyPage, BoundResult, Interior, Leaf, NodeMarker, Page, PageAccess, PageAccessMut, Read,
-    SearchResult, Write,
+    AnyPage, BoundResult, Index, Interior, Leaf, NodeMarker, Page, PageAccess, PageAccessMut, Read,
+    SearchResult, Table, TreeMarker, Write,
 };
 /// Errors returned while validating or manipulating encoded pages and cells.
 pub(crate) use error::{CellCorruption, PageCorruption, PageError, PageResult};
 /// Public page-format constants and layout metadata used by page encoders and decoders.
 pub use format::{
     CELL_LENGTH_SIZE, FORMAT_VERSION, FREEBLOCK_HEADER_SIZE, INTERIOR_HEADER_SIZE,
-    LEAF_HEADER_SIZE, MAX_FRAGMENTED_FREE_BYTES, NEXT_PAGE_ID_OFFSET, PREV_PAGE_ID_OFFSET,
-    PageKind, RESERVED_FOOTER_SIZE, SHARED_HEADER_SIZE, SLOT_ENTRY_SIZE, USABLE_SPACE_END,
+    LEAF_HEADER_SIZE, MAX_FRAGMENTED_FREE_BYTES, NEXT_PAGE_ID_OFFSET, NodeKind,
+    PREV_PAGE_ID_OFFSET, PageKind, RESERVED_FOOTER_SIZE, SHARED_HEADER_SIZE, SLOT_ENTRY_SIZE,
+    TreeKind, USABLE_SPACE_END,
 };

--- a/crates/databas_core/src/page/mod.rs
+++ b/crates/databas_core/src/page/mod.rs
@@ -23,6 +23,8 @@ mod cell;
 mod core;
 mod error;
 pub mod format;
+mod index_interior;
+mod index_leaf;
 mod interior;
 mod leaf;
 

--- a/crates/databas_core/src/page/mod.rs
+++ b/crates/databas_core/src/page/mod.rs
@@ -44,3 +44,12 @@ pub use format::{
     PREV_PAGE_ID_OFFSET, PageKind, RESERVED_FOOTER_SIZE, SHARED_HEADER_SIZE, SLOT_ENTRY_SIZE,
     TreeKind, USABLE_SPACE_END,
 };
+
+/// A typed table leaf page alias.
+pub type TableLeafPage<A> = Page<A, Leaf, Table>;
+/// A typed table interior page alias.
+pub type TableInteriorPage<A> = Page<A, Interior, Table>;
+/// A typed index leaf page alias.
+pub type IndexLeafPage<A> = Page<A, Leaf, Index>;
+/// A typed index interior page alias.
+pub type IndexInteriorPage<A> = Page<A, Interior, Index>;

--- a/crates/databas_core/src/page_cache.rs
+++ b/crates/databas_core/src/page_cache.rs
@@ -25,7 +25,7 @@ use std::{
 use crate::{
     disk_manager::DiskManager,
     error::{PageCacheError, PageCacheResult},
-    page::{AnyPage, NodeMarker, Page, PageResult, Read, Write},
+    page::{AnyPage, NodeMarker, Page, PageResult, Read, TreeMarker, Write},
     page_replacement::ClockPolicy,
     {PAGE_SIZE, PageId},
 };
@@ -366,6 +366,15 @@ impl PageReadGuard<'_> {
         Page::<Read<'_>, N>::open(self.page())
     }
 
+    /// Opens a typed immutable view over the page bytes for any node/tree pair.
+    pub(crate) fn open_typed<N, T>(&self) -> PageResult<Page<Read<'_>, N, T>>
+    where
+        N: NodeMarker,
+        T: TreeMarker,
+    {
+        Page::<Read<'_>, N, T>::open(self.page())
+    }
+
     /// Opens an immutable typed page view based on the encoded page kind.
     pub(crate) fn open_any(&self) -> PageResult<AnyPage<Read<'_>>> {
         AnyPage::<Read<'_>>::try_from(self.page())
@@ -400,12 +409,30 @@ impl PageWriteGuard<'_> {
         Page::<Read<'_>, N>::open(self.page())
     }
 
+    /// Opens a typed immutable view over the page bytes for any node/tree pair.
+    pub(crate) fn open_typed<N, T>(&self) -> PageResult<Page<Read<'_>, N, T>>
+    where
+        N: NodeMarker,
+        T: TreeMarker,
+    {
+        Page::<Read<'_>, N, T>::open(self.page())
+    }
+
     /// Opens a typed mutable view over the page bytes.
     pub(crate) fn open_mut<N>(&mut self) -> PageResult<Page<Write<'_>, N>>
     where
         N: NodeMarker,
     {
         Page::<Write<'_>, N>::open(self.page_mut())
+    }
+
+    /// Opens a typed mutable view over the page bytes for any node/tree pair.
+    pub(crate) fn open_typed_mut<N, T>(&mut self) -> PageResult<Page<Write<'_>, N, T>>
+    where
+        N: NodeMarker,
+        T: TreeMarker,
+    {
+        Page::<Write<'_>, N, T>::open(self.page_mut())
     }
 
     /// Opens an immutable typed page view based on the encoded page kind.

--- a/crates/databas_core/src/page_cache.rs
+++ b/crates/databas_core/src/page_cache.rs
@@ -616,15 +616,15 @@ mod tests {
             let mut write = guard.write().unwrap();
             let _ = Page::<Write<'_>, Leaf>::init(write.page_mut());
 
-            assert_eq!(write.open::<Leaf>().unwrap().kind(), PageKind::Leaf);
-            assert!(matches!(write.open_any().unwrap(), AnyPage::Leaf(_)));
-            assert_eq!(write.open_mut::<Leaf>().unwrap().kind(), PageKind::Leaf);
-            assert!(matches!(write.open_any_mut().unwrap(), AnyPage::Leaf(_)));
+            assert_eq!(write.open::<Leaf>().unwrap().kind(), PageKind::TableLeaf);
+            assert!(matches!(write.open_any().unwrap(), AnyPage::TableLeaf(_)));
+            assert_eq!(write.open_mut::<Leaf>().unwrap().kind(), PageKind::TableLeaf);
+            assert!(matches!(write.open_any_mut().unwrap(), AnyPage::TableLeaf(_)));
         }
 
         let read = guard.read().unwrap();
-        assert_eq!(read.open::<Leaf>().unwrap().kind(), PageKind::Leaf);
-        assert!(matches!(read.open_any().unwrap(), AnyPage::Leaf(_)));
+        assert_eq!(read.open::<Leaf>().unwrap().kind(), PageKind::TableLeaf);
+        assert!(matches!(read.open_any().unwrap(), AnyPage::TableLeaf(_)));
     }
 
     #[test]

--- a/crates/databas_core/src/page_cache.rs
+++ b/crates/databas_core/src/page_cache.rs
@@ -27,7 +27,7 @@ use crate::{
     error::{PageCacheError, PageCacheResult},
     page::{AnyPage, NodeMarker, Page, PageResult, Read, Write},
     page_replacement::ClockPolicy,
-    types::{PAGE_SIZE, PageId},
+    {PAGE_SIZE, PageId},
 };
 
 pub(crate) type FrameId = usize;

--- a/crates/databas_core/src/types.rs
+++ b/crates/databas_core/src/types.rs
@@ -1,5 +1,0 @@
-pub(crate) const PAGE_SIZE: usize = 4096;
-
-pub type PageId = u64;
-pub type RowId = u64;
-pub(crate) type SlotId = u16;


### PR DESCRIPTION
This PR adds support for index pages and cells. This change required a refactor of the `page` module which previously only supported table pages. We continue to use generics here, adding a third 'type axis' to the core `Page` struct for 'marking' whether the page for a table or an index.