### PR TITLE
Refactor cell format around payload semantics

### DIFF
--- a/crates/databas_core/src/page/cell.rs
+++ b/crates/databas_core/src/page/cell.rs
@@ -214,28 +214,18 @@ impl CellMut<'_, Leaf, Table> {
 }
 
 impl Cell<'_, Leaf, Index> {
-    /// Returns the indexed key stored in this leaf cell.
-    pub fn key(&self) -> PageResult<&[u8]> {
-        let range = self.index_leaf_parts().key_range.clone();
+    /// Returns the variable-sized payload bytes stored in this leaf cell.
+    pub fn payload(&self) -> PageResult<&[u8]> {
+        let range = self.index_leaf_parts().payload_range.clone();
         Ok(&self.bytes[range])
-    }
-
-    /// Returns the row reference stored alongside this index key.
-    pub fn row_id(&self) -> PageResult<RowId> {
-        Ok(self.index_leaf_parts().row_id)
     }
 }
 
 impl CellMut<'_, Leaf, Index> {
-    /// Returns the indexed key stored in this leaf cell.
-    pub fn key(&self) -> PageResult<&[u8]> {
-        let range = self.index_leaf_parts().key_range.clone();
+    /// Returns the variable-sized payload bytes stored in this leaf cell.
+    pub fn payload(&self) -> PageResult<&[u8]> {
+        let range = self.index_leaf_parts().payload_range.clone();
         Ok(&self.bytes[range])
-    }
-
-    /// Returns the row reference stored alongside this index key.
-    pub fn row_id(&self) -> PageResult<RowId> {
-        Ok(self.index_leaf_parts().row_id)
     }
 }
 
@@ -273,9 +263,9 @@ impl CellMut<'_, Interior, Table> {
 }
 
 impl Cell<'_, Interior, Index> {
-    /// Returns the separator key stored in this interior cell.
-    pub fn key(&self) -> PageResult<&[u8]> {
-        let range = self.index_interior_parts().key_range.clone();
+    /// Returns the variable-sized payload bytes stored in this interior cell.
+    pub fn payload(&self) -> PageResult<&[u8]> {
+        let range = self.index_interior_parts().payload_range.clone();
         Ok(&self.bytes[range])
     }
 
@@ -286,9 +276,9 @@ impl Cell<'_, Interior, Index> {
 }
 
 impl CellMut<'_, Interior, Index> {
-    /// Returns the separator key stored in this interior cell.
-    pub fn key(&self) -> PageResult<&[u8]> {
-        let range = self.index_interior_parts().key_range.clone();
+    /// Returns the variable-sized payload bytes stored in this interior cell.
+    pub fn payload(&self) -> PageResult<&[u8]> {
+        let range = self.index_interior_parts().payload_range.clone();
         Ok(&self.bytes[range])
     }
 

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -13,11 +13,11 @@ use super::{
     },
 };
 
-/// Marker type for leaf pages that store payload-bearing records.
+/// Marker type for leaf pages that store b-tree records.
 #[derive(Debug)]
 pub enum Leaf {}
 
-/// Marker type for interior pages that store separator keys and child pointers.
+/// Marker type for interior pages that store separators and child pointers.
 #[derive(Debug)]
 pub enum Interior {}
 

--- a/crates/databas_core/src/page/index_interior.rs
+++ b/crates/databas_core/src/page/index_interior.rs
@@ -16,7 +16,7 @@ pub const INDEX_INTERIOR_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + PAGE_ID_SI
 #[derive(Debug, Clone)]
 pub(crate) struct IndexInteriorCellParts {
     pub(crate) left_child: PageId,
-    pub(crate) key_range: std::ops::Range<usize>,
+    pub(crate) payload_range: std::ops::Range<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -57,7 +57,7 @@ where
         cell_len,
         parts: IndexInteriorCellParts {
             left_child: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
-            key_range: INDEX_INTERIOR_CELL_PREFIX_SIZE..cell_len,
+            payload_range: INDEX_INTERIOR_CELL_PREFIX_SIZE..cell_len,
         },
     })
 }
@@ -93,8 +93,8 @@ where
 {
     let parsed = cell_parts(page, slot_index)?;
     let cell_offset = parsed.cell_offset;
-    let key_range = parsed.parts.key_range;
-    Ok(page.bytes()[cell_offset + key_range.start..cell_offset + key_range.end].cmp(key))
+    let payload_range = parsed.parts.payload_range;
+    Ok(page.bytes()[cell_offset + payload_range.start..cell_offset + payload_range.end].cmp(key))
 }
 
 impl<A> Page<A, Interior, Index>
@@ -183,7 +183,7 @@ mod tests {
 
         let page = page.as_ref();
         let cell = page.cell(0).unwrap();
-        assert_eq!(cell.key().unwrap(), b"mango");
+        assert_eq!(cell.payload().unwrap(), b"mango");
         assert_eq!(cell.left_child().unwrap(), 5);
         assert_eq!(page.rightmost_child(), 99);
     }
@@ -210,13 +210,13 @@ mod tests {
         page.insert(b"mango", 3).unwrap();
 
         let page = page.as_ref();
-        assert_eq!(page.cell(0).unwrap().key().unwrap(), b"apple");
+        assert_eq!(page.cell(0).unwrap().payload().unwrap(), b"apple");
         assert_eq!(page.cell(0).unwrap().left_child().unwrap(), 1);
-        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"mango");
+        assert_eq!(page.cell(1).unwrap().payload().unwrap(), b"mango");
         assert_eq!(page.cell(1).unwrap().left_child().unwrap(), 2);
-        assert_eq!(page.cell(2).unwrap().key().unwrap(), b"mango");
+        assert_eq!(page.cell(2).unwrap().payload().unwrap(), b"mango");
         assert_eq!(page.cell(2).unwrap().left_child().unwrap(), 3);
-        assert_eq!(page.cell(3).unwrap().key().unwrap(), b"pear");
+        assert_eq!(page.cell(3).unwrap().payload().unwrap(), b"pear");
         assert_eq!(page.cell(3).unwrap().left_child().unwrap(), 4);
     }
 
@@ -292,13 +292,13 @@ mod tests {
     }
 
     #[test]
-    fn cell_key_is_sliced_relative_to_cell_start() {
+    fn cell_payload_is_sliced_relative_to_cell_start() {
         let mut bytes = new_index_interior_page(9);
         let mut page = Page::<Write<'_>, Interior, Index>::open(&mut bytes).unwrap();
         page.insert(&[5_u8; 64], 1).unwrap();
         page.insert(b"mango", 2).unwrap();
 
         let page = page.as_ref();
-        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"mango");
+        assert_eq!(page.cell(1).unwrap().payload().unwrap(), b"mango");
     }
 }

--- a/crates/databas_core/src/page/index_interior.rs
+++ b/crates/databas_core/src/page/index_interior.rs
@@ -5,7 +5,7 @@ use crate::{PAGE_SIZE, PageId, SlotId};
 use super::{
     CellCorruption, PageError, PageResult,
     cell::{Cell, CellMut},
-    core::{BoundResult, Index, Interior, Page, PageAccess, PageAccessMut, Read, Write},
+    core::{BoundResult, Index, Interior, Page, PageAccess, PageAccessMut},
     format::{self, CELL_LENGTH_SIZE, RIGHTMOST_CHILD_OFFSET, USABLE_SPACE_END},
 };
 
@@ -167,6 +167,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::{Read, Write};
 
     fn new_index_interior_page(rightmost_child: PageId) -> [u8; PAGE_SIZE] {
         let mut bytes = [0_u8; PAGE_SIZE];

--- a/crates/databas_core/src/page/index_leaf.rs
+++ b/crates/databas_core/src/page/index_leaf.rs
@@ -5,7 +5,7 @@ use crate::{PAGE_SIZE, RowId, SlotId};
 use super::{
     CellCorruption, PageError, PageResult,
     cell::{Cell, CellMut},
-    core::{BoundResult, Index, Leaf, Page, PageAccess, PageAccessMut, Read, SearchResult, Write},
+    core::{BoundResult, Index, Leaf, Page, PageAccess, PageAccessMut, SearchResult},
     format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
 };
 
@@ -192,6 +192,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::{Read, Write};
 
     fn new_index_leaf_page() -> [u8; PAGE_SIZE] {
         let mut bytes = [0_u8; PAGE_SIZE];

--- a/crates/databas_core/src/page/index_leaf.rs
+++ b/crates/databas_core/src/page/index_leaf.rs
@@ -15,14 +15,14 @@ pub const INDEX_LEAF_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + ROW_ID_SIZE;
 
 #[derive(Debug, Clone)]
 pub(crate) struct IndexLeafCellParts {
-    pub(crate) row_id: RowId,
-    pub(crate) key_range: Range<usize>,
+    pub(crate) payload_range: Range<usize>,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct ParsedIndexLeafCell {
     pub(crate) cell_offset: usize,
     pub(crate) cell_len: usize,
+    pub(crate) row_id: RowId,
     pub(crate) parts: IndexLeafCellParts,
 }
 
@@ -55,10 +55,8 @@ where
     Ok(ParsedIndexLeafCell {
         cell_offset,
         cell_len,
-        parts: IndexLeafCellParts {
-            row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
-            key_range: INDEX_LEAF_CELL_PREFIX_SIZE..cell_len,
-        },
+        row_id: format::read_u64(page.bytes(), cell_offset + CELL_LENGTH_SIZE),
+        parts: IndexLeafCellParts { payload_range: INDEX_LEAF_CELL_PREFIX_SIZE..cell_len },
     })
 }
 
@@ -87,8 +85,8 @@ where
 {
     let parsed = cell_parts(page, slot_index)?;
     let cell_offset = parsed.cell_offset;
-    let key_range = parsed.parts.key_range;
-    Ok(page.bytes()[cell_offset + key_range.start..cell_offset + key_range.end].cmp(key))
+    let payload_range = parsed.parts.payload_range;
+    Ok(page.bytes()[cell_offset + payload_range.start..cell_offset + payload_range.end].cmp(key))
 }
 
 fn compare_entry<A>(
@@ -102,10 +100,10 @@ where
 {
     let parsed = cell_parts(page, slot_index)?;
     let cell_offset = parsed.cell_offset;
-    let key_range = parsed.parts.key_range.clone();
+    let payload_range = parsed.parts.payload_range.clone();
     let ordering =
-        page.bytes()[cell_offset + key_range.start..cell_offset + key_range.end].cmp(key);
-    Ok(if ordering == Ordering::Equal { parsed.parts.row_id.cmp(&row_id) } else { ordering })
+        page.bytes()[cell_offset + payload_range.start..cell_offset + payload_range.end].cmp(key);
+    Ok(if ordering == Ordering::Equal { parsed.row_id.cmp(&row_id) } else { ordering })
 }
 
 fn bound_to_slot(bound: BoundResult, slot_count: SlotId) -> SlotId {
@@ -208,8 +206,7 @@ mod tests {
 
         let page = page.as_ref();
         let cell = page.cell(0).unwrap();
-        assert_eq!(cell.key().unwrap(), b"beta");
-        assert_eq!(cell.row_id().unwrap(), 7);
+        assert_eq!(cell.payload().unwrap(), b"beta");
     }
 
     #[test]
@@ -222,14 +219,20 @@ mod tests {
         page.insert(b"apple", 1).unwrap();
 
         let page = page.as_ref();
-        assert_eq!(page.cell(0).unwrap().key().unwrap(), b"apple");
-        assert_eq!(page.cell(0).unwrap().row_id().unwrap(), 1);
-        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"apple");
-        assert_eq!(page.cell(1).unwrap().row_id().unwrap(), 9);
-        assert_eq!(page.cell(2).unwrap().key().unwrap(), b"banana");
-        assert_eq!(page.cell(2).unwrap().row_id().unwrap(), 2);
-        assert_eq!(page.cell(3).unwrap().key().unwrap(), b"banana");
-        assert_eq!(page.cell(3).unwrap().row_id().unwrap(), 4);
+        assert_eq!(page.cell(0).unwrap().payload().unwrap(), b"apple");
+        assert_eq!(page.cell(1).unwrap().payload().unwrap(), b"apple");
+        assert_eq!(page.cell(2).unwrap().payload().unwrap(), b"banana");
+        assert_eq!(page.cell(3).unwrap().payload().unwrap(), b"banana");
+
+        let mut bytes = new_index_leaf_page();
+        let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
+        page.insert(b"banana", 4).unwrap();
+        page.insert(b"banana", 2).unwrap();
+        page.insert(b"banana", 8).unwrap();
+
+        assert_eq!(page.delete(b"banana", 2).unwrap(), 0);
+        assert_eq!(page.delete(b"banana", 4).unwrap(), 0);
+        assert_eq!(page.delete(b"banana", 8).unwrap(), 0);
     }
 
     #[test]
@@ -290,8 +293,8 @@ mod tests {
 
         let page = page.as_ref();
         assert_eq!(page.equal_range(b"banana").unwrap(), 0..2);
-        assert_eq!(page.cell(0).unwrap().row_id().unwrap(), 2);
-        assert_eq!(page.cell(1).unwrap().row_id().unwrap(), 8);
+        assert_eq!(page.cell(0).unwrap().payload().unwrap(), b"banana");
+        assert_eq!(page.cell(1).unwrap().payload().unwrap(), b"banana");
     }
 
     #[test]
@@ -312,18 +315,17 @@ mod tests {
 
         let cell = page.cell_mut(0).unwrap();
         let cell = cell.as_ref();
-        assert_eq!(cell.key().unwrap(), b"banana");
-        assert_eq!(cell.row_id().unwrap(), 2);
+        assert_eq!(cell.payload().unwrap(), b"banana");
     }
 
     #[test]
-    fn cell_key_is_sliced_relative_to_cell_start() {
+    fn cell_payload_is_sliced_relative_to_cell_start() {
         let mut bytes = new_index_leaf_page();
         let mut page = Page::<Write<'_>, Leaf, Index>::open(&mut bytes).unwrap();
         page.insert(&[7_u8; 64], 1).unwrap();
         page.insert(b"banana", 2).unwrap();
 
         let page = page.as_ref();
-        assert_eq!(page.cell(1).unwrap().key().unwrap(), b"banana");
+        assert_eq!(page.cell(1).unwrap().payload().unwrap(), b"banana");
     }
 }

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -3,9 +3,7 @@ use crate::{PAGE_SIZE, PageId, RowId, SlotId};
 use super::{
     PageError, PageResult,
     cell::{Cell, CellMut},
-    core::{
-        BoundResult, Interior, Page, PageAccess, PageAccessMut, Read, SearchResult, Table, Write,
-    },
+    core::{BoundResult, Interior, Page, PageAccess, PageAccessMut, SearchResult, Table},
     format::{self, RIGHTMOST_CHILD_OFFSET},
 };
 
@@ -160,6 +158,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::{Read, Write};
 
     fn new_interior_page(rightmost_child: PageId) -> [u8; PAGE_SIZE] {
         let mut bytes = [0_u8; PAGE_SIZE];

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -5,7 +5,7 @@ use crate::{PAGE_SIZE, RowId, SlotId};
 use super::{
     CellCorruption, PageError, PageResult,
     cell::{Cell, CellMut},
-    core::{BoundResult, Leaf, Page, PageAccess, PageAccessMut, Read, SearchResult, Table, Write},
+    core::{BoundResult, Leaf, Page, PageAccess, PageAccessMut, SearchResult, Table},
     format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
 };
 
@@ -187,6 +187,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::{Read, Write};
 
     fn new_leaf_page() -> [u8; PAGE_SIZE] {
         let mut bytes = [0_u8; PAGE_SIZE];

--- a/crates/databas_core/src/page/mod.rs
+++ b/crates/databas_core/src/page/mod.rs
@@ -2,9 +2,10 @@
 //!
 //! This module exposes the typed page API used by the storage layer to read and
 //! mutate fixed-size on-disk pages. Pages are split across two orthogonal axes:
-//! node kind and tree kind. [`Leaf`] pages store payload-bearing records, while
-//! [`Interior`] pages store separators and child pointers. [`Table`] pages use
-//! row ids as keys; [`Index`] pages use byte-slice keys.
+//! node kind and tree kind. [`Leaf`] pages store records, while [`Interior`]
+//! pages store separators and child pointers. [`Table`] pages use row ids as
+//! keys; [`Index`] pages use byte-slice keys. Depending on the page kind, cells
+//! may also carry a variable-sized payload region.
 //!
 //! The main entry point is [`Page`]. A page is parameterized both by access mode
 //! ([`Read`] or [`Write`]), node kind ([`Leaf`] or [`Interior`]), and tree kind

--- a/crates/databas_core/src/page/mod.rs
+++ b/crates/databas_core/src/page/mod.rs
@@ -28,24 +28,10 @@ mod index_leaf;
 mod interior;
 mod leaf;
 
-/// A typed view over a single page cell in either a leaf or interior page.
-pub use cell::Cell;
-/// A typed mutable view over a single page cell in either a leaf or interior page.
-pub use cell::CellMut;
 /// Page handles, marker types, access traits, and search helpers for typed page access.
-pub use core::{
-    AnyPage, BoundResult, Index, Interior, Leaf, NodeMarker, Page, PageAccess, PageAccessMut, Read,
-    SearchResult, Table, TreeMarker, Write,
-};
+pub use core::{AnyPage, Index, Interior, Leaf, NodeMarker, Page, Read, Table, TreeMarker, Write};
 /// Errors returned while validating or manipulating encoded pages and cells.
 pub(crate) use error::{CellCorruption, PageCorruption, PageError, PageResult};
-/// Public page-format constants and layout metadata used by page encoders and decoders.
-pub use format::{
-    CELL_LENGTH_SIZE, FORMAT_VERSION, FREEBLOCK_HEADER_SIZE, INTERIOR_HEADER_SIZE,
-    LEAF_HEADER_SIZE, MAX_FRAGMENTED_FREE_BYTES, NEXT_PAGE_ID_OFFSET, NodeKind,
-    PREV_PAGE_ID_OFFSET, PageKind, RESERVED_FOOTER_SIZE, SHARED_HEADER_SIZE, SLOT_ENTRY_SIZE,
-    TreeKind, USABLE_SPACE_END,
-};
 
 /// A typed table leaf page alias.
 pub type TableLeafPage<A> = Page<A, Leaf, Table>;

--- a/crates/databas_core/src/page_cache.rs
+++ b/crates/databas_core/src/page_cache.rs
@@ -453,7 +453,8 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::*;
-    use crate::page::{AnyPage, Leaf, Page, PageKind, Write};
+    use crate::page::format::PageKind;
+    use crate::page::{AnyPage, Leaf, Page, Write};
 
     /// Generates a deterministic page payload from a seed byte.
     fn page_with_pattern(seed: u8) -> [u8; PAGE_SIZE] {


### PR DESCRIPTION
This PR refactors the cell formats to be oriented around payloads. The purpose of doing this is to make it easier to implement oversized cells and overflow pages in the future. With this change, all cells can be divided into a fixed-size part and a variable-sized part. 