### PR TITLE
Implement B+-tree support for oversized cells

### DIFF
--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -4,7 +4,7 @@
 //! only with raw byte keys and raw byte values stored in `RawLeaf` pages
 //! and separator byte keys stored in `RawInterior` pages.
 
-use std::{cell::Cell, fmt, ops::Range, rc::Rc};
+use std::{cell::Cell, cmp::Ordering, fmt, ops::Range, rc::Rc};
 
 use crate::{
     PAGE_SIZE, PageId,
@@ -531,6 +531,56 @@ fn read_interior_cell(
     Ok((left_child, key))
 }
 
+fn compare_key_prefix(
+    page_id: PageId,
+    inline_key: &[u8],
+    key_len: usize,
+    key: &[u8],
+) -> StorageResult<Option<Ordering>> {
+    if inline_key.len() > key_len {
+        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+    }
+
+    if key.len() <= inline_key.len() {
+        let ordering = inline_key[..key.len()].cmp(key);
+        if ordering != Ordering::Equal {
+            return Ok(Some(ordering));
+        }
+        return Ok(Some(key_len.cmp(&key.len())));
+    }
+
+    let ordering = inline_key.cmp(&key[..inline_key.len()]);
+    if ordering != Ordering::Equal {
+        return Ok(Some(ordering));
+    }
+
+    if inline_key.len() == key_len {
+        return Ok(Some(Ordering::Less));
+    }
+
+    Ok(None)
+}
+
+fn materialize_overflow_key(
+    page_cache: &PageCache,
+    page_id: PageId,
+    mut inline_key: Vec<u8>,
+    first_overflow_page_id: Option<PageId>,
+    key_len: usize,
+) -> StorageResult<Vec<u8>> {
+    let first_overflow_page_id = first_overflow_page_id
+        .ok_or_else(|| cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds))?;
+    inline_key.extend(overflow::read_chain_prefix(
+        page_cache,
+        first_overflow_page_id,
+        key_len - inline_key.len(),
+    )?);
+    if inline_key.len() != key_len {
+        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+    }
+    Ok(inline_key)
+}
+
 impl TreeCursor {
     /// Creates a cursor anchored at `root_page_id` in page-level state.
     pub(crate) fn new(page_cache: PageCache, root_page_id: PageId) -> Self {
@@ -605,17 +655,84 @@ impl TreeCursor {
         Ok(interior.slot_count())
     }
 
+    fn compare_leaf_key(
+        &self,
+        page_id: PageId,
+        slot_index: u16,
+        key: &[u8],
+    ) -> StorageResult<Ordering> {
+        let (inline_key, first_overflow_page_id, key_len) = {
+            let pin = self.page_cache.fetch_page(page_id)?;
+            let page = pin.read()?;
+            let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
+            let (key_len, _, first_overflow_page_id, inline_range) =
+                leaf.cell_payload_parts(slot_index)?;
+            let inline_key_len = key_len.min(inline_range.len());
+            let inline_key = &page.page()[inline_range.start..inline_range.start + inline_key_len];
+            if let Some(ordering) = compare_key_prefix(page_id, inline_key, key_len, key)? {
+                return Ok(ordering);
+            }
+            (inline_key.to_vec(), first_overflow_page_id, key_len)
+        };
+
+        let materialized_key = materialize_overflow_key(
+            &self.page_cache,
+            page_id,
+            inline_key,
+            first_overflow_page_id,
+            key_len,
+        )?;
+        Ok(materialized_key.as_slice().cmp(key))
+    }
+
+    fn compare_interior_key(
+        &self,
+        page_id: PageId,
+        slot_index: u16,
+        key: &[u8],
+    ) -> StorageResult<Ordering> {
+        let (inline_key, first_overflow_page_id, key_len) = {
+            let pin = self.page_cache.fetch_page(page_id)?;
+            let page = pin.read()?;
+            let interior = RawInterior::<Read<'_>>::open(page.page())?;
+            let (_, key_len, first_overflow_page_id, inline_range) =
+                interior.cell_payload_parts(slot_index)?;
+            let inline_key_len = key_len.min(inline_range.len());
+            let inline_key = &page.page()[inline_range.start..inline_range.start + inline_key_len];
+            if let Some(ordering) = compare_key_prefix(page_id, inline_key, key_len, key)? {
+                return Ok(ordering);
+            }
+            (inline_key.to_vec(), first_overflow_page_id, key_len)
+        };
+
+        let materialized_key = materialize_overflow_key(
+            &self.page_cache,
+            page_id,
+            inline_key,
+            first_overflow_page_id,
+            key_len,
+        )?;
+        Ok(materialized_key.as_slice().cmp(key))
+    }
+
+    fn read_interior_left_child(&self, page_id: PageId, slot_index: u16) -> StorageResult<PageId> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        let interior = RawInterior::<Read<'_>>::open(page.page())?;
+        let (left_child, _, _, _) = interior.cell_payload_parts(slot_index)?;
+        Ok(left_child)
+    }
+
     fn search_leaf_slot(&self, page_id: PageId, key: &[u8]) -> StorageResult<SearchResult> {
         let mut low: u16 = 0;
         let mut high = self.raw_leaf_slot_count(page_id)?;
 
         while low < high {
             let mid = low + (high - low) / 2;
-            let (cell_key, _) = read_leaf_cell(&self.page_cache, page_id, mid)?;
-            match cell_key.as_slice().cmp(key) {
-                std::cmp::Ordering::Less => low = mid + 1,
-                std::cmp::Ordering::Greater => high = mid,
-                std::cmp::Ordering::Equal => return Ok(SearchResult::Found(mid)),
+            match self.compare_leaf_key(page_id, mid, key)? {
+                Ordering::Less => low = mid + 1,
+                Ordering::Greater => high = mid,
+                Ordering::Equal => return Ok(SearchResult::Found(mid)),
             }
         }
 
@@ -629,8 +746,7 @@ impl TreeCursor {
 
         while low < high {
             let mid = low + (high - low) / 2;
-            let (cell_key, _) = read_leaf_cell(&self.page_cache, page_id, mid)?;
-            if cell_key.as_slice() < key {
+            if self.compare_leaf_key(page_id, mid, key)? == Ordering::Less {
                 low = mid + 1;
             } else {
                 high = mid;
@@ -647,8 +763,7 @@ impl TreeCursor {
 
         while low < high {
             let mid = low + (high - low) / 2;
-            let (_, cell_key) = read_interior_cell(&self.page_cache, page_id, mid)?;
-            if cell_key.as_slice() < key {
+            if self.compare_interior_key(page_id, mid, key)? == Ordering::Less {
                 low = mid + 1;
             } else {
                 high = mid;
@@ -660,10 +775,7 @@ impl TreeCursor {
 
     fn interior_child_for_key(&self, page_id: PageId, key: &[u8]) -> StorageResult<PageId> {
         match self.lower_bound_interior_slot(page_id, key)? {
-            BoundResult::At(slot_index) => {
-                let (left_child, _) = read_interior_cell(&self.page_cache, page_id, slot_index)?;
-                Ok(left_child)
-            }
+            BoundResult::At(slot_index) => self.read_interior_left_child(page_id, slot_index),
             BoundResult::PastEnd => {
                 let pin = self.page_cache.fetch_page(page_id)?;
                 let page = pin.read()?;
@@ -766,8 +878,8 @@ impl TreeCursor {
                         drop(pin);
                         match self.lower_bound_interior_slot(page_id, key)? {
                             BoundResult::At(slot_index) => {
-                                let (child_page_id, _) =
-                                    read_interior_cell(&self.page_cache, page_id, slot_index)?;
+                                let child_page_id =
+                                    self.read_interior_left_child(page_id, slot_index)?;
                                 path.push(PathFrame {
                                     page_id,
                                     child_ref: ChildSlotRef::Slot(slot_index),
@@ -1120,9 +1232,12 @@ impl TreeCursor {
         let insert_slot_index =
             match self.lower_bound_interior_slot(parent_frame.page_id, &pending.separator)? {
                 BoundResult::At(slot_index) => {
-                    let (_, existing_key) =
-                        read_interior_cell(&self.page_cache, parent_frame.page_id, slot_index)?;
-                    if existing_key == pending.separator {
+                    if self.compare_interior_key(
+                        parent_frame.page_id,
+                        slot_index,
+                        &pending.separator,
+                    )? == Ordering::Equal
+                    {
                         return Err(PageError::DuplicateKey.into());
                     }
                     slot_index
@@ -1740,6 +1855,64 @@ mod tests {
             .to_owned_record()
             .unwrap();
         assert_owned_record_matches(&owned, b"alpha", b"value");
+    }
+
+    #[test]
+    fn binary_search_supports_inline_key_with_overflow_value() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 8).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let value = vec![7; PAGE_SIZE];
+
+        cursor.insert(b"alpha", b"small").unwrap();
+        cursor.insert(b"bravo", &value).unwrap();
+        cursor.insert(b"charlie", b"small").unwrap();
+
+        let record = cursor.get(b"bravo").unwrap().expect("overflow value key should exist");
+        assert_record_matches(&record, b"bravo", &value);
+        assert!(cursor.get(b"between").unwrap().is_none());
+    }
+
+    #[test]
+    fn binary_search_supports_oversized_key_with_overflow_value() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 16).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let key = oversized_key(7);
+        let value = vec![11; PAGE_SIZE];
+
+        cursor.insert(&key, &value).unwrap();
+
+        let record = cursor.get(&key).unwrap().expect("oversized key should exist");
+        assert_record_matches(&record, &key, &value);
+    }
+
+    #[test]
+    fn binary_search_supports_oversized_interior_separator_keys() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 256).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut expected = BTreeMap::new();
+
+        for index in 0..48 {
+            let key = oversized_key(index);
+            let value = format!("value-{index}").into_bytes();
+            cursor.insert(&key, &value).unwrap();
+            expected.insert(key, value);
+        }
+
+        assert!(tree_height(&cursor).unwrap() >= 2, "large keys should force interior routing");
+        for (key, value) in &expected {
+            assert!(cursor.seek_to_key(key).unwrap(), "seek_to_key should find oversized key");
+            let record = cursor.current().unwrap().expect("seek_to_key should position cursor");
+            assert_record_matches(&record, key, value);
+        }
     }
 
     fn assert_record_matches(record: &Record, expected_key: &[u8], expected_value: &[u8]) {

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -4,7 +4,7 @@
 //! only with raw byte keys and raw byte values stored in `RawLeaf` pages
 //! and separator byte keys stored in `RawInterior` pages.
 
-use std::{cell::Cell, fmt, rc::Rc};
+use std::{cell::Cell, fmt, ops::Range, rc::Rc};
 
 use crate::{
     PAGE_SIZE, PageId,
@@ -14,7 +14,7 @@ use crate::{
         self, BoundResult, PageError, RawInterior, RawLeaf, Read, SearchResult, Write,
         format::{KIND_OFFSET, MAX_INLINE_OVERFLOW_PAYLOAD_BYTES, PageKind},
     },
-    page_cache::{PageCache, PageWriteGuard},
+    page_cache::{PageCache, PageWriteGuard, PinGuard},
 };
 
 const LEAF_CELL_PREFIX_SIZE: usize = 2 + 8 + 2 + 2;
@@ -104,12 +104,56 @@ impl ScanDirection {
     }
 }
 
-/// Materialized raw record view returned by tree reads and cursor iteration.
+enum RecordStorage {
+    PageResident { pin: PinGuard, key_range: Range<usize>, value_range: Range<usize> },
+    Materialized { key: Box<[u8]>, value: Box<[u8]> },
+}
+
+/// Raw record returned by tree reads and cursor iteration.
+///
+/// Records for cells that fit entirely in their leaf page borrow the page
+/// through an internal pin and only expose byte slices during accessor
+/// callbacks. Records for cells with overflow payload are materialized into
+/// fixed-size heap allocations. Use [`OwnedRecord`] when a stable snapshot is
+/// needed across later tree mutations.
 pub struct Record {
     page_id: PageId,
     slot_index: u16,
-    key: Vec<u8>,
-    value: Vec<u8>,
+    storage: RecordStorage,
+}
+
+/// Stable, owned raw record snapshot.
+pub struct OwnedRecord {
+    key: Box<[u8]>,
+    value: Box<[u8]>,
+}
+
+/// Borrowed record view valid only for the callback that receives it.
+#[derive(Debug, Clone, Copy)]
+pub struct RecordView<'a> {
+    key: &'a [u8],
+    value: &'a [u8],
+}
+
+impl<'a> RecordView<'a> {
+    fn new(key: &'a [u8], value: &'a [u8]) -> Self {
+        Self { key, value }
+    }
+
+    /// Returns the record key bytes.
+    pub fn key(&self) -> &'a [u8] {
+        self.key
+    }
+
+    /// Returns the record value bytes.
+    pub fn value(&self) -> &'a [u8] {
+        self.value
+    }
+
+    /// Returns the record key and value bytes.
+    pub fn key_value(&self) -> (&'a [u8], &'a [u8]) {
+        (self.key, self.value)
+    }
 }
 
 impl Record {
@@ -119,8 +163,47 @@ impl Record {
         page_id: PageId,
         slot_index: u16,
     ) -> StorageResult<Self> {
-        let (key, value) = read_leaf_cell(page_cache, page_id, slot_index)?;
-        Ok(Self { page_id, slot_index, key, value })
+        let pin = page_cache.fetch_page(page_id)?;
+        let (key_len, value_len, first_overflow_page_id, inline_range) = {
+            let page = pin.read()?;
+            let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
+            leaf.cell_payload_parts(slot_index)?
+        };
+
+        let storage = match first_overflow_page_id {
+            None => {
+                if inline_range.len() != key_len + value_len {
+                    return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+                }
+
+                let key_start = inline_range.start;
+                let value_start = key_start + key_len;
+                RecordStorage::PageResident {
+                    pin,
+                    key_range: key_start..value_start,
+                    value_range: value_start..inline_range.end,
+                }
+            }
+            Some(first_overflow_page_id) => {
+                let inline_payload = {
+                    let page = pin.read()?;
+                    page.page()[inline_range].to_vec()
+                };
+                drop(pin);
+
+                let (key, value) = materialize_leaf_cell(
+                    page_cache,
+                    page_id,
+                    inline_payload,
+                    first_overflow_page_id,
+                    key_len,
+                    value_len,
+                )?;
+                RecordStorage::Materialized { key, value }
+            }
+        };
+
+        Ok(Self { page_id, slot_index, storage })
     }
 
     /// Returns the slot index that this record refers to within its leaf page.
@@ -128,19 +211,72 @@ impl Record {
         self.slot_index
     }
 
+    /// Executes `f` with a borrowed view of this record.
+    pub fn with_view<R>(&self, f: impl FnOnce(RecordView<'_>) -> R) -> StorageResult<R> {
+        match &self.storage {
+            RecordStorage::PageResident { pin, key_range, value_range } => {
+                let page = pin.read()?;
+                let key = &page.page()[key_range.clone()];
+                let value = &page.page()[value_range.clone()];
+                Ok(f(RecordView::new(key, value)))
+            }
+            RecordStorage::Materialized { key, value } => {
+                Ok(f(RecordView::new(key.as_ref(), value.as_ref())))
+            }
+        }
+    }
+
+    /// Returns a stable, owned snapshot of this record.
+    pub fn to_owned_record(&self) -> StorageResult<OwnedRecord> {
+        self.with_key_value(|key, value| OwnedRecord::new(key.into(), value.into()))
+    }
+
     /// Executes `f` with a borrowed view of the record key.
     pub fn with_key<R>(&self, f: impl FnOnce(&[u8]) -> R) -> StorageResult<R> {
-        Ok(f(&self.key))
+        self.with_view(|record| f(record.key()))
     }
 
     /// Executes `f` with a borrowed view of the record value.
     pub fn with_value<R>(&self, f: impl FnOnce(&[u8]) -> R) -> StorageResult<R> {
-        Ok(f(&self.value))
+        self.with_view(|record| f(record.value()))
     }
 
     /// Executes `f` with borrowed views of the key and value.
     pub fn with_key_value<R>(&self, f: impl FnOnce(&[u8], &[u8]) -> R) -> StorageResult<R> {
-        Ok(f(&self.key, &self.value))
+        self.with_view(|record| {
+            let (key, value) = record.key_value();
+            f(key, value)
+        })
+    }
+}
+
+impl OwnedRecord {
+    fn new(key: Box<[u8]>, value: Box<[u8]>) -> Self {
+        Self { key, value }
+    }
+
+    /// Executes `f` with a borrowed view of the record key.
+    pub fn with_key<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
+        f(&self.key)
+    }
+
+    /// Executes `f` with a borrowed view of the record value.
+    pub fn with_value<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
+        f(&self.value)
+    }
+
+    /// Executes `f` with borrowed views of the key and value.
+    pub fn with_key_value<R>(&self, f: impl FnOnce(&[u8], &[u8]) -> R) -> R {
+        f(&self.key, &self.value)
+    }
+}
+
+impl fmt::Debug for OwnedRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OwnedRecord")
+            .field("key_len", &self.key.len())
+            .field("value_len", &self.value.len())
+            .finish()
     }
 }
 
@@ -320,6 +456,29 @@ fn materialize_payload(
         return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
     }
     Ok(payload)
+}
+
+fn materialize_leaf_cell(
+    page_cache: &PageCache,
+    page_id: PageId,
+    inline_payload: Vec<u8>,
+    first_overflow_page_id: PageId,
+    key_len: usize,
+    value_len: usize,
+) -> StorageResult<(Box<[u8]>, Box<[u8]>)> {
+    let mut payload = materialize_payload(
+        page_cache,
+        page_id,
+        inline_payload,
+        Some(first_overflow_page_id),
+        key_len + value_len,
+    )?;
+    if payload.len() < key_len {
+        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+    }
+
+    let value = payload.split_off(key_len);
+    Ok((payload.into_boxed_slice(), value.into_boxed_slice()))
 }
 
 fn read_leaf_cell(
@@ -722,6 +881,11 @@ impl TreeCursor {
         }
     }
 
+    /// Searches the raw tree for `key` and returns a stable owned record snapshot.
+    pub fn get_owned(&mut self, key: &[u8]) -> StorageResult<Option<OwnedRecord>> {
+        self.get(key)?.map(|record| record.to_owned_record()).transpose()
+    }
+
     fn checked_payload_len(&self, payload_len: usize) -> StorageResult<()> {
         if payload_len > u16::MAX as usize {
             return Err(PageError::CellTooLarge { len: payload_len, max: u16::MAX as usize }.into());
@@ -885,14 +1049,29 @@ impl TreeCursor {
         }
     }
 
+    /// Reads the currently selected record as a stable owned snapshot, if any.
+    pub fn current_owned(&self) -> StorageResult<Option<OwnedRecord>> {
+        self.current()?.map(|record| record.to_owned_record()).transpose()
+    }
+
     /// Advances to the next record in sorted key order.
     pub fn next_record(&mut self) -> StorageResult<Option<Record>> {
         self.step_record(ScanDirection::Forward)
     }
 
+    /// Advances to the next record and returns a stable owned snapshot.
+    pub fn next_owned_record(&mut self) -> StorageResult<Option<OwnedRecord>> {
+        self.next_record()?.map(|record| record.to_owned_record()).transpose()
+    }
+
     /// Moves to the previous record in sorted key order.
     pub fn prev_record(&mut self) -> StorageResult<Option<Record>> {
         self.step_record(ScanDirection::Backward)
+    }
+
+    /// Moves to the previous record and returns a stable owned snapshot.
+    pub fn prev_owned_record(&mut self) -> StorageResult<Option<OwnedRecord>> {
+        self.prev_record()?.map(|record| record.to_owned_record()).transpose()
     }
 
     /// Bubbles one pending split up the recorded tree path until it lands.
@@ -1513,6 +1692,56 @@ mod tests {
         assert_forward_scan_matches(&mut cursor, &expected);
     }
 
+    #[test]
+    fn inline_record_is_page_resident() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 4).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+
+        cursor.insert(b"alpha", b"value").unwrap();
+
+        let record = cursor.get(b"alpha").unwrap().expect("inline record should exist");
+        assert!(matches!(record.storage, RecordStorage::PageResident { .. }));
+        assert_record_matches(&record, b"alpha", b"value");
+    }
+
+    #[test]
+    fn overflow_record_is_materialized() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 4).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let value = vec![42; PAGE_SIZE];
+
+        cursor.insert(b"alpha", &value).unwrap();
+
+        let record = cursor.get(b"alpha").unwrap().expect("overflow record should exist");
+        assert!(matches!(record.storage, RecordStorage::Materialized { .. }));
+        assert_record_matches(&record, b"alpha", &value);
+    }
+
+    #[test]
+    fn inline_record_converts_to_owned_snapshot() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 4).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+
+        cursor.insert(b"alpha", b"value").unwrap();
+
+        let owned = cursor
+            .get(b"alpha")
+            .unwrap()
+            .expect("inline record should exist")
+            .to_owned_record()
+            .unwrap();
+        assert_owned_record_matches(&owned, b"alpha", b"value");
+    }
+
     fn assert_record_matches(record: &Record, expected_key: &[u8], expected_value: &[u8]) {
         record
             .with_key_value(|actual_key, actual_value| {
@@ -1520,6 +1749,17 @@ mod tests {
                 assert_eq!(actual_value, expected_value);
             })
             .unwrap();
+    }
+
+    fn assert_owned_record_matches(
+        record: &OwnedRecord,
+        expected_key: &[u8],
+        expected_value: &[u8],
+    ) {
+        record.with_key_value(|actual_key, actual_value| {
+            assert_eq!(actual_key, expected_key);
+            assert_eq!(actual_value, expected_value);
+        });
     }
 
     fn assert_forward_scan_matches(cursor: &mut TreeCursor, expected: &BTreeMap<Vec<u8>, Vec<u8>>) {

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -4,20 +4,21 @@
 //! only with raw byte keys and raw byte values stored in `RawLeaf` pages
 //! and separator byte keys stored in `RawInterior` pages.
 
-use std::{cell::Cell, fmt, ops::Range, rc::Rc};
+use std::{cell::Cell, fmt, rc::Rc};
 
 use crate::{
     PAGE_SIZE, PageId,
     error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
+    overflow,
     page::{
         self, BoundResult, PageError, RawInterior, RawLeaf, Read, SearchResult, Write,
-        format::{KIND_OFFSET, PageKind},
+        format::{KIND_OFFSET, MAX_INLINE_OVERFLOW_PAYLOAD_BYTES, PageKind},
     },
-    page_cache::{PageCache, PageWriteGuard, PinGuard},
+    page_cache::{PageCache, PageWriteGuard},
 };
 
-const LEAF_CELL_PREFIX_SIZE: usize = 2 + 2 + 2;
-const INTERIOR_CELL_PREFIX_SIZE: usize = 2 + 8 + 2;
+const LEAF_CELL_PREFIX_SIZE: usize = 2 + 8 + 2 + 2;
+const INTERIOR_CELL_PREFIX_SIZE: usize = 2 + 8 + 8 + 2;
 
 /// Outcome of trying to position a scan within or beyond one leaf page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,21 +104,23 @@ impl ScanDirection {
     }
 }
 
-/// Guard-backed raw record view returned by tree reads and cursor iteration.
+/// Materialized raw record view returned by tree reads and cursor iteration.
 pub struct Record {
-    pin: PinGuard,
+    page_id: PageId,
     slot_index: u16,
+    key: Vec<u8>,
+    value: Vec<u8>,
 }
 
 impl Record {
-    /// Builds a record view from one pinned raw leaf-page slot.
-    pub(crate) fn new(pin: PinGuard, slot_index: u16) -> StorageResult<Self> {
-        {
-            let page = pin.read()?;
-            let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
-            let _ = leaf.cell(slot_index)?;
-        }
-        Ok(Self { pin, slot_index })
+    /// Builds a record view from one raw leaf-page slot.
+    pub(crate) fn new(
+        page_cache: &PageCache,
+        page_id: PageId,
+        slot_index: u16,
+    ) -> StorageResult<Self> {
+        let (key, value) = read_leaf_cell(page_cache, page_id, slot_index)?;
+        Ok(Self { page_id, slot_index, key, value })
     }
 
     /// Returns the slot index that this record refers to within its leaf page.
@@ -125,38 +128,26 @@ impl Record {
         self.slot_index
     }
 
-    /// Executes `f` with a borrowed view of the record key while the backing
-    /// page remains pinned and immutably borrowed.
+    /// Executes `f` with a borrowed view of the record key.
     pub fn with_key<R>(&self, f: impl FnOnce(&[u8]) -> R) -> StorageResult<R> {
-        let page = self.pin.read()?;
-        let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
-        let cell = leaf.cell(self.slot_index)?;
-        Ok(f(cell.key()?))
+        Ok(f(&self.key))
     }
 
-    /// Executes `f` with a borrowed view of the record value while the backing
-    /// page remains pinned and immutably borrowed.
+    /// Executes `f` with a borrowed view of the record value.
     pub fn with_value<R>(&self, f: impl FnOnce(&[u8]) -> R) -> StorageResult<R> {
-        let page = self.pin.read()?;
-        let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
-        let cell = leaf.cell(self.slot_index)?;
-        Ok(f(cell.value()?))
+        Ok(f(&self.value))
     }
 
-    /// Executes `f` with borrowed views of the key and value while the backing
-    /// page remains pinned and immutably borrowed.
+    /// Executes `f` with borrowed views of the key and value.
     pub fn with_key_value<R>(&self, f: impl FnOnce(&[u8], &[u8]) -> R) -> StorageResult<R> {
-        let page = self.pin.read()?;
-        let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
-        let cell = leaf.cell(self.slot_index)?;
-        Ok(f(cell.key()?, cell.value()?))
+        Ok(f(&self.key, &self.value))
     }
 }
 
 impl fmt::Debug for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Record")
-            .field("page_id", &self.pin.page_id())
+            .field("page_id", &self.page_id)
             .field("slot_index", &self.slot_index)
             .finish_non_exhaustive()
     }
@@ -220,99 +211,165 @@ struct PendingSplit {
 
 /// Temporary description of one leaf cell while rebuilding split pages.
 #[derive(Debug, Clone)]
-enum LeafSplitCell<'c> {
-    /// An existing cell borrowed from the pre-split page snapshot.
-    Snapshot { key_range: Range<usize>, value_range: Range<usize> },
-    /// The newly inserted cell that triggered the split.
-    Incoming { key: &'c [u8], value: &'c [u8] },
+struct LeafSplitCell {
+    key: Vec<u8>,
+    value: Vec<u8>,
 }
 
 /// Temporary description of one interior cell while rebuilding split pages.
 #[derive(Debug, Clone)]
-enum InteriorSplitCell<'c> {
-    /// An existing cell borrowed from the pre-split page snapshot.
-    Snapshot { left_child: PageId, key_range: Range<usize> },
-    /// The newly inserted separator cell that triggered the split.
-    Incoming { left_child: PageId, key: &'c [u8] },
+struct InteriorSplitCell {
+    left_child: PageId,
+    key: Vec<u8>,
 }
 
-impl<'c> LeafSplitCell<'c> {
+impl LeafSplitCell {
     /// Returns the key length this cell will occupy after the split.
     fn key_len(&self) -> usize {
-        match self {
-            Self::Snapshot { key_range, .. } => key_range.len(),
-            Self::Incoming { key, .. } => key.len(),
-        }
+        self.key.len()
     }
 
     /// Returns the value length this cell will occupy after the split.
     fn value_len(&self) -> usize {
-        match self {
-            Self::Snapshot { value_range, .. } => value_range.len(),
-            Self::Incoming { value, .. } => value.len(),
-        }
+        self.value.len()
     }
 
     /// Returns the total encoded size of the cell including fixed fields.
     fn encoded_size(&self) -> usize {
-        LEAF_CELL_PREFIX_SIZE + self.key_len() + self.value_len()
+        LEAF_CELL_PREFIX_SIZE + local_payload_len(self.key_len() + self.value_len())
     }
 
     /// Returns the key bytes from either the page snapshot or owned storage.
-    fn key<'a>(&'a self, snapshot: &'a [u8; PAGE_SIZE]) -> &'a [u8] {
-        match self {
-            Self::Snapshot { key_range, .. } => &snapshot[key_range.clone()],
-            Self::Incoming { key, .. } => key,
-        }
+    fn key(&self) -> &[u8] {
+        &self.key
     }
 
     /// Returns the value bytes from either the page snapshot or owned storage.
-    fn value<'a>(&'a self, snapshot: &'a [u8; PAGE_SIZE]) -> &'a [u8] {
-        match self {
-            Self::Snapshot { value_range, .. } => &snapshot[value_range.clone()],
-            Self::Incoming { value, .. } => value,
-        }
+    fn value(&self) -> &[u8] {
+        &self.value
     }
 }
 
-impl<'c> InteriorSplitCell<'c> {
+impl InteriorSplitCell {
     /// Returns the left child page referenced by this interior cell.
     fn left_child(&self) -> PageId {
-        match self {
-            Self::Snapshot { left_child, .. } | Self::Incoming { left_child, .. } => *left_child,
-        }
+        self.left_child
     }
 
     /// Returns the key length this cell will occupy after the split.
     fn key_len(&self) -> usize {
-        match self {
-            Self::Snapshot { key_range, .. } => key_range.len(),
-            Self::Incoming { key, .. } => key.len(),
-        }
+        self.key.len()
     }
 
     /// Returns the total encoded size of the cell including fixed fields.
     fn encoded_size(&self) -> usize {
-        INTERIOR_CELL_PREFIX_SIZE + self.key_len()
+        INTERIOR_CELL_PREFIX_SIZE + local_payload_len(self.key_len())
     }
 
     /// Returns the separator key bytes from either the page snapshot or incoming storage.
-    fn key<'a>(&'a self, snapshot: &'a [u8; PAGE_SIZE]) -> &'a [u8] {
-        match self {
-            Self::Snapshot { key_range, .. } => &snapshot[key_range.clone()],
-            Self::Incoming { key, .. } => key,
-        }
+    fn key(&self) -> &[u8] {
+        &self.key
     }
 
     /// Replaces the left-child pointer while preserving the cell key storage.
     fn with_left_child(&self, left_child: PageId) -> Self {
-        match self {
-            Self::Snapshot { key_range, .. } => {
-                Self::Snapshot { left_child, key_range: key_range.clone() }
-            }
-            Self::Incoming { key, .. } => Self::Incoming { left_child, key },
-        }
+        Self { left_child, key: self.key.clone() }
     }
+}
+
+fn payload_uses_overflow(payload_len: usize) -> bool {
+    payload_len > MAX_INLINE_OVERFLOW_PAYLOAD_BYTES
+}
+
+fn local_payload_len(payload_len: usize) -> usize {
+    if payload_uses_overflow(payload_len) { MAX_INLINE_OVERFLOW_PAYLOAD_BYTES } else { payload_len }
+}
+
+fn cell_corruption(page_id: PageId, kind: CorruptionKind) -> StorageError {
+    StorageError::Corruption(CorruptionError {
+        component: CorruptionComponent::Cell,
+        page_id: Some(page_id),
+        kind,
+    })
+}
+
+fn materialize_payload(
+    page_cache: &PageCache,
+    page_id: PageId,
+    inline_payload: Vec<u8>,
+    first_overflow_page_id: Option<PageId>,
+    payload_len: usize,
+) -> StorageResult<Vec<u8>> {
+    if inline_payload.len() > payload_len {
+        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+    }
+
+    let mut payload = inline_payload;
+    match first_overflow_page_id {
+        Some(first_overflow_page_id) => {
+            let remaining = payload_len - payload.len();
+            payload.extend(overflow::read_chain(page_cache, first_overflow_page_id, remaining)?);
+        }
+        None if payload.len() != payload_len => {
+            return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+        }
+        None => {}
+    }
+
+    if payload.len() != payload_len {
+        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+    }
+    Ok(payload)
+}
+
+fn read_leaf_cell(
+    page_cache: &PageCache,
+    page_id: PageId,
+    slot_index: u16,
+) -> StorageResult<(Vec<u8>, Vec<u8>)> {
+    let pin = page_cache.fetch_page(page_id)?;
+    let (key_len, value_len, first_overflow_page_id, inline_payload) = {
+        let page = pin.read()?;
+        let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
+        let (key_len, value_len, first_overflow_page_id, inline_range) =
+            leaf.cell_payload_parts(slot_index)?;
+        (key_len, value_len, first_overflow_page_id, page.page()[inline_range].to_vec())
+    };
+    drop(pin);
+
+    let payload = materialize_payload(
+        page_cache,
+        page_id,
+        inline_payload,
+        first_overflow_page_id,
+        key_len + value_len,
+    )?;
+    if payload.len() < key_len {
+        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+    }
+    let key = payload[..key_len].to_vec();
+    let value = payload[key_len..].to_vec();
+    Ok((key, value))
+}
+
+fn read_interior_cell(
+    page_cache: &PageCache,
+    page_id: PageId,
+    slot_index: u16,
+) -> StorageResult<(PageId, Vec<u8>)> {
+    let pin = page_cache.fetch_page(page_id)?;
+    let (left_child, key_len, first_overflow_page_id, inline_payload) = {
+        let page = pin.read()?;
+        let interior = RawInterior::<Read<'_>>::open(page.page())?;
+        let (left_child, key_len, first_overflow_page_id, inline_range) =
+            interior.cell_payload_parts(slot_index)?;
+        (left_child, key_len, first_overflow_page_id, page.page()[inline_range].to_vec())
+    };
+    drop(pin);
+
+    let key =
+        materialize_payload(page_cache, page_id, inline_payload, first_overflow_page_id, key_len)?;
+    Ok((left_child, key))
 }
 
 impl TreeCursor {
@@ -372,8 +429,89 @@ impl TreeCursor {
 
     /// Materializes one record from a positioned raw leaf slot.
     fn record_at(&self, page_id: PageId, slot_index: u16) -> StorageResult<Record> {
+        Record::new(&self.page_cache, page_id, slot_index)
+    }
+
+    fn raw_leaf_slot_count(&self, page_id: PageId) -> StorageResult<u16> {
         let pin = self.page_cache.fetch_page(page_id)?;
-        Record::new(pin, slot_index)
+        let page = pin.read()?;
+        let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
+        Ok(leaf.slot_count())
+    }
+
+    fn raw_interior_slot_count(&self, page_id: PageId) -> StorageResult<u16> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        let interior = RawInterior::<Read<'_>>::open(page.page())?;
+        Ok(interior.slot_count())
+    }
+
+    fn search_leaf_slot(&self, page_id: PageId, key: &[u8]) -> StorageResult<SearchResult> {
+        let mut low: u16 = 0;
+        let mut high = self.raw_leaf_slot_count(page_id)?;
+
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let (cell_key, _) = read_leaf_cell(&self.page_cache, page_id, mid)?;
+            match cell_key.as_slice().cmp(key) {
+                std::cmp::Ordering::Less => low = mid + 1,
+                std::cmp::Ordering::Greater => high = mid,
+                std::cmp::Ordering::Equal => return Ok(SearchResult::Found(mid)),
+            }
+        }
+
+        Ok(SearchResult::InsertAt(low))
+    }
+
+    fn lower_bound_leaf_slot(&self, page_id: PageId, key: &[u8]) -> StorageResult<BoundResult> {
+        let mut low: u16 = 0;
+        let slot_count = self.raw_leaf_slot_count(page_id)?;
+        let mut high = slot_count;
+
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let (cell_key, _) = read_leaf_cell(&self.page_cache, page_id, mid)?;
+            if cell_key.as_slice() < key {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+
+        if low == slot_count { Ok(BoundResult::PastEnd) } else { Ok(BoundResult::At(low)) }
+    }
+
+    fn lower_bound_interior_slot(&self, page_id: PageId, key: &[u8]) -> StorageResult<BoundResult> {
+        let mut low: u16 = 0;
+        let slot_count = self.raw_interior_slot_count(page_id)?;
+        let mut high = slot_count;
+
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let (_, cell_key) = read_interior_cell(&self.page_cache, page_id, mid)?;
+            if cell_key.as_slice() < key {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+
+        if low == slot_count { Ok(BoundResult::PastEnd) } else { Ok(BoundResult::At(low)) }
+    }
+
+    fn interior_child_for_key(&self, page_id: PageId, key: &[u8]) -> StorageResult<PageId> {
+        match self.lower_bound_interior_slot(page_id, key)? {
+            BoundResult::At(slot_index) => {
+                let (left_child, _) = read_interior_cell(&self.page_cache, page_id, slot_index)?;
+                Ok(left_child)
+            }
+            BoundResult::PastEnd => {
+                let pin = self.page_cache.fetch_page(page_id)?;
+                let page = pin.read()?;
+                let interior = RawInterior::<Read<'_>>::open(page.page())?;
+                Ok(interior.rightmost_child())
+            }
+        }
     }
 
     /// Follows leftmost children from `start_page_id` until reaching a leaf.
@@ -440,8 +578,9 @@ impl TreeCursor {
                         return Ok(page_id);
                     }
                     PageKind::RawInterior => {
-                        let interior = RawInterior::<Read<'_>>::open(page.page())?;
-                        interior.child_for(key)?
+                        drop(page);
+                        drop(pin);
+                        self.interior_child_for_key(page_id, key)?
                     }
                 }
             };
@@ -464,10 +603,12 @@ impl TreeCursor {
                         return Ok((page_id, path));
                     }
                     PageKind::RawInterior => {
-                        let interior = RawInterior::<Read<'_>>::open(page.page())?;
-                        match interior.lower_bound(key)? {
+                        drop(page);
+                        drop(pin);
+                        match self.lower_bound_interior_slot(page_id, key)? {
                             BoundResult::At(slot_index) => {
-                                let child_page_id = interior.cell(slot_index)?.left_child()?;
+                                let (child_page_id, _) =
+                                    read_interior_cell(&self.page_cache, page_id, slot_index)?;
                                 path.push(PathFrame {
                                     page_id,
                                     child_ref: ChildSlotRef::Slot(slot_index),
@@ -479,6 +620,9 @@ impl TreeCursor {
                                     page_id,
                                     child_ref: ChildSlotRef::Rightmost,
                                 });
+                                let pin = self.page_cache.fetch_page(page_id)?;
+                                let page = pin.read()?;
+                                let interior = RawInterior::<Read<'_>>::open(page.page())?;
                                 interior.rightmost_child()
                             }
                         }
@@ -510,7 +654,7 @@ impl TreeCursor {
             match seek {
                 LeafSeek::Positioned(slot_index) => {
                     self.set_positioned_state(page_id, slot_index);
-                    return Record::new(pin, slot_index).map(Some);
+                    return self.record_at(page_id, slot_index).map(Some);
                 }
                 LeafSeek::Advance(next_page_id) => page_id = next_page_id,
                 LeafSeek::Exhausted => {
@@ -541,7 +685,7 @@ impl TreeCursor {
                 match seek {
                     LeafSeek::Positioned(next_slot) => {
                         self.set_positioned_state(page_id, next_slot);
-                        Record::new(pin, next_slot).map(Some)
+                        self.record_at(page_id, next_slot).map(Some)
                     }
                     LeafSeek::Advance(next_page_id) => {
                         self.edge_record_from_leaf(next_page_id, direction)
@@ -561,17 +705,15 @@ impl TreeCursor {
     /// where `key` would be inserted when absent.
     pub fn get(&mut self, key: &[u8]) -> StorageResult<Option<Record>> {
         let page_id = self.leaf_page_for_key(key)?;
-        let pin = self.page_cache.fetch_page(page_id)?;
-        let slot_index = {
-            let page = pin.read()?;
-            let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
-            leaf.lookup(key)?.map(|cell| cell.slot_index())
+        let slot_index = match self.search_leaf_slot(page_id, key)? {
+            SearchResult::Found(slot_index) => Some(slot_index),
+            SearchResult::InsertAt(_) => None,
         };
 
         match slot_index {
             Some(slot_index) => {
                 self.set_positioned_state(page_id, slot_index);
-                Record::new(pin, slot_index).map(Some)
+                self.record_at(page_id, slot_index).map(Some)
             }
             None => {
                 self.set_page_state(page_id);
@@ -580,30 +722,103 @@ impl TreeCursor {
         }
     }
 
+    fn checked_payload_len(&self, payload_len: usize) -> StorageResult<()> {
+        if payload_len > u16::MAX as usize {
+            return Err(PageError::CellTooLarge { len: payload_len, max: u16::MAX as usize }.into());
+        }
+        Ok(())
+    }
+
+    fn leaf_cell_local_size(&self, key: &[u8], value: &[u8]) -> StorageResult<usize> {
+        let payload_len = key.len() + value.len();
+        self.checked_payload_len(payload_len)?;
+        Ok(LEAF_CELL_PREFIX_SIZE + local_payload_len(payload_len))
+    }
+
+    fn interior_cell_local_size(&self, key: &[u8]) -> StorageResult<usize> {
+        self.checked_payload_len(key.len())?;
+        Ok(INTERIOR_CELL_PREFIX_SIZE + local_payload_len(key.len()))
+    }
+
+    fn payload_storage_parts(&self, payload: &[u8]) -> StorageResult<(Option<PageId>, Vec<u8>)> {
+        self.checked_payload_len(payload.len())?;
+        if !payload_uses_overflow(payload.len()) {
+            return Ok((None, payload.to_vec()));
+        }
+
+        let inline_payload = payload[..MAX_INLINE_OVERFLOW_PAYLOAD_BYTES].to_vec();
+        let first_overflow_page_id =
+            overflow::write_chain(&self.page_cache, &payload[MAX_INLINE_OVERFLOW_PAYLOAD_BYTES..])?
+                .ok_or_else(|| {
+                    cell_corruption(self.root_page_id(), CorruptionKind::CellLengthOutOfBounds)
+                })?;
+        Ok((Some(first_overflow_page_id), inline_payload))
+    }
+
+    fn insert_leaf_payload_at(
+        &self,
+        leaf: &mut RawLeaf<Write<'_>>,
+        slot_index: u16,
+        key: &[u8],
+        value: &[u8],
+    ) -> StorageResult<u16> {
+        let mut payload = Vec::with_capacity(key.len() + value.len());
+        payload.extend_from_slice(key);
+        payload.extend_from_slice(value);
+        let (first_overflow_page_id, inline_payload) = self.payload_storage_parts(&payload)?;
+        Ok(leaf.insert_payload_at(
+            slot_index,
+            key.len(),
+            value.len(),
+            first_overflow_page_id,
+            &inline_payload,
+        )?)
+    }
+
+    fn insert_interior_payload_at(
+        &self,
+        interior: &mut RawInterior<Write<'_>>,
+        slot_index: u16,
+        left_child: PageId,
+        key: &[u8],
+    ) -> StorageResult<u16> {
+        let (first_overflow_page_id, inline_payload) = self.payload_storage_parts(key)?;
+        Ok(interior.insert_payload_at(
+            slot_index,
+            left_child,
+            key.len(),
+            first_overflow_page_id,
+            &inline_payload,
+        )?)
+    }
+
     /// Inserts a new raw key/value record into the tree.
     pub fn insert(&mut self, key: &[u8], value: &[u8]) -> StorageResult<()> {
         let (leaf_page_id, tree_path) = self.leaf_page_path_for_key(key)?;
+        let slot_index = match self.search_leaf_slot(leaf_page_id, key)? {
+            SearchResult::Found(_) => return Err(PageError::DuplicateKey.into()),
+            SearchResult::InsertAt(slot_index) => slot_index,
+        };
         let leaf_pin_guard = self.page_cache.fetch_page(leaf_page_id)?;
         let mut leaf_guard = leaf_pin_guard.write()?;
-        let insert_result = {
-            let mut page = RawLeaf::<Write<'_>>::open(leaf_guard.page_mut())?;
-            page.insert(key, value)
+        let has_capacity = {
+            let page = RawLeaf::<Write<'_>>::open(leaf_guard.page_mut())?;
+            let needed = self.leaf_cell_local_size(key, value)? + page::format::SLOT_ENTRY_SIZE;
+            page.total_reclaimable_space()? >= needed
         };
 
-        match insert_result {
-            Ok(slot_index) => {
-                self.set_positioned_state(leaf_page_id, slot_index);
-                Ok(())
-            }
-            Err(PageError::PageFull { .. }) => {
-                let pending =
-                    self.insert_with_leaf_page_split(leaf_page_id, &mut leaf_guard, key, value)?;
-                drop(leaf_guard);
-                drop(leaf_pin_guard);
-                self.propagate_split(&tree_path, pending)
-            }
-            Err(err) => Err(err.into()),
+        if has_capacity {
+            let mut page = RawLeaf::<Write<'_>>::open(leaf_guard.page_mut())?;
+            let slot_index = self.insert_leaf_payload_at(&mut page, slot_index, key, value)?;
+            self.set_positioned_state(leaf_page_id, slot_index);
+            return Ok(());
         }
+
+        let pending =
+            self.insert_with_leaf_page_split(leaf_page_id, &mut leaf_guard, key, value)?;
+        drop(leaf_guard);
+        drop(leaf_pin_guard);
+        self.propagate_split(&tree_path, pending)
     }
 
     /// Replaces the value stored for an existing `key`.
@@ -628,7 +843,8 @@ impl TreeCursor {
         let seek = {
             let page = pin.read()?;
             let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
-            match leaf.lower_bound(key)? {
+            let bound = self.lower_bound_leaf_slot(page_id, key)?;
+            match bound {
                 BoundResult::At(slot_index) => LeafSeek::Positioned(slot_index),
                 BoundResult::PastEnd => match leaf.next_page_id() {
                     Some(next_page_id) => LeafSeek::Advance(next_page_id),
@@ -722,24 +938,46 @@ impl TreeCursor {
         parent_frame: PathFrame,
         pending: PendingSplit,
     ) -> StorageResult<Option<PendingSplit>> {
+        let insert_slot_index =
+            match self.lower_bound_interior_slot(parent_frame.page_id, &pending.separator)? {
+                BoundResult::At(slot_index) => {
+                    let (_, existing_key) =
+                        read_interior_cell(&self.page_cache, parent_frame.page_id, slot_index)?;
+                    if existing_key == pending.separator {
+                        return Err(PageError::DuplicateKey.into());
+                    }
+                    slot_index
+                }
+                BoundResult::PastEnd => self.raw_interior_slot_count(parent_frame.page_id)?,
+            };
         let interior_page_guard = self.page_cache.fetch_page(parent_frame.page_id)?;
         let mut interior_guard = interior_page_guard.write()?;
-        let mut interior_page = RawInterior::<Write<'_>>::open(interior_guard.page_mut())?;
+        let has_capacity = {
+            let page = RawInterior::<Write<'_>>::open(interior_guard.page_mut())?;
+            let needed =
+                self.interior_cell_local_size(&pending.separator)? + page::format::SLOT_ENTRY_SIZE;
+            page.total_reclaimable_space()? >= needed
+        };
 
-        match interior_page.insert(&pending.separator, pending.left_page_id) {
-            Ok(inserted_slot_index) => Self::update_interior_child_ref(
+        if has_capacity {
+            let mut interior_page = RawInterior::<Write<'_>>::open(interior_guard.page_mut())?;
+            let inserted_slot_index = self.insert_interior_payload_at(
+                &mut interior_page,
+                insert_slot_index,
+                pending.left_page_id,
+                &pending.separator,
+            )?;
+            Self::update_interior_child_ref(
                 &mut interior_page,
                 parent_frame.child_ref,
                 inserted_slot_index,
                 pending.right_page_id,
             )
-            .map(|()| None),
-            Err(PageError::PageFull { .. }) => {
-                drop(interior_guard);
-                drop(interior_page_guard);
-                self.insert_with_interior_page_split(parent_frame, pending).map(Some)
-            }
-            Err(err) => Err(err.into()),
+            .map(|()| None)
+        } else {
+            drop(interior_guard);
+            drop(interior_page_guard);
+            self.insert_with_interior_page_split(parent_frame, pending).map(Some)
         }
     }
 
@@ -807,15 +1045,26 @@ impl TreeCursor {
         let next_page_id = leaf_snapshot.next_page_id();
         let mut cells = Vec::with_capacity(leaf_snapshot.slot_count() as usize + 1);
         for slot_index in 0..leaf_snapshot.slot_count() {
-            let (key_range, value_range) = leaf_snapshot.cell_key_value_ranges(slot_index)?;
-            cells.push(LeafSplitCell::Snapshot { key_range, value_range });
+            let (key_len, value_len, first_overflow_page_id, inline_range) =
+                leaf_snapshot.cell_payload_parts(slot_index)?;
+            let payload = materialize_payload(
+                &self.page_cache,
+                leaf_page_id,
+                leaf_snapshot_bytes[inline_range].to_vec(),
+                first_overflow_page_id,
+                key_len + value_len,
+            )?;
+            cells.push(LeafSplitCell {
+                key: payload[..key_len].to_vec(),
+                value: payload[key_len..].to_vec(),
+            });
         }
 
-        let idx = match cells.binary_search_by(|cell| cell.key(&leaf_snapshot_bytes).cmp(key)) {
+        let idx = match cells.binary_search_by(|cell| cell.key().cmp(key)) {
             Ok(_) => return Err(PageError::DuplicateKey.into()),
             Err(insert_index) => insert_index,
         };
-        cells.insert(idx, LeafSplitCell::Incoming { key, value });
+        cells.insert(idx, LeafSplitCell { key: key.to_vec(), value: value.to_vec() });
 
         let (right_page_id, right_page_guard) = self.page_cache.new_page()?;
         let mut right_guard = right_page_guard.write()?;
@@ -831,10 +1080,12 @@ impl TreeCursor {
         right_page.set_next_page_id(next_page_id);
 
         for cell in left_cells {
-            leaf_page.insert(cell.key(&leaf_snapshot_bytes), cell.value(&leaf_snapshot_bytes))?;
+            let slot_index = leaf_page.slot_count();
+            self.insert_leaf_payload_at(&mut leaf_page, slot_index, cell.key(), cell.value())?;
         }
         for cell in right_cells {
-            right_page.insert(cell.key(&leaf_snapshot_bytes), cell.value(&leaf_snapshot_bytes))?;
+            let slot_index = right_page.slot_count();
+            self.insert_leaf_payload_at(&mut right_page, slot_index, cell.key(), cell.value())?;
         }
 
         if let Some(next_page_id) = next_page_id {
@@ -844,21 +1095,15 @@ impl TreeCursor {
             next_page.set_prev_page_id(Some(right_page_id));
         }
 
-        let separator = left_cells
-            .last()
-            .expect("leaf split must leave a non-empty left page")
-            .key(&leaf_snapshot_bytes)
-            .to_vec();
+        let separator =
+            left_cells.last().expect("leaf split must leave a non-empty left page").key().to_vec();
 
         let target_page_id = if key <= separator.as_slice() { leaf_page_id } else { right_page_id };
-        let target_slot_index = match if target_page_id == leaf_page_id {
-            leaf_page.search(key)?
-        } else {
-            right_page.search(key)?
-        } {
-            SearchResult::Found(slot_index) => slot_index,
-            SearchResult::InsertAt(_) => unreachable!("split insert must place the new key"),
-        };
+        let target_cells = if target_page_id == leaf_page_id { left_cells } else { right_cells };
+        let target_slot_index = target_cells
+            .iter()
+            .position(|cell| cell.key() == key)
+            .expect("split insert must place the new key") as u16;
         self.set_positioned_state(target_page_id, target_slot_index);
 
         Ok(PendingSplit { separator, left_page_id: leaf_page_id, right_page_id })
@@ -929,9 +1174,16 @@ impl TreeCursor {
         let mut old_rightmost_child = interior_snapshot.rightmost_child();
         let mut cells = Vec::with_capacity(interior_snapshot.slot_count() as usize + 1);
         for slot_index in 0..interior_snapshot.slot_count() {
-            let (left_child, key_range) =
-                interior_snapshot.cell_left_child_key_range(slot_index)?;
-            cells.push(InteriorSplitCell::Snapshot { left_child, key_range });
+            let (left_child, key_len, first_overflow_page_id, inline_range) =
+                interior_snapshot.cell_payload_parts(slot_index)?;
+            let key = materialize_payload(
+                &self.page_cache,
+                parent_frame.page_id,
+                interior_snapshot_bytes[inline_range].to_vec(),
+                first_overflow_page_id,
+                key_len,
+            )?;
+            cells.push(InteriorSplitCell { left_child, key });
         }
 
         match parent_frame.child_ref {
@@ -944,18 +1196,13 @@ impl TreeCursor {
             }
         }
 
-        let idx = match cells
-            .binary_search_by(|cell| cell.key(&interior_snapshot_bytes).cmp(&pending.separator))
-        {
+        let idx = match cells.binary_search_by(|cell| cell.key().cmp(&pending.separator)) {
             Ok(_) => return Err(PageError::DuplicateKey.into()),
             Err(insert_index) => insert_index,
         };
         cells.insert(
             idx,
-            InteriorSplitCell::Incoming {
-                left_child: pending.left_page_id,
-                key: &pending.separator,
-            },
+            InteriorSplitCell { left_child: pending.left_page_id, key: pending.separator.clone() },
         );
 
         let (right_page_id, right_page_guard) = self.page_cache.new_page()?;
@@ -978,10 +1225,22 @@ impl TreeCursor {
         right_page.set_next_page_id(next_page_id);
 
         for cell in left_cells {
-            interior_page.insert(cell.key(&interior_snapshot_bytes), cell.left_child())?;
+            let slot_index = interior_page.slot_count();
+            self.insert_interior_payload_at(
+                &mut interior_page,
+                slot_index,
+                cell.left_child(),
+                cell.key(),
+            )?;
         }
         for cell in right_cells {
-            right_page.insert(cell.key(&interior_snapshot_bytes), cell.left_child())?;
+            let slot_index = right_page.slot_count();
+            self.insert_interior_payload_at(
+                &mut right_page,
+                slot_index,
+                cell.left_child(),
+                cell.key(),
+            )?;
         }
 
         if let Some(next_page_id) = next_page_id {
@@ -994,7 +1253,7 @@ impl TreeCursor {
         let separator = left_cells
             .last()
             .expect("interior split must leave a non-empty left page")
-            .key(&interior_snapshot_bytes)
+            .key()
             .to_vec();
 
         Ok(PendingSplit { separator, left_page_id: parent_frame.page_id, right_page_id })
@@ -1008,7 +1267,12 @@ impl TreeCursor {
             root_guard.page_mut(),
             pending.right_page_id,
         );
-        root_page.insert(&pending.separator, pending.left_page_id)?;
+        self.insert_interior_payload_at(
+            &mut root_page,
+            0,
+            pending.left_page_id,
+            &pending.separator,
+        )?;
         self.root_page_id.set(root_page_id);
         Ok(())
     }
@@ -1079,10 +1343,10 @@ mod tests {
 
     use super::*;
     use crate::disk_manager::DiskManager;
-    use crate::page::format::USABLE_SPACE_END;
 
     const KEY_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=192;
-    const VALUE_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=512;
+    const VALUE_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=PAGE_SIZE * 3;
+    const INLINE_VALUE_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=512;
     const TARGET_HEIGHT: usize = 4;
     const MAX_RECORDS: usize = 50_000;
 
@@ -1098,7 +1362,11 @@ mod tests {
     ) -> (Vec<u8>, Vec<u8>) {
         loop {
             let key_len = rng.usize(KEY_LEN_RANGE);
-            let value_len = rng.usize(VALUE_LEN_RANGE);
+            let value_len = if rng.u8(0..32) == 0 {
+                rng.usize(VALUE_LEN_RANGE)
+            } else {
+                rng.usize(INLINE_VALUE_LEN_RANGE)
+            };
             let key = random_bytes(rng, key_len);
             if expected.contains_key(&key) {
                 continue;
@@ -1109,20 +1377,14 @@ mod tests {
         }
     }
 
-    fn assert_inline_cell(key: &[u8], value: &[u8]) {
-        let leaf_cell_len = LEAF_CELL_PREFIX_SIZE + key.len() + value.len();
-        let leaf_max_cell_len = USABLE_SPACE_END - PageKind::RawLeaf.header_size();
+    fn assert_supported_cell(key: &[u8], value: &[u8]) {
         assert!(
-            leaf_cell_len <= leaf_max_cell_len,
-            "leaf cell should fit inline: len={leaf_cell_len}, max={leaf_max_cell_len}"
+            key.len() + value.len() <= u16::MAX as usize,
+            "leaf payload should fit the current u16 payload-length field"
         );
-
-        let interior_cell_len = INTERIOR_CELL_PREFIX_SIZE + key.len();
-        let interior_max_cell_len = USABLE_SPACE_END - PageKind::RawInterior.header_size();
         assert!(
-            interior_cell_len <= interior_max_cell_len,
-            "interior separator should fit inline: len={interior_cell_len}, \
-             max={interior_max_cell_len}"
+            key.len() <= u16::MAX as usize,
+            "interior separator should fit the current u16 payload-length field"
         );
     }
 
@@ -1159,7 +1421,7 @@ mod tests {
     // Builds a four-level raw B+ tree from deterministic random inline cells,
     // proving leaf splits, repeated interior split propagation, exact-key
     // lookups, and forward/backward sorted cursor scans.
-    fn random_insert_get_simulation_reaches_four_levels() {
+    fn random_insert_get_simulation_with_oversized_values_reaches_four_levels() {
         let file = NamedTempFile::new().unwrap();
         let disk_manager = DiskManager::new(file.path()).unwrap();
         let page_cache = PageCache::new(disk_manager, 256).unwrap();
@@ -1177,7 +1439,7 @@ mod tests {
 
         for _ in 0..MAX_RECORDS {
             let (key, value) = random_unique_cell(&mut rng, &expected);
-            assert_inline_cell(&key, &value);
+            assert_supported_cell(&key, &value);
 
             cursor.insert(&key, &value).unwrap();
             assert!(expected.insert(key.clone(), value.clone()).is_none());
@@ -1215,6 +1477,40 @@ mod tests {
         assert_forward_scan_matches(&mut cursor, &expected);
         assert_reverse_scan_matches(&mut cursor, &expected);
         assert_eq!(expected.len(), cells.len());
+    }
+
+    fn oversized_key(index: u16) -> Vec<u8> {
+        let mut key = vec![0; PAGE_SIZE + 256];
+        key[..2].copy_from_slice(&index.to_be_bytes());
+        for byte in &mut key[2..] {
+            *byte = (index % 251) as u8;
+        }
+        key
+    }
+
+    #[test]
+    fn insert_get_supports_oversized_keys_promoted_to_interior_pages() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 256).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut expected = BTreeMap::new();
+
+        for index in 0..48 {
+            let key = oversized_key(index);
+            let value = format!("value-{index}").into_bytes();
+            assert_supported_cell(&key, &value);
+            cursor.insert(&key, &value).unwrap();
+            expected.insert(key, value);
+        }
+
+        assert!(tree_height(&cursor).unwrap() >= 2, "large keys should force a root split");
+        for (key, value) in &expected {
+            let record = cursor.get(key).unwrap().expect("inserted oversized key should exist");
+            assert_record_matches(&record, key, value);
+        }
+        assert_forward_scan_matches(&mut cursor, &expected);
     }
 
     fn assert_record_matches(record: &Record, expected_key: &[u8], expected_value: &[u8]) {

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -37,6 +37,7 @@ pub struct CorruptionError {
 pub enum CorruptionComponent {
     DatabaseFile,
     DiskPage,
+    OverflowPage,
     Page,
     LeafPage,
     InteriorPage,
@@ -83,6 +84,10 @@ pub enum CorruptionKind {
     InvalidTableRowIdKeyLength { actual: usize },
     #[error("index row-id value has invalid length {actual}")]
     InvalidIndexRowIdValueLength { actual: usize },
+    #[error("overflow chain ended before {expected} bytes could be read")]
+    OverflowChainTooShort { expected: usize, actual: usize },
+    #[error("overflow chain has extra pages after {expected} bytes were read")]
+    OverflowChainTooLong { expected: usize },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -314,6 +319,7 @@ impl fmt::Display for CorruptionComponent {
         match self {
             Self::DatabaseFile => write!(f, "database file"),
             Self::DiskPage => write!(f, "disk page"),
+            Self::OverflowPage => write!(f, "overflow page"),
             Self::Page => write!(f, "page"),
             Self::LeafPage => write!(f, "leaf page"),
             Self::InteriorPage => write!(f, "interior page"),

--- a/crates/databas_core/src/lib.rs
+++ b/crates/databas_core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod btree;
 pub(crate) mod disk_manager;
 pub mod error;
+pub(crate) mod overflow;
 pub(crate) mod page;
 pub(crate) mod page_cache;
 pub(crate) mod page_replacement;

--- a/crates/databas_core/src/lib.rs
+++ b/crates/databas_core/src/lib.rs
@@ -9,7 +9,7 @@ pub(crate) mod page_cache;
 pub(crate) mod page_replacement;
 pub mod pager;
 
-pub use btree::{CursorState, Record, TreeCursor};
+pub use btree::{CursorState, OwnedRecord, Record, RecordView, TreeCursor};
 pub use pager::{Pager, PagerOptions};
 
 pub(crate) const PAGE_SIZE: usize = 4096;

--- a/crates/databas_core/src/overflow.rs
+++ b/crates/databas_core/src/overflow.rs
@@ -110,3 +110,50 @@ pub(crate) fn read_chain(
 
     Ok(payload)
 }
+
+/// Reads the first `expected_len` bytes from an overflow chain.
+///
+/// Unlike [`read_chain`], this helper does not require the chain to end after
+/// the requested bytes. It is used by key comparisons that only need the key
+/// suffix from a larger overflow payload.
+pub(crate) fn read_chain_prefix(
+    page_cache: &PageCache,
+    first_page_id: PageId,
+    expected_len: usize,
+) -> StorageResult<Vec<u8>> {
+    let mut page_id = Some(first_page_id);
+    let mut payload = Vec::with_capacity(expected_len);
+
+    while payload.len() < expected_len {
+        let Some(current_page_id) = page_id else {
+            return Err(overflow_corruption(
+                None,
+                CorruptionKind::OverflowChainTooShort {
+                    expected: expected_len,
+                    actual: payload.len(),
+                },
+            ));
+        };
+
+        if current_page_id == NO_OVERFLOW_PAGE_ID {
+            return Err(overflow_corruption(
+                Some(current_page_id),
+                CorruptionKind::OverflowChainTooShort {
+                    expected: expected_len,
+                    actual: payload.len(),
+                },
+            ));
+        }
+
+        let pin = page_cache.fetch_page(current_page_id)?;
+        let page = pin.read()?;
+        let remaining = expected_len - payload.len();
+        let take = remaining.min(OVERFLOW_PAYLOAD_SIZE);
+        payload.extend_from_slice(
+            &page.page()[OVERFLOW_NEXT_PAGE_ID_SIZE..OVERFLOW_NEXT_PAGE_ID_SIZE + take],
+        );
+        page_id = read_next_page_id(page.page());
+    }
+
+    Ok(payload)
+}

--- a/crates/databas_core/src/overflow.rs
+++ b/crates/databas_core/src/overflow.rs
@@ -1,0 +1,112 @@
+//! Overflow-page chain helpers for large B+-tree cell payloads.
+
+use crate::{
+    PAGE_SIZE, PageId,
+    error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
+    page::format::{self, NO_OVERFLOW_PAGE_ID, OVERFLOW_NEXT_PAGE_ID_SIZE},
+    page_cache::PageCache,
+};
+
+pub(crate) const OVERFLOW_PAYLOAD_SIZE: usize = PAGE_SIZE - OVERFLOW_NEXT_PAGE_ID_SIZE;
+
+fn write_next_page_id(page: &mut [u8; PAGE_SIZE], next_page_id: Option<PageId>) {
+    format::write_optional_u64(page, 0, next_page_id);
+}
+
+fn read_next_page_id(page: &[u8; PAGE_SIZE]) -> Option<PageId> {
+    format::read_optional_u64(page, 0)
+}
+
+fn overflow_corruption(page_id: Option<PageId>, kind: CorruptionKind) -> StorageError {
+    StorageError::Corruption(CorruptionError {
+        component: CorruptionComponent::OverflowPage,
+        page_id,
+        kind,
+    })
+}
+
+/// Writes `payload` into a newly allocated overflow chain.
+pub(crate) fn write_chain(page_cache: &PageCache, payload: &[u8]) -> StorageResult<Option<PageId>> {
+    if payload.is_empty() {
+        return Ok(None);
+    }
+
+    let mut first_page_id = None;
+    let mut previous_page_id = None;
+
+    for chunk in payload.chunks(OVERFLOW_PAYLOAD_SIZE) {
+        let (page_id, pin) = page_cache.new_page()?;
+        {
+            let mut page = pin.write()?;
+            page.page_mut().fill(0);
+            write_next_page_id(page.page_mut(), None);
+            page.page_mut()[OVERFLOW_NEXT_PAGE_ID_SIZE..OVERFLOW_NEXT_PAGE_ID_SIZE + chunk.len()]
+                .copy_from_slice(chunk);
+        }
+        drop(pin);
+
+        if first_page_id.is_none() {
+            first_page_id = Some(page_id);
+        }
+
+        if let Some(previous_page_id) = previous_page_id {
+            let previous_pin = page_cache.fetch_page(previous_page_id)?;
+            let mut previous_page = previous_pin.write()?;
+            write_next_page_id(previous_page.page_mut(), Some(page_id));
+        }
+
+        previous_page_id = Some(page_id);
+    }
+
+    Ok(first_page_id)
+}
+
+/// Reads exactly `expected_len` bytes from an overflow chain.
+pub(crate) fn read_chain(
+    page_cache: &PageCache,
+    first_page_id: PageId,
+    expected_len: usize,
+) -> StorageResult<Vec<u8>> {
+    let mut page_id = Some(first_page_id);
+    let mut payload = Vec::with_capacity(expected_len);
+
+    while payload.len() < expected_len {
+        let Some(current_page_id) = page_id else {
+            return Err(overflow_corruption(
+                None,
+                CorruptionKind::OverflowChainTooShort {
+                    expected: expected_len,
+                    actual: payload.len(),
+                },
+            ));
+        };
+
+        if current_page_id == NO_OVERFLOW_PAGE_ID {
+            return Err(overflow_corruption(
+                Some(current_page_id),
+                CorruptionKind::OverflowChainTooShort {
+                    expected: expected_len,
+                    actual: payload.len(),
+                },
+            ));
+        }
+
+        let pin = page_cache.fetch_page(current_page_id)?;
+        let page = pin.read()?;
+        let remaining = expected_len - payload.len();
+        let take = remaining.min(OVERFLOW_PAYLOAD_SIZE);
+        payload.extend_from_slice(
+            &page.page()[OVERFLOW_NEXT_PAGE_ID_SIZE..OVERFLOW_NEXT_PAGE_ID_SIZE + take],
+        );
+        page_id = read_next_page_id(page.page());
+    }
+
+    if page_id.is_some() {
+        return Err(overflow_corruption(
+            page_id,
+            CorruptionKind::OverflowChainTooLong { expected: expected_len },
+        ));
+    }
+
+    Ok(payload)
+}

--- a/crates/databas_core/src/page/format.rs
+++ b/crates/databas_core/src/page/format.rs
@@ -4,10 +4,10 @@
 //! upward from the header, a packed cell-content region that grows downward
 //! from the end of usable space, and a zeroed reserved footer.
 
-use crate::{PAGE_SIZE, SlotId};
+use crate::{PAGE_SIZE, PageId, SlotId};
 
 /// Current on-disk page format version.
-pub const FORMAT_VERSION: u8 = 3;
+pub const FORMAT_VERSION: u8 = 4;
 /// Number of bytes reserved at the end of every page.
 pub const RESERVED_FOOTER_SIZE: usize = 4;
 /// Exclusive end offset of the usable region within a page buffer.
@@ -16,6 +16,16 @@ pub const USABLE_SPACE_END: usize = PAGE_SIZE - RESERVED_FOOTER_SIZE;
 pub const SLOT_ENTRY_SIZE: usize = 2;
 /// Width in bytes of the length prefix at the start of every cell.
 pub const CELL_LENGTH_SIZE: usize = 2;
+/// Width in bytes of the first-overflow-page field stored in every cell.
+pub const CELL_OVERFLOW_PAGE_ID_SIZE: usize = 8;
+/// Sentinel page id stored when a cell has no overflow chain.
+pub const NO_OVERFLOW_PAGE_ID: PageId = PageId::MAX;
+/// Minimum number of logical payload bytes an overflow cell must keep inline.
+pub const MIN_INLINE_OVERFLOW_PAYLOAD_BYTES: usize = 64;
+/// Maximum number of logical payload bytes an overflow cell may keep inline.
+pub const MAX_INLINE_OVERFLOW_PAYLOAD_BYTES: usize = 512;
+/// Width in bytes of the next-page field at the start of every overflow page.
+pub const OVERFLOW_NEXT_PAGE_ID_SIZE: usize = 8;
 /// Width in bytes of a freeblock header: next freeblock plus total span size.
 pub const FREEBLOCK_HEADER_SIZE: usize = 4;
 /// Maximum fragmented free bytes permitted on a page before defragmentation.

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -6,18 +6,26 @@ use super::{
     CellCorruption, PageError, PageResult,
     cell::{Cell, CellMut},
     core::{BoundResult, Interior, Page, PageAccess, PageAccessMut, SearchResult},
-    format::{self, CELL_LENGTH_SIZE, RIGHTMOST_CHILD_OFFSET, USABLE_SPACE_END},
+    format::{
+        self, CELL_LENGTH_SIZE, CELL_OVERFLOW_PAGE_ID_SIZE, MAX_INLINE_OVERFLOW_PAYLOAD_BYTES,
+        MIN_INLINE_OVERFLOW_PAYLOAD_BYTES, RIGHTMOST_CHILD_OFFSET, USABLE_SPACE_END,
+    },
 };
 
 const PAGE_ID_SIZE: usize = 8;
 const KEY_LENGTH_SIZE: usize = 2;
-const LEFT_CHILD_OFFSET: usize = CELL_LENGTH_SIZE;
+const FIRST_OVERFLOW_PAGE_ID_OFFSET: usize = CELL_LENGTH_SIZE;
+const LEFT_CHILD_OFFSET: usize = FIRST_OVERFLOW_PAGE_ID_OFFSET + CELL_OVERFLOW_PAGE_ID_SIZE;
 const KEY_LENGTH_OFFSET: usize = LEFT_CHILD_OFFSET + PAGE_ID_SIZE;
-/// The fixed-size prefix of a raw interior cell: cell length, left child, and key length.
-pub const INTERIOR_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + PAGE_ID_SIZE + KEY_LENGTH_SIZE;
+/// The fixed-size prefix of a raw interior cell.
+pub const INTERIOR_CELL_PREFIX_SIZE: usize =
+    CELL_LENGTH_SIZE + CELL_OVERFLOW_PAGE_ID_SIZE + PAGE_ID_SIZE + KEY_LENGTH_SIZE;
 
 #[derive(Debug, Clone)]
 pub(crate) struct InteriorCellParts {
+    pub(crate) payload_len: usize,
+    pub(crate) first_overflow_page_id: Option<PageId>,
+    pub(crate) inline_payload_range: Range<usize>,
     pub(crate) left_child: PageId,
     pub(crate) key_range: Range<usize>,
 }
@@ -29,24 +37,49 @@ pub(crate) struct ParsedInteriorCell {
     pub(crate) parts: InteriorCellParts,
 }
 
+pub(crate) fn inline_payload_len(
+    payload_len: usize,
+    first_overflow_page_id: Option<PageId>,
+) -> Option<usize> {
+    match first_overflow_page_id {
+        None => Some(payload_len),
+        Some(_) => {
+            if payload_len <= MAX_INLINE_OVERFLOW_PAYLOAD_BYTES {
+                return None;
+            }
+            Some(MAX_INLINE_OVERFLOW_PAYLOAD_BYTES)
+        }
+    }
+}
+
 pub(crate) fn cell_len_at(
     bytes: &[u8; PAGE_SIZE],
     slot_index: SlotId,
     cell_offset: usize,
 ) -> PageResult<usize> {
-    let cell_len = format::read_u16(bytes, cell_offset) as usize;
-    if cell_len < INTERIOR_CELL_PREFIX_SIZE {
+    if cell_offset + INTERIOR_CELL_PREFIX_SIZE > USABLE_SPACE_END {
         return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthTooSmall });
     }
+
+    let payload_len = format::read_u16(bytes, cell_offset) as usize;
+    let first_overflow_page_id =
+        format::read_optional_u64(bytes, cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET);
+    let key_len = format::read_u16(bytes, cell_offset + KEY_LENGTH_OFFSET) as usize;
+    if key_len != payload_len {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    }
+
+    let Some(inline_payload_len) = inline_payload_len(payload_len, first_overflow_page_id) else {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    };
+    if first_overflow_page_id.is_some() && inline_payload_len < MIN_INLINE_OVERFLOW_PAYLOAD_BYTES {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    }
+
+    let cell_len = INTERIOR_CELL_PREFIX_SIZE + inline_payload_len;
     if cell_offset + cell_len > USABLE_SPACE_END {
         return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
     }
-
-    let key_len = format::read_u16(bytes, cell_offset + KEY_LENGTH_OFFSET) as usize;
-    if INTERIOR_CELL_PREFIX_SIZE + key_len != cell_len {
-        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
-    }
-
     Ok(cell_len)
 }
 
@@ -60,14 +93,22 @@ where
     page.validate_slot_index(slot_index)?;
     let cell_offset = page.slot_offset(slot_index)? as usize;
     let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
+    let payload_len = format::read_u16(page.bytes(), cell_offset) as usize;
+    let first_overflow_page_id =
+        format::read_optional_u64(page.bytes(), cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET);
     let key_len = format::read_u16(page.bytes(), cell_offset + KEY_LENGTH_OFFSET) as usize;
+    let inline_payload_len = cell_len - INTERIOR_CELL_PREFIX_SIZE;
     let key_start = INTERIOR_CELL_PREFIX_SIZE;
-    let key_end = key_start + key_len;
+    let key_end = key_start + key_len.min(inline_payload_len);
 
     Ok(ParsedInteriorCell {
         cell_offset,
         cell_len,
         parts: InteriorCellParts {
+            payload_len,
+            first_overflow_page_id,
+            inline_payload_range: INTERIOR_CELL_PREFIX_SIZE
+                ..INTERIOR_CELL_PREFIX_SIZE + inline_payload_len,
             left_child: format::read_u64(page.bytes(), cell_offset + LEFT_CHILD_OFFSET),
             key_range: key_start..key_end,
         },
@@ -84,10 +125,32 @@ fn encoded_len(key_len: usize) -> PageResult<usize> {
 
 fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, left_child: PageId, key: &[u8]) {
     let cell_len = INTERIOR_CELL_PREFIX_SIZE + key.len();
-    format::write_u16(bytes, cell_offset, cell_len as u16);
+    format::write_u16(bytes, cell_offset, key.len() as u16);
+    format::write_optional_u64(bytes, cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET, None);
     write_left_child(&mut bytes[cell_offset..cell_offset + cell_len], left_child);
     format::write_u16(bytes, cell_offset + KEY_LENGTH_OFFSET, key.len() as u16);
     bytes[cell_offset + INTERIOR_CELL_PREFIX_SIZE..cell_offset + cell_len].copy_from_slice(key);
+}
+
+pub(crate) fn write_cell_with_payload(
+    bytes: &mut [u8; PAGE_SIZE],
+    cell_offset: usize,
+    left_child: PageId,
+    key_len: usize,
+    first_overflow_page_id: Option<PageId>,
+    inline_payload: &[u8],
+) {
+    format::write_u16(bytes, cell_offset, key_len as u16);
+    format::write_optional_u64(
+        bytes,
+        cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET,
+        first_overflow_page_id,
+    );
+    let cell_len = INTERIOR_CELL_PREFIX_SIZE + inline_payload.len();
+    write_left_child(&mut bytes[cell_offset..cell_offset + cell_len], left_child);
+    format::write_u16(bytes, cell_offset + KEY_LENGTH_OFFSET, key_len as u16);
+    let payload_start = cell_offset + INTERIOR_CELL_PREFIX_SIZE;
+    bytes[payload_start..payload_start + inline_payload.len()].copy_from_slice(inline_payload);
 }
 
 pub(crate) fn write_left_child(bytes: &mut [u8], page_id: PageId) {
@@ -160,6 +223,23 @@ where
         Ok((parsed.parts.left_child, key_range))
     }
 
+    /// Returns full payload metadata and the page-relative inline payload range for one cell.
+    pub(crate) fn cell_payload_parts(
+        &self,
+        slot_index: SlotId,
+    ) -> PageResult<(PageId, usize, Option<PageId>, Range<usize>)> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_offset = parsed.cell_offset;
+        let inline_payload_range = cell_offset + parsed.parts.inline_payload_range.start
+            ..cell_offset + parsed.parts.inline_payload_range.end;
+        Ok((
+            parsed.parts.left_child,
+            parsed.parts.payload_len,
+            parsed.parts.first_overflow_page_id,
+            inline_payload_range,
+        ))
+    }
+
     /// Looks up a separator key and returns its cell if present.
     pub fn lookup(&self, key: &[u8]) -> PageResult<Option<Cell<'_, Interior>>> {
         match self.search(key)? {
@@ -196,6 +276,45 @@ where
 
         let cell_offset = self.reserve_space_for_insert(cell_len)?;
         write_cell(self.bytes_mut(), cell_offset as usize, left_child, key);
+        self.insert_slot(slot_index, cell_offset)?;
+        Ok(slot_index)
+    }
+
+    /// Inserts an interior cell whose separator key may continue in an overflow chain.
+    pub(crate) fn insert_payload_at(
+        &mut self,
+        slot_index: SlotId,
+        left_child: PageId,
+        key_len: usize,
+        first_overflow_page_id: Option<PageId>,
+        inline_payload: &[u8],
+    ) -> PageResult<SlotId> {
+        if key_len > u16::MAX as usize {
+            return Err(PageError::CellTooLarge { len: key_len, max: u16::MAX as usize });
+        }
+        let Some(expected_inline_len) = inline_payload_len(key_len, first_overflow_page_id) else {
+            return Err(PageError::CellTooLarge { len: key_len, max: u16::MAX as usize });
+        };
+        if inline_payload.len() != expected_inline_len {
+            return Err(PageError::CellTooLarge {
+                len: INTERIOR_CELL_PREFIX_SIZE + inline_payload.len(),
+                max: INTERIOR_CELL_PREFIX_SIZE + expected_inline_len,
+            });
+        }
+        if slot_index > self.slot_count() {
+            return Err(PageError::InvalidSlotIndex { slot_index, slot_count: self.slot_count() });
+        }
+
+        let cell_len = INTERIOR_CELL_PREFIX_SIZE + inline_payload.len();
+        let cell_offset = self.reserve_space_for_insert(cell_len)?;
+        write_cell_with_payload(
+            self.bytes_mut(),
+            cell_offset as usize,
+            left_child,
+            key_len,
+            first_overflow_page_id,
+            inline_payload,
+        );
         self.insert_slot(slot_index, cell_offset)?;
         Ok(slot_index)
     }

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -1,23 +1,31 @@
 use std::ops::Range;
 
-use crate::{PAGE_SIZE, SlotId};
+use crate::{PAGE_SIZE, PageId, SlotId};
 
 use super::{
     CellCorruption, PageError, PageResult,
     cell::{Cell, CellMut},
     core::{BoundResult, Leaf, Page, PageAccess, PageAccessMut, SearchResult},
-    format::{self, CELL_LENGTH_SIZE, USABLE_SPACE_END},
+    format::{
+        self, CELL_LENGTH_SIZE, CELL_OVERFLOW_PAGE_ID_SIZE, MAX_INLINE_OVERFLOW_PAYLOAD_BYTES,
+        MIN_INLINE_OVERFLOW_PAYLOAD_BYTES, USABLE_SPACE_END,
+    },
 };
 
 const KEY_LENGTH_SIZE: usize = 2;
 const VALUE_LENGTH_SIZE: usize = 2;
-const KEY_LENGTH_OFFSET: usize = CELL_LENGTH_SIZE;
+const FIRST_OVERFLOW_PAGE_ID_OFFSET: usize = CELL_LENGTH_SIZE;
+const KEY_LENGTH_OFFSET: usize = FIRST_OVERFLOW_PAGE_ID_OFFSET + CELL_OVERFLOW_PAGE_ID_SIZE;
 const VALUE_LENGTH_OFFSET: usize = KEY_LENGTH_OFFSET + KEY_LENGTH_SIZE;
-/// The fixed-size prefix of a raw leaf cell: cell length, key length, and value length.
-pub const LEAF_CELL_PREFIX_SIZE: usize = CELL_LENGTH_SIZE + KEY_LENGTH_SIZE + VALUE_LENGTH_SIZE;
+/// The fixed-size prefix of a raw leaf cell.
+pub const LEAF_CELL_PREFIX_SIZE: usize =
+    CELL_LENGTH_SIZE + CELL_OVERFLOW_PAGE_ID_SIZE + KEY_LENGTH_SIZE + VALUE_LENGTH_SIZE;
 
 #[derive(Debug, Clone)]
 pub(crate) struct LeafCellParts {
+    pub(crate) payload_len: usize,
+    pub(crate) first_overflow_page_id: Option<PageId>,
+    pub(crate) inline_payload_range: Range<usize>,
     pub(crate) key_range: Range<usize>,
     pub(crate) value_range: Range<usize>,
 }
@@ -29,25 +37,50 @@ pub(crate) struct ParsedLeafCell {
     pub(crate) parts: LeafCellParts,
 }
 
+pub(crate) fn inline_payload_len(
+    payload_len: usize,
+    first_overflow_page_id: Option<PageId>,
+) -> Option<usize> {
+    match first_overflow_page_id {
+        None => Some(payload_len),
+        Some(_) => {
+            if payload_len <= MAX_INLINE_OVERFLOW_PAYLOAD_BYTES {
+                return None;
+            }
+            Some(MAX_INLINE_OVERFLOW_PAYLOAD_BYTES)
+        }
+    }
+}
+
 pub(crate) fn cell_len_at(
     bytes: &[u8; PAGE_SIZE],
     slot_index: SlotId,
     cell_offset: usize,
 ) -> PageResult<usize> {
-    let cell_len = format::read_u16(bytes, cell_offset) as usize;
-    if cell_len < LEAF_CELL_PREFIX_SIZE {
+    if cell_offset + LEAF_CELL_PREFIX_SIZE > USABLE_SPACE_END {
         return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthTooSmall });
     }
+
+    let payload_len = format::read_u16(bytes, cell_offset) as usize;
+    let first_overflow_page_id =
+        format::read_optional_u64(bytes, cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET);
+    let key_len = format::read_u16(bytes, cell_offset + KEY_LENGTH_OFFSET) as usize;
+    let value_len = format::read_u16(bytes, cell_offset + VALUE_LENGTH_OFFSET) as usize;
+    if key_len + value_len != payload_len {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    }
+
+    let Some(inline_payload_len) = inline_payload_len(payload_len, first_overflow_page_id) else {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    };
+    if first_overflow_page_id.is_some() && inline_payload_len < MIN_INLINE_OVERFLOW_PAYLOAD_BYTES {
+        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
+    }
+
+    let cell_len = LEAF_CELL_PREFIX_SIZE + inline_payload_len;
     if cell_offset + cell_len > USABLE_SPACE_END {
         return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
     }
-
-    let key_len = format::read_u16(bytes, cell_offset + KEY_LENGTH_OFFSET) as usize;
-    let value_len = format::read_u16(bytes, cell_offset + VALUE_LENGTH_OFFSET) as usize;
-    if LEAF_CELL_PREFIX_SIZE + key_len + value_len != cell_len {
-        return Err(PageError::CorruptCell { slot_index, kind: CellCorruption::LengthOutOfBounds });
-    }
-
     Ok(cell_len)
 }
 
@@ -58,16 +91,22 @@ where
     page.validate_slot_index(slot_index)?;
     let cell_offset = page.slot_offset(slot_index)? as usize;
     let cell_len = cell_len_at(page.bytes(), slot_index, cell_offset)?;
+    let payload_len = format::read_u16(page.bytes(), cell_offset) as usize;
+    let first_overflow_page_id =
+        format::read_optional_u64(page.bytes(), cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET);
     let key_len = format::read_u16(page.bytes(), cell_offset + KEY_LENGTH_OFFSET) as usize;
-    let value_len = format::read_u16(page.bytes(), cell_offset + VALUE_LENGTH_OFFSET) as usize;
+    let inline_payload_len = cell_len - LEAF_CELL_PREFIX_SIZE;
     let key_start = LEAF_CELL_PREFIX_SIZE;
-    let value_start = key_start + key_len;
-    let value_end = value_start + value_len;
+    let value_start = key_start + key_len.min(inline_payload_len);
+    let value_end = LEAF_CELL_PREFIX_SIZE + inline_payload_len;
 
     Ok(ParsedLeafCell {
         cell_offset,
         cell_len,
         parts: LeafCellParts {
+            payload_len,
+            first_overflow_page_id,
+            inline_payload_range: LEAF_CELL_PREFIX_SIZE..LEAF_CELL_PREFIX_SIZE + inline_payload_len,
             key_range: key_start..value_start,
             value_range: value_start..value_end,
         },
@@ -75,7 +114,8 @@ where
 }
 
 fn encoded_len(key_len: usize, value_len: usize) -> PageResult<usize> {
-    let len = LEAF_CELL_PREFIX_SIZE + key_len + value_len;
+    let payload_len = key_len + value_len;
+    let len = LEAF_CELL_PREFIX_SIZE + payload_len;
     if key_len > u16::MAX as usize || value_len > u16::MAX as usize {
         return Err(PageError::CellTooLarge { len, max: u16::MAX as usize });
     }
@@ -86,8 +126,9 @@ fn encoded_len(key_len: usize, value_len: usize) -> PageResult<usize> {
 }
 
 fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, key: &[u8], value: &[u8]) {
-    let cell_len = LEAF_CELL_PREFIX_SIZE + key.len() + value.len();
-    format::write_u16(bytes, cell_offset, cell_len as u16);
+    let payload_len = key.len() + value.len();
+    format::write_u16(bytes, cell_offset, payload_len as u16);
+    format::write_optional_u64(bytes, cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET, None);
     format::write_u16(bytes, cell_offset + KEY_LENGTH_OFFSET, key.len() as u16);
     format::write_u16(bytes, cell_offset + VALUE_LENGTH_OFFSET, value.len() as u16);
     let key_start = cell_offset + LEAF_CELL_PREFIX_SIZE;
@@ -95,6 +136,27 @@ fn write_cell(bytes: &mut [u8; PAGE_SIZE], cell_offset: usize, key: &[u8], value
     let value_end = value_start + value.len();
     bytes[key_start..value_start].copy_from_slice(key);
     bytes[value_start..value_end].copy_from_slice(value);
+}
+
+pub(crate) fn write_cell_with_payload(
+    bytes: &mut [u8; PAGE_SIZE],
+    cell_offset: usize,
+    key_len: usize,
+    value_len: usize,
+    first_overflow_page_id: Option<PageId>,
+    inline_payload: &[u8],
+) {
+    let payload_len = key_len + value_len;
+    format::write_u16(bytes, cell_offset, payload_len as u16);
+    format::write_optional_u64(
+        bytes,
+        cell_offset + FIRST_OVERFLOW_PAGE_ID_OFFSET,
+        first_overflow_page_id,
+    );
+    format::write_u16(bytes, cell_offset + KEY_LENGTH_OFFSET, key_len as u16);
+    format::write_u16(bytes, cell_offset + VALUE_LENGTH_OFFSET, value_len as u16);
+    let payload_start = cell_offset + LEAF_CELL_PREFIX_SIZE;
+    bytes[payload_start..payload_start + inline_payload.len()].copy_from_slice(inline_payload);
 }
 
 fn compare_key<A>(
@@ -151,6 +213,21 @@ where
         Ok((key_range, value_range))
     }
 
+    /// Returns full payload metadata and the page-relative inline payload range for one cell.
+    pub(crate) fn cell_payload_parts(
+        &self,
+        slot_index: SlotId,
+    ) -> PageResult<(usize, usize, Option<PageId>, Range<usize>)> {
+        let parsed = cell_parts(self, slot_index)?;
+        let cell_offset = parsed.cell_offset;
+        let inline_payload_range = cell_offset + parsed.parts.inline_payload_range.start
+            ..cell_offset + parsed.parts.inline_payload_range.end;
+        let key_len =
+            format::read_u16(self.bytes(), parsed.cell_offset + KEY_LENGTH_OFFSET) as usize;
+        let value_len = parsed.parts.payload_len - key_len;
+        Ok((key_len, value_len, parsed.parts.first_overflow_page_id, inline_payload_range))
+    }
+
     /// Looks up a key and returns its cell if present.
     pub fn lookup(&self, key: &[u8]) -> PageResult<Option<Cell<'_, Leaf>>> {
         match self.search(key)? {
@@ -182,6 +259,50 @@ where
 
         let cell_offset = self.reserve_space_for_insert(cell_len)?;
         write_cell(self.bytes_mut(), cell_offset as usize, key, value);
+        self.insert_slot(slot_index, cell_offset)?;
+        Ok(slot_index)
+    }
+
+    /// Inserts a leaf cell whose logical payload may continue in an overflow chain.
+    pub(crate) fn insert_payload_at(
+        &mut self,
+        slot_index: SlotId,
+        key_len: usize,
+        value_len: usize,
+        first_overflow_page_id: Option<PageId>,
+        inline_payload: &[u8],
+    ) -> PageResult<SlotId> {
+        let payload_len = key_len + value_len;
+        if key_len > u16::MAX as usize
+            || value_len > u16::MAX as usize
+            || payload_len > u16::MAX as usize
+        {
+            return Err(PageError::CellTooLarge { len: payload_len, max: u16::MAX as usize });
+        }
+        let Some(expected_inline_len) = inline_payload_len(payload_len, first_overflow_page_id)
+        else {
+            return Err(PageError::CellTooLarge { len: payload_len, max: u16::MAX as usize });
+        };
+        if inline_payload.len() != expected_inline_len {
+            return Err(PageError::CellTooLarge {
+                len: LEAF_CELL_PREFIX_SIZE + inline_payload.len(),
+                max: LEAF_CELL_PREFIX_SIZE + expected_inline_len,
+            });
+        }
+        if slot_index > self.slot_count() {
+            return Err(PageError::InvalidSlotIndex { slot_index, slot_count: self.slot_count() });
+        }
+
+        let cell_len = LEAF_CELL_PREFIX_SIZE + inline_payload.len();
+        let cell_offset = self.reserve_space_for_insert(cell_len)?;
+        write_cell_with_payload(
+            self.bytes_mut(),
+            cell_offset as usize,
+            key_len,
+            value_len,
+            first_overflow_page_id,
+            inline_payload,
+        );
         self.insert_slot(slot_index, cell_offset)?;
         Ok(slot_index)
     }


### PR DESCRIPTION
This PR implements support for inserting oversized cells into B+-trees. Like SQLite, these cells are stored in a chain of overflow pages. Between 64 and 512 bytes of the cell's payload is stored inline, and the leaf page can be split to ensure this is possible. For oversized cells, we store the page ID of the cell's first overflow page in its header.

The tree cursor can now return either borrowed or owned records (cells), depending on if the cell fits inline without overflow pages or not.

The `insert` + `get` stress test has been updated to insert oversized cells into the tree.