### PR TITLE
Refactor page cells to operate on per-cell byte slices

### DIFF
--- a/crates/databas_core/src/page/cell.rs
+++ b/crates/databas_core/src/page/cell.rs
@@ -1,162 +1,308 @@
 use core::marker::PhantomData;
 
-use crate::{PAGE_SIZE, PageId, RowId, SlotId};
+use crate::{PageId, RowId, SlotId};
 
 use super::{
     PageResult,
-    core::{Index, Interior, Leaf, Page, PageAccess, PageAccessMut, Read, Table, Write},
+    core::{Index, Interior, Leaf, Table},
     index_interior, index_leaf, interior, leaf,
 };
 
-/// A typed view over a single slot entry within a page.
+#[derive(Debug, Clone)]
+enum CellMetadata {
+    TableLeaf(leaf::LeafCellParts),
+    IndexLeaf(index_leaf::IndexLeafCellParts),
+    TableInterior(interior::InteriorCellParts),
+    IndexInterior(index_interior::IndexInteriorCellParts),
+}
+
+/// A typed immutable view over a single page cell.
 #[derive(Debug)]
-pub struct Cell<A, N, T = Table> {
-    access: A,
+pub struct Cell<'a, N, T = Table> {
+    bytes: &'a [u8],
+    metadata: CellMetadata,
     slot_index: SlotId,
     _marker: PhantomData<(N, T)>,
 }
 
-impl<A, N, T> Cell<A, N, T> {
-    pub(crate) fn new(access: A, slot_index: SlotId) -> Self {
-        Self { access, slot_index, _marker: PhantomData }
+/// A typed mutable view over a single page cell.
+#[derive(Debug)]
+pub struct CellMut<'a, N, T = Table> {
+    bytes: &'a mut [u8],
+    metadata: CellMetadata,
+    slot_index: SlotId,
+    _marker: PhantomData<(N, T)>,
+}
+
+impl<'a, N, T> Cell<'a, N, T> {
+    fn new(bytes: &'a [u8], metadata: CellMetadata, slot_index: SlotId) -> Self {
+        Self { bytes, metadata, slot_index, _marker: PhantomData }
+    }
+
+    pub(crate) fn new_table_leaf(
+        bytes: &'a [u8],
+        parts: leaf::LeafCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::TableLeaf(parts), slot_index)
+    }
+
+    pub(crate) fn new_index_leaf(
+        bytes: &'a [u8],
+        parts: index_leaf::IndexLeafCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::IndexLeaf(parts), slot_index)
+    }
+
+    pub(crate) fn new_table_interior(
+        bytes: &'a [u8],
+        parts: interior::InteriorCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::TableInterior(parts), slot_index)
+    }
+
+    pub(crate) fn new_index_interior(
+        bytes: &'a [u8],
+        parts: index_interior::IndexInteriorCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::IndexInterior(parts), slot_index)
     }
 
     /// Returns the slot index that this cell view refers to.
     pub fn slot_index(&self) -> SlotId {
         self.slot_index
     }
-}
 
-impl<A, N, T> Cell<A, N, T>
-where
-    A: PageAccess,
-{
-    fn bytes(&self) -> &[u8; PAGE_SIZE] {
-        self.access.bytes()
+    fn table_leaf_parts(&self) -> &leaf::LeafCellParts {
+        match &self.metadata {
+            CellMetadata::TableLeaf(parts) => parts,
+            _ => unreachable!("table leaf cell metadata mismatch"),
+        }
+    }
+
+    fn index_leaf_parts(&self) -> &index_leaf::IndexLeafCellParts {
+        match &self.metadata {
+            CellMetadata::IndexLeaf(parts) => parts,
+            _ => unreachable!("index leaf cell metadata mismatch"),
+        }
+    }
+
+    fn table_interior_parts(&self) -> &interior::InteriorCellParts {
+        match &self.metadata {
+            CellMetadata::TableInterior(parts) => parts,
+            _ => unreachable!("table interior cell metadata mismatch"),
+        }
+    }
+
+    fn index_interior_parts(&self) -> &index_interior::IndexInteriorCellParts {
+        match &self.metadata {
+            CellMetadata::IndexInterior(parts) => parts,
+            _ => unreachable!("index interior cell metadata mismatch"),
+        }
     }
 }
 
-impl<A, N, T> Cell<A, N, T>
-where
-    A: PageAccessMut,
-{
-    fn bytes_mut(&mut self) -> &mut [u8; PAGE_SIZE] {
-        self.access.bytes_mut()
+impl<'a, N, T> CellMut<'a, N, T> {
+    fn new(bytes: &'a mut [u8], metadata: CellMetadata, slot_index: SlotId) -> Self {
+        Self { bytes, metadata, slot_index, _marker: PhantomData }
     }
-}
 
-impl<'a, N, T> Cell<Write<'a>, N, T> {
+    pub(crate) fn new_table_leaf(
+        bytes: &'a mut [u8],
+        parts: leaf::LeafCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::TableLeaf(parts), slot_index)
+    }
+
+    pub(crate) fn new_index_leaf(
+        bytes: &'a mut [u8],
+        parts: index_leaf::IndexLeafCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::IndexLeaf(parts), slot_index)
+    }
+
+    pub(crate) fn new_table_interior(
+        bytes: &'a mut [u8],
+        parts: interior::InteriorCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::TableInterior(parts), slot_index)
+    }
+
+    pub(crate) fn new_index_interior(
+        bytes: &'a mut [u8],
+        parts: index_interior::IndexInteriorCellParts,
+        slot_index: SlotId,
+    ) -> Self {
+        Self::new(bytes, CellMetadata::IndexInterior(parts), slot_index)
+    }
+
+    /// Returns the slot index that this cell view refers to.
+    pub fn slot_index(&self) -> SlotId {
+        self.slot_index
+    }
+
     /// Borrows this mutable cell as an immutable cell view.
-    pub fn as_ref(&self) -> Cell<Read<'_>, N, T> {
-        Cell::new(Read { bytes: self.bytes() }, self.slot_index)
+    pub fn as_ref(&self) -> Cell<'_, N, T> {
+        Cell::new(self.bytes, self.metadata.clone(), self.slot_index)
+    }
+
+    fn table_leaf_parts(&self) -> &leaf::LeafCellParts {
+        match &self.metadata {
+            CellMetadata::TableLeaf(parts) => parts,
+            _ => unreachable!("table leaf cell metadata mismatch"),
+        }
+    }
+
+    fn index_leaf_parts(&self) -> &index_leaf::IndexLeafCellParts {
+        match &self.metadata {
+            CellMetadata::IndexLeaf(parts) => parts,
+            _ => unreachable!("index leaf cell metadata mismatch"),
+        }
+    }
+
+    fn table_interior_parts(&self) -> &interior::InteriorCellParts {
+        match &self.metadata {
+            CellMetadata::TableInterior(parts) => parts,
+            _ => unreachable!("table interior cell metadata mismatch"),
+        }
+    }
+
+    fn index_interior_parts(&self) -> &index_interior::IndexInteriorCellParts {
+        match &self.metadata {
+            CellMetadata::IndexInterior(parts) => parts,
+            _ => unreachable!("index interior cell metadata mismatch"),
+        }
     }
 }
 
-impl<A> Cell<A, Leaf, Table>
-where
-    A: PageAccess,
-{
+impl Cell<'_, Leaf, Table> {
     /// Returns the row id stored in this leaf cell.
     pub fn row_id(&self) -> PageResult<RowId> {
-        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
-        Ok(leaf::cell_parts(&page, self.slot_index)?.row_id)
+        Ok(self.table_leaf_parts().row_id)
     }
 
     /// Returns the payload bytes stored in this leaf cell.
     pub fn payload(&self) -> PageResult<&[u8]> {
-        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
-        let parts = leaf::cell_parts(&page, self.slot_index)?;
-        Ok(&self.bytes()[parts.payload_start..parts.payload_end])
+        let range = self.table_leaf_parts().payload_range.clone();
+        Ok(&self.bytes[range])
     }
 }
 
-impl<A> Cell<A, Leaf, Table>
-where
-    A: PageAccessMut,
-{
+impl CellMut<'_, Leaf, Table> {
+    /// Returns the row id stored in this leaf cell.
+    pub fn row_id(&self) -> PageResult<RowId> {
+        Ok(self.table_leaf_parts().row_id)
+    }
+
+    /// Returns the payload bytes stored in this leaf cell.
+    pub fn payload(&self) -> PageResult<&[u8]> {
+        let range = self.table_leaf_parts().payload_range.clone();
+        Ok(&self.bytes[range])
+    }
+
     /// Returns the payload bytes stored in this leaf cell mutably.
     pub fn payload_mut(&mut self) -> PageResult<&mut [u8]> {
-        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
-        let parts = leaf::cell_parts(&page, self.slot_index)?;
-        Ok(&mut self.bytes_mut()[parts.payload_start..parts.payload_end])
+        let range = self.table_leaf_parts().payload_range.clone();
+        Ok(&mut self.bytes[range])
     }
 }
 
-impl<A> Cell<A, Leaf, Index>
-where
-    A: PageAccess,
-{
+impl Cell<'_, Leaf, Index> {
     /// Returns the indexed key stored in this leaf cell.
     pub fn key(&self) -> PageResult<&[u8]> {
-        let page = Page::<Read<'_>, Leaf, Index>::open(self.bytes())?;
-        let parts = index_leaf::cell_parts(&page, self.slot_index)?;
-        Ok(&self.bytes()[parts.key_start..parts.key_end])
+        let range = self.index_leaf_parts().key_range.clone();
+        Ok(&self.bytes[range])
     }
 
     /// Returns the row reference stored alongside this index key.
     pub fn row_id(&self) -> PageResult<RowId> {
-        let page = Page::<Read<'_>, Leaf, Index>::open(self.bytes())?;
-        Ok(index_leaf::cell_parts(&page, self.slot_index)?.row_id)
+        Ok(self.index_leaf_parts().row_id)
     }
 }
 
-impl<A> Cell<A, Interior, Table>
-where
-    A: PageAccess,
-{
+impl CellMut<'_, Leaf, Index> {
+    /// Returns the indexed key stored in this leaf cell.
+    pub fn key(&self) -> PageResult<&[u8]> {
+        let range = self.index_leaf_parts().key_range.clone();
+        Ok(&self.bytes[range])
+    }
+
+    /// Returns the row reference stored alongside this index key.
+    pub fn row_id(&self) -> PageResult<RowId> {
+        Ok(self.index_leaf_parts().row_id)
+    }
+}
+
+impl Cell<'_, Interior, Table> {
     /// Returns the separator row id stored in this interior cell.
     pub fn row_id(&self) -> PageResult<RowId> {
-        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
-        Ok(interior::cell_parts(&page, self.slot_index)?.row_id)
+        Ok(self.table_interior_parts().row_id)
     }
 
     /// Returns the left-child page id referenced by this interior cell.
     pub fn left_child(&self) -> PageResult<PageId> {
-        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
-        Ok(interior::cell_parts(&page, self.slot_index)?.left_child)
+        Ok(self.table_interior_parts().left_child)
     }
 }
 
-impl<A> Cell<A, Interior, Table>
-where
-    A: PageAccessMut,
-{
+impl CellMut<'_, Interior, Table> {
+    /// Returns the separator row id stored in this interior cell.
+    pub fn row_id(&self) -> PageResult<RowId> {
+        Ok(self.table_interior_parts().row_id)
+    }
+
+    /// Returns the left-child page id referenced by this interior cell.
+    pub fn left_child(&self) -> PageResult<PageId> {
+        Ok(self.table_interior_parts().left_child)
+    }
+
     /// Updates the left-child page id stored in this interior cell.
     pub fn set_left_child(&mut self, page_id: PageId) -> PageResult<()> {
-        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
-        let parts = interior::cell_parts(&page, self.slot_index)?;
-        interior::write_left_child(self.bytes_mut(), parts.cell_offset, page_id);
+        interior::write_left_child(self.bytes, page_id);
+        if let CellMetadata::TableInterior(parts) = &mut self.metadata {
+            parts.left_child = page_id;
+        }
         Ok(())
     }
 }
 
-impl<A> Cell<A, Interior, Index>
-where
-    A: PageAccess,
-{
+impl Cell<'_, Interior, Index> {
     /// Returns the separator key stored in this interior cell.
     pub fn key(&self) -> PageResult<&[u8]> {
-        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
-        let parts = index_interior::cell_parts(&page, self.slot_index)?;
-        Ok(&self.bytes()[parts.key_start..parts.key_end])
+        let range = self.index_interior_parts().key_range.clone();
+        Ok(&self.bytes[range])
     }
 
     /// Returns the left-child page id referenced by this interior cell.
     pub fn left_child(&self) -> PageResult<PageId> {
-        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
-        Ok(index_interior::cell_parts(&page, self.slot_index)?.left_child)
+        Ok(self.index_interior_parts().left_child)
     }
 }
 
-impl<A> Cell<A, Interior, Index>
-where
-    A: PageAccessMut,
-{
+impl CellMut<'_, Interior, Index> {
+    /// Returns the separator key stored in this interior cell.
+    pub fn key(&self) -> PageResult<&[u8]> {
+        let range = self.index_interior_parts().key_range.clone();
+        Ok(&self.bytes[range])
+    }
+
+    /// Returns the left-child page id referenced by this interior cell.
+    pub fn left_child(&self) -> PageResult<PageId> {
+        Ok(self.index_interior_parts().left_child)
+    }
+
     /// Updates the left-child page id stored in this interior cell.
     pub fn set_left_child(&mut self, page_id: PageId) -> PageResult<()> {
-        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
-        let parts = index_interior::cell_parts(&page, self.slot_index)?;
-        index_interior::write_left_child(self.bytes_mut(), parts.cell_offset, page_id);
+        index_interior::write_left_child(self.bytes, page_id);
+        if let CellMetadata::IndexInterior(parts) = &mut self.metadata {
+            parts.left_child = page_id;
+        }
         Ok(())
     }
 }

--- a/crates/databas_core/src/page/index_interior.rs
+++ b/crates/databas_core/src/page/index_interior.rs
@@ -4,7 +4,7 @@ use crate::{PAGE_SIZE, PageId, SlotId};
 
 use super::{
     CellCorruption, PageError, PageResult,
-    cell::Cell,
+    cell::{Cell, CellMut},
     core::{BoundResult, Index, Interior, Page, PageAccess, PageAccessMut, Read, Write},
     format::{self, CELL_LENGTH_SIZE, RIGHTMOST_CHILD_OFFSET, USABLE_SPACE_END},
 };
@@ -13,12 +13,17 @@ const PAGE_ID_SIZE: usize = 8;
 /// The fixed-size prefix of an index interior cell: encoded length plus left-child page id.
 pub const INDEX_INTERIOR_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + PAGE_ID_SIZE;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct IndexInteriorCellParts {
-    pub(crate) cell_offset: usize,
     pub(crate) left_child: PageId,
-    pub(crate) key_start: usize,
-    pub(crate) key_end: usize,
+    pub(crate) key_range: std::ops::Range<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedIndexInteriorCell {
+    pub(crate) cell_offset: usize,
+    pub(crate) cell_len: usize,
+    pub(crate) parts: IndexInteriorCellParts,
 }
 
 pub(crate) fn cell_len_at(
@@ -39,26 +44,27 @@ pub(crate) fn cell_len_at(
 pub(crate) fn cell_parts<A>(
     page: &Page<A, Interior, Index>,
     slot_index: SlotId,
-) -> PageResult<IndexInteriorCellParts>
+) -> PageResult<ParsedIndexInteriorCell>
 where
     A: PageAccess,
 {
     page.validate_slot_index(slot_index)?;
     let cell_offset = page.slot_offset(slot_index)? as usize;
     let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
-    let key_start = cell_offset + INDEX_INTERIOR_CELL_PREFIX_SIZE;
-    let key_end = cell_offset + cell_len;
 
-    Ok(IndexInteriorCellParts {
+    Ok(ParsedIndexInteriorCell {
         cell_offset,
-        left_child: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
-        key_start,
-        key_end,
+        cell_len,
+        parts: IndexInteriorCellParts {
+            left_child: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
+            key_range: INDEX_INTERIOR_CELL_PREFIX_SIZE..cell_len,
+        },
     })
 }
 
-pub(crate) fn write_left_child(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, page_id: PageId) {
-    format::write_u64(bytes, cell_offset + CELL_LENGTH_SIZE, page_id);
+pub(crate) fn write_left_child(bytes: &mut [u8], page_id: PageId) {
+    bytes[CELL_LENGTH_SIZE..CELL_LENGTH_SIZE + PAGE_ID_SIZE]
+        .copy_from_slice(&page_id.to_le_bytes());
 }
 
 fn encoded_len(key_len: usize) -> PageResult<usize> {
@@ -72,7 +78,7 @@ fn encoded_len(key_len: usize) -> PageResult<usize> {
 fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, left_child: PageId, key: &[u8]) {
     let cell_len = INDEX_INTERIOR_CELL_PREFIX_SIZE + key.len();
     format::write_u16(bytes, cell_offset, cell_len as u16);
-    write_left_child(bytes, cell_offset, left_child);
+    write_left_child(&mut bytes[cell_offset..cell_offset + cell_len], left_child);
     bytes[cell_offset + INDEX_INTERIOR_CELL_PREFIX_SIZE..cell_offset + cell_len]
         .copy_from_slice(key);
 }
@@ -85,8 +91,10 @@ fn compare_key<A>(
 where
     A: PageAccess,
 {
-    let parts = cell_parts(page, slot_index)?;
-    Ok(page.bytes()[parts.key_start..parts.key_end].cmp(key))
+    let parsed = cell_parts(page, slot_index)?;
+    let cell_offset = parsed.cell_offset;
+    let key_range = parsed.parts.key_range;
+    Ok(page.bytes()[cell_offset + key_range.start..cell_offset + key_range.end].cmp(key))
 }
 
 impl<A> Page<A, Interior, Index>
@@ -111,15 +119,16 @@ where
     /// Returns the child page that may contain `key`.
     pub fn child_for(&self, key: &[u8]) -> PageResult<PageId> {
         match self.lower_bound(key)? {
-            BoundResult::At(slot_index) => Ok(cell_parts(self, slot_index)?.left_child),
+            BoundResult::At(slot_index) => Ok(cell_parts(self, slot_index)?.parts.left_child),
             BoundResult::PastEnd => Ok(self.rightmost_child()),
         }
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.
-    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Interior, Index>> {
-        cell_parts(self, slot_index)?;
-        Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<'_, Interior, Index>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes = &self.bytes()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(Cell::new_index_interior(cell_bytes, parsed.parts, slot_index))
     }
 }
 
@@ -133,10 +142,11 @@ where
     }
 
     /// Returns a typed mutable view of the cell at `slot_index`.
-    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Interior, Index>> {
-        let page = Page::<Read<'_>, Interior, Index>::open(self.bytes())?;
-        cell_parts(&page, slot_index)?;
-        Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<CellMut<'_, Interior, Index>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes =
+            &mut self.bytes_mut()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(CellMut::new_index_interior(cell_bytes, parsed.parts, slot_index))
     }
 
     /// Inserts a new separator key and its left-child pointer while preserving slot order.
@@ -278,5 +288,16 @@ mod tests {
 
         let page = page.as_ref();
         assert_eq!(page.cell(0).unwrap().left_child().unwrap(), 66);
+    }
+
+    #[test]
+    fn cell_key_is_sliced_relative_to_cell_start() {
+        let mut bytes = new_index_interior_page(9);
+        let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
+        page.insert(&[5_u8; 64], 1).unwrap();
+        page.insert(b"mango", 2).unwrap();
+
+        let page = page.as_ref();
+        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"mango");
     }
 }

--- a/crates/databas_core/src/page/index_leaf.rs
+++ b/crates/databas_core/src/page/index_leaf.rs
@@ -4,7 +4,7 @@ use crate::{PAGE_SIZE, RowId, SlotId};
 
 use super::{
     CellCorruption, PageError, PageResult,
-    cell::Cell,
+    cell::{Cell, CellMut},
     core::{BoundResult, Index, Leaf, Page, PageAccess, PageAccessMut, Read, SearchResult, Write},
     format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
 };
@@ -13,11 +13,17 @@ const ROW_ID_SIZE: usize = 8;
 /// The fixed-size prefix of an index leaf cell: encoded length plus row reference.
 pub const INDEX_LEAF_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + ROW_ID_SIZE;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct IndexLeafCellParts {
     pub(crate) row_id: RowId,
-    pub(crate) key_start: usize,
-    pub(crate) key_end: usize,
+    pub(crate) key_range: Range<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedIndexLeafCell {
+    pub(crate) cell_offset: usize,
+    pub(crate) cell_len: usize,
+    pub(crate) parts: IndexLeafCellParts,
 }
 
 pub(crate) fn cell_len_at(
@@ -38,20 +44,21 @@ pub(crate) fn cell_len_at(
 pub(crate) fn cell_parts<A>(
     page: &Page<A, Leaf, Index>,
     slot_index: SlotId,
-) -> PageResult<IndexLeafCellParts>
+) -> PageResult<ParsedIndexLeafCell>
 where
     A: PageAccess,
 {
     page.validate_slot_index(slot_index)?;
     let cell_offset = page.slot_offset(slot_index)? as usize;
     let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
-    let key_start = cell_offset + INDEX_LEAF_CELL_PREFIX_SIZE;
-    let key_end = cell_offset + cell_len;
 
-    Ok(IndexLeafCellParts {
-        row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
-        key_start,
-        key_end,
+    Ok(ParsedIndexLeafCell {
+        cell_offset,
+        cell_len,
+        parts: IndexLeafCellParts {
+            row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
+            key_range: INDEX_LEAF_CELL_PREFIX_SIZE..cell_len,
+        },
     })
 }
 
@@ -78,8 +85,10 @@ fn compare_key<A>(
 where
     A: PageAccess,
 {
-    let parts = cell_parts(page, slot_index)?;
-    Ok(page.bytes()[parts.key_start..parts.key_end].cmp(key))
+    let parsed = cell_parts(page, slot_index)?;
+    let cell_offset = parsed.cell_offset;
+    let key_range = parsed.parts.key_range;
+    Ok(page.bytes()[cell_offset + key_range.start..cell_offset + key_range.end].cmp(key))
 }
 
 fn compare_entry<A>(
@@ -91,9 +100,12 @@ fn compare_entry<A>(
 where
     A: PageAccess,
 {
-    let parts = cell_parts(page, slot_index)?;
-    let ordering = page.bytes()[parts.key_start..parts.key_end].cmp(key);
-    Ok(if ordering == Ordering::Equal { parts.row_id.cmp(&row_id) } else { ordering })
+    let parsed = cell_parts(page, slot_index)?;
+    let cell_offset = parsed.cell_offset;
+    let key_range = parsed.parts.key_range.clone();
+    let ordering =
+        page.bytes()[cell_offset + key_range.start..cell_offset + key_range.end].cmp(key);
+    Ok(if ordering == Ordering::Equal { parsed.parts.row_id.cmp(&row_id) } else { ordering })
 }
 
 fn bound_to_slot(bound: BoundResult, slot_count: SlotId) -> SlotId {
@@ -125,9 +137,10 @@ where
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.
-    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Leaf, Index>> {
-        cell_parts(self, slot_index)?;
-        Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<'_, Leaf, Index>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes = &self.bytes()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(Cell::new_index_leaf(cell_bytes, parsed.parts, slot_index))
     }
 }
 
@@ -136,10 +149,11 @@ where
     A: PageAccessMut,
 {
     /// Returns a typed mutable view of the cell at `slot_index`.
-    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Leaf, Index>> {
-        let page = Page::<Read<'_>, Leaf, Index>::open(self.bytes())?;
-        cell_parts(&page, slot_index)?;
-        Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<CellMut<'_, Leaf, Index>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes =
+            &mut self.bytes_mut()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(CellMut::new_index_leaf(cell_bytes, parsed.parts, slot_index))
     }
 
     /// Inserts a new `(key, row_id)` entry while preserving lexicographic key order.
@@ -299,5 +313,16 @@ mod tests {
         let cell = cell.as_ref();
         assert_eq!(cell.key().unwrap(), b"banana");
         assert_eq!(cell.row_id().unwrap(), 2);
+    }
+
+    #[test]
+    fn cell_key_is_sliced_relative_to_cell_start() {
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(&[7_u8; 64], 1).unwrap();
+        page.insert(b"banana", 2).unwrap();
+
+        let page = page.as_ref();
+        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"banana");
     }
 }

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -2,7 +2,7 @@ use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 
 use super::{
     PageError, PageResult,
-    cell::Cell,
+    cell::{Cell, CellMut},
     core::{
         BoundResult, Interior, Page, PageAccess, PageAccessMut, Read, SearchResult, Table, Write,
     },
@@ -16,25 +16,34 @@ pub const INTERIOR_CELL_SIZE: usize = PAGE_ID_SIZE + ROW_ID_SIZE;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct InteriorCellParts {
-    pub(crate) cell_offset: usize,
     pub(crate) left_child: PageId,
     pub(crate) row_id: RowId,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ParsedInteriorCell {
+    pub(crate) cell_offset: usize,
+    pub(crate) cell_len: usize,
+    pub(crate) parts: InteriorCellParts,
 }
 
 pub(crate) fn cell_parts<A>(
     page: &Page<A, Interior, Table>,
     slot_index: SlotId,
-) -> PageResult<InteriorCellParts>
+) -> PageResult<ParsedInteriorCell>
 where
     A: PageAccess,
 {
     page.validate_slot_index(slot_index)?;
     let cell_offset = page.slot_offset(slot_index)? as usize;
 
-    Ok(InteriorCellParts {
+    Ok(ParsedInteriorCell {
         cell_offset,
-        left_child: format::read_u64(page.bytes(), cell_offset),
-        row_id: format::read_u64(page.bytes(), cell_offset + PAGE_ID_SIZE),
+        cell_len: INTERIOR_CELL_SIZE,
+        parts: InteriorCellParts {
+            left_child: format::read_u64(page.bytes(), cell_offset),
+            row_id: format::read_u64(page.bytes(), cell_offset + PAGE_ID_SIZE),
+        },
     })
 }
 
@@ -43,12 +52,12 @@ fn encoded_len() -> usize {
 }
 
 fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, left_child: PageId, row_id: RowId) {
-    write_left_child(bytes, cell_offset, left_child);
+    write_left_child(&mut bytes[cell_offset..cell_offset + INTERIOR_CELL_SIZE], left_child);
     format::write_u64(bytes, cell_offset + PAGE_ID_SIZE, row_id);
 }
 
-pub(crate) fn write_left_child(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, page_id: PageId) {
-    format::write_u64(bytes, cell_offset, page_id);
+pub(crate) fn write_left_child(bytes: &mut [u8], page_id: PageId) {
+    bytes[..PAGE_ID_SIZE].copy_from_slice(&page_id.to_le_bytes());
 }
 
 impl<A> Page<A, Interior, Table>
@@ -63,21 +72,21 @@ where
     /// Returns the first slot whose separator row id is greater than or equal to `row_id`.
     pub fn lower_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
         self.lower_bound_slots_by(|page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+            Ok(cell_parts(page, slot_index)?.parts.row_id.cmp(&row_id))
         })
     }
 
     /// Returns the first slot whose separator row id is strictly greater than `row_id`.
     pub fn upper_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
         self.upper_bound_slots_by(|page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+            Ok(cell_parts(page, slot_index)?.parts.row_id.cmp(&row_id))
         })
     }
 
     /// Returns the child page that may contain `row_id`.
     pub fn child_for(&self, row_id: RowId) -> PageResult<PageId> {
         match self.lower_bound(row_id)? {
-            BoundResult::At(slot_index) => Ok(cell_parts(self, slot_index)?.left_child),
+            BoundResult::At(slot_index) => Ok(cell_parts(self, slot_index)?.parts.left_child),
             BoundResult::PastEnd => Ok(self.rightmost_child()),
         }
     }
@@ -85,18 +94,19 @@ where
     /// Searches the interior page for `row_id`.
     pub fn search(&self, row_id: RowId) -> PageResult<SearchResult> {
         self.search_slots_by(|page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+            Ok(cell_parts(page, slot_index)?.parts.row_id.cmp(&row_id))
         })
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.
-    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Interior, Table>> {
-        cell_parts(self, slot_index)?;
-        Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<'_, Interior, Table>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes = &self.bytes()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(Cell::new_table_interior(cell_bytes, parsed.parts, slot_index))
     }
 
     /// Looks up a separator key and returns its cell if present.
-    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<Read<'_>, Interior, Table>>> {
+    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<'_, Interior, Table>>> {
         match self.search(row_id)? {
             SearchResult::Found(slot_index) => self.cell(slot_index).map(Some),
             SearchResult::InsertAt(_) => Ok(None),
@@ -114,10 +124,11 @@ where
     }
 
     /// Returns a typed mutable view of the cell at `slot_index`.
-    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Interior, Table>> {
-        let page = Page::<Read<'_>, Interior, Table>::open(self.bytes())?;
-        cell_parts(&page, slot_index)?;
-        Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<CellMut<'_, Interior, Table>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes =
+            &mut self.bytes_mut()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(CellMut::new_table_interior(cell_bytes, parsed.parts, slot_index))
     }
 
     /// Inserts a new separator key and its left-child pointer while preserving slot order.

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -1,8 +1,10 @@
+use std::ops::Range;
+
 use crate::{PAGE_SIZE, RowId, SlotId};
 
 use super::{
     CellCorruption, PageError, PageResult,
-    cell::Cell,
+    cell::{Cell, CellMut},
     core::{BoundResult, Leaf, Page, PageAccess, PageAccessMut, Read, SearchResult, Table, Write},
     format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
 };
@@ -11,11 +13,17 @@ const ROW_ID_SIZE: usize = 8;
 /// The fixed-size prefix of a leaf cell: encoded length plus row id.
 pub const LEAF_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + ROW_ID_SIZE;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct LeafCellParts {
     pub(crate) row_id: RowId,
-    pub(crate) payload_start: usize,
-    pub(crate) payload_end: usize,
+    pub(crate) payload_range: Range<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedLeafCell {
+    pub(crate) cell_offset: usize,
+    pub(crate) cell_len: usize,
+    pub(crate) parts: LeafCellParts,
 }
 
 pub(crate) fn cell_len_at(
@@ -36,7 +44,7 @@ pub(crate) fn cell_len_at(
 pub(crate) fn cell_parts<A>(
     page: &Page<A, Leaf, Table>,
     slot_index: SlotId,
-) -> PageResult<LeafCellParts>
+) -> PageResult<ParsedLeafCell>
 where
     A: PageAccess,
 {
@@ -44,13 +52,13 @@ where
     let cell_offset = page.slot_offset(slot_index)? as usize;
     let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
 
-    let payload_start = cell_offset + LEAF_CELL_PREFIX_SIZE;
-    let payload_end = cell_offset + cell_len;
-
-    Ok(LeafCellParts {
-        row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
-        payload_start,
-        payload_end,
+    Ok(ParsedLeafCell {
+        cell_offset,
+        cell_len,
+        parts: LeafCellParts {
+            row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
+            payload_range: LEAF_CELL_PREFIX_SIZE..cell_len,
+        },
     })
 }
 
@@ -76,32 +84,33 @@ where
     /// Returns the first slot whose row id is greater than or equal to `row_id`.
     pub fn lower_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
         self.lower_bound_slots_by(|page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+            Ok(cell_parts(page, slot_index)?.parts.row_id.cmp(&row_id))
         })
     }
 
     /// Returns the first slot whose row id is strictly greater than `row_id`.
     pub fn upper_bound(&self, row_id: RowId) -> PageResult<BoundResult> {
         self.upper_bound_slots_by(|page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+            Ok(cell_parts(page, slot_index)?.parts.row_id.cmp(&row_id))
         })
     }
 
     /// Searches the leaf page for `row_id`.
     pub fn search(&self, row_id: RowId) -> PageResult<SearchResult> {
         self.search_slots_by(|page, slot_index| {
-            Ok(cell_parts(page, slot_index)?.row_id.cmp(&row_id))
+            Ok(cell_parts(page, slot_index)?.parts.row_id.cmp(&row_id))
         })
     }
 
     /// Returns a typed immutable view of the cell at `slot_index`.
-    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<Read<'_>, Leaf, Table>> {
-        cell_parts(self, slot_index)?;
-        Ok(Cell::new(Read { bytes: self.bytes() }, slot_index))
+    pub fn cell(&self, slot_index: SlotId) -> PageResult<Cell<'_, Leaf, Table>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes = &self.bytes()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(Cell::new_table_leaf(cell_bytes, parsed.parts, slot_index))
     }
 
     /// Looks up a row id and returns its cell if present.
-    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<Read<'_>, Leaf, Table>>> {
+    pub fn lookup(&self, row_id: RowId) -> PageResult<Option<Cell<'_, Leaf, Table>>> {
         match self.search(row_id)? {
             SearchResult::Found(slot_index) => self.cell(slot_index).map(Some),
             SearchResult::InsertAt(_) => Ok(None),
@@ -114,10 +123,11 @@ where
     A: PageAccessMut,
 {
     /// Returns a typed mutable view of the cell at `slot_index`.
-    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<Cell<Write<'_>, Leaf, Table>> {
-        let page = Page::<Read<'_>, Leaf, Table>::open(self.bytes())?;
-        cell_parts(&page, slot_index)?;
-        Ok(Cell::new(Write { bytes: self.bytes_mut() }, slot_index))
+    pub fn cell_mut(&mut self, slot_index: SlotId) -> PageResult<CellMut<'_, Leaf, Table>> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_bytes =
+            &mut self.bytes_mut()[parsed.cell_offset..parsed.cell_offset + parsed.cell_len];
+        Ok(CellMut::new_table_leaf(cell_bytes, parsed.parts, slot_index))
     }
 
     /// Inserts a new `(row_id, payload)` record while preserving slot order.
@@ -657,5 +667,16 @@ mod tests {
 
         let page_ref = page.as_ref();
         assert_eq!(page_ref.lookup(10).unwrap().unwrap().payload().unwrap(), b"xyz");
+    }
+
+    #[test]
+    fn cell_payload_is_sliced_relative_to_cell_start() {
+        let mut bytes = new_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf>::open(&mut bytes).unwrap();
+        page.insert(10, &[1_u8; 64]).unwrap();
+        page.insert(20, b"payload").unwrap();
+
+        let page_ref = page.as_ref();
+        assert_eq!(page_ref.cell(1).unwrap().payload().unwrap(), b"payload");
     }
 }

--- a/crates/databas_core/src/page/mod.rs
+++ b/crates/databas_core/src/page/mod.rs
@@ -12,8 +12,8 @@
 //! invalid combinations harder to express.
 //!
 //! When the concrete page kind is not known ahead of time, use [`AnyPage`] to
-//! inspect an already-initialized byte buffer. [`Cell`] provides typed access to
-//! individual slot entries after lookup.
+//! inspect an already-initialized byte buffer. [`Cell`] and [`CellMut`] provide
+//! typed access to individual slot entries after lookup.
 //!
 //! Layout details that are part of the stable page format are re-exported from
 //! [`mod@format`], including header sizes, slot entry width, and the current
@@ -30,6 +30,8 @@ mod leaf;
 
 /// A typed view over a single page cell in either a leaf or interior page.
 pub use cell::Cell;
+/// A typed mutable view over a single page cell in either a leaf or interior page.
+pub use cell::CellMut;
 /// Page handles, marker types, access traits, and search helpers for typed page access.
 pub use core::{
     AnyPage, BoundResult, Index, Interior, Leaf, NodeMarker, Page, PageAccess, PageAccessMut, Read,


### PR DESCRIPTION
Split page cell views into immutable `Cell` and mutable `CellMut` types that borrow only the encoded bytes for a single cell instead of the whole page.

Leaf and interior page parsers now return parsed metadata separately from the cell offset and length, and express payload and key ranges relative to the start of each cell. This keeps cell reads and left-child updates working on per-cell slices and adds regression coverage for non-first cells.