### PR TITLE
feat/in memory db

### DIFF
--- a/crates/databas_core/docs/btree-delete.md
+++ b/crates/databas_core/docs/btree-delete.md
@@ -1,0 +1,801 @@
+# B+-tree Delete and Cursor Walkthrough
+
+This document explains the raw byte-oriented B+-tree delete path implemented in
+`src/btree.rs` and the page primitives under `src/page/`. The tree stores raw
+key/value records in leaf pages and separator keys in interior pages.
+
+The important design choice is that interior separator keys are the maximum key
+reachable through the child to their left. Each interior page stores one extra
+rightmost child pointer in the page header, so a page with `n` separator cells
+has `n + 1` children.
+
+## Data Structures Involved
+
+`TreeCursor` owns the page cache handle, a shared root page id, and logical
+cursor state:
+
+```rust
+pub enum CursorState {
+    Page { page_id: PageId },
+    Positioned { page_id: PageId, slot_index: u16 },
+    Exhausted,
+}
+
+pub struct TreeCursor {
+    page_cache: PageCache,
+    root_page_id: Rc<Cell<PageId>>,
+    state: CursorState,
+}
+```
+
+During a delete descent, the cursor records the interior pages it traversed:
+
+```rust
+enum ChildSlotRef {
+    Slot(u16),
+    Rightmost,
+}
+
+struct PathFrame {
+    page_id: PageId,
+    child_ref: ChildSlotRef,
+}
+```
+
+`PathFrame` is what lets delete repair the path after removing a record. It
+identifies both the parent page and the exact child reference followed from that
+parent.
+
+## High-level Delete Flow
+
+The public delete entry point is compact:
+
+```rust
+pub fn delete(&mut self, key: &[u8]) -> StorageResult<()> {
+    let (leaf_page_id, tree_path) = self.leaf_page_path_for_key(key)?;
+    {
+        let leaf_pin_guard = self.page_cache.fetch_page(leaf_page_id)?;
+        let mut leaf_guard = leaf_pin_guard.write()?;
+        let mut page = RawLeaf::<Write<'_>>::open(leaf_guard.page_mut())?;
+        page.delete(key)?;
+    }
+
+    self.set_page_state(leaf_page_id);
+    self.rebalance_after_leaf_delete(leaf_page_id, &tree_path)?;
+    self.refresh_path_separators(&tree_path)?;
+    self.shrink_root_if_empty()?;
+    Ok(())
+}
+```
+
+The operation has five phases:
+
+1. Descend to the target leaf and capture the interior path.
+2. Delete the cell from the leaf page.
+3. Put the cursor in `Page` state, no longer on a concrete slot.
+4. Rebalance underoccupied leaf and interior pages.
+5. Refresh separator keys and shrink an empty interior root if possible.
+
+If the key is missing, `RawLeaf::delete` returns `PageError::KeyNotFound`, which
+is propagated as a storage error. No rebalance is attempted in that case.
+
+## Step 1: Descend and Record the Path
+
+`leaf_page_path_for_key` starts at the current root and repeatedly follows an
+interior child until it reaches a leaf:
+
+```rust
+fn leaf_page_path_for_key(&self, key: &[u8]) -> StorageResult<(PageId, Vec<PathFrame>)> {
+    let mut path = Vec::new();
+    let mut page_id = self.root_page_id();
+
+    loop {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let next = {
+            let page = pin.read()?;
+            match read_page_kind(page.page(), page_id)? {
+                PageKind::RawLeaf => {
+                    let _ = RawLeaf::<Read<'_>>::open(page.page())?;
+                    return Ok((page_id, path));
+                }
+                PageKind::RawInterior => {
+                    drop(page);
+                    drop(pin);
+                    match self.lower_bound_interior_slot(page_id, key)? {
+                        BoundResult::At(slot_index) => {
+                            let child_page_id =
+                                self.read_interior_left_child(page_id, slot_index)?;
+                            path.push(PathFrame {
+                                page_id,
+                                child_ref: ChildSlotRef::Slot(slot_index),
+                            });
+                            child_page_id
+                        }
+                        BoundResult::PastEnd => {
+                            path.push(PathFrame {
+                                page_id,
+                                child_ref: ChildSlotRef::Rightmost,
+                            });
+                            ...
+                            interior.rightmost_child()
+                        }
+                    }
+                }
+            }
+        };
+        page_id = next;
+    }
+}
+```
+
+The code uses lower-bound semantics on separator keys. If the key is less than
+or equal to a separator, the matching child pointer is in that separator cell.
+If the key is larger than all separators, the search follows the rightmost child
+stored in the header.
+
+The path is also used defensively after merges. A page on the original path may
+have been removed from its parent, so later separator refresh only touches pages
+that are still reachable.
+
+## Step 2: Delete the Leaf Cell
+
+The raw leaf page delete is local to one page:
+
+```rust
+pub fn delete(&mut self, key: &[u8]) -> PageResult<SlotId> {
+    let slot_index = match self.search(key)? {
+        SearchResult::Found(slot_index) => slot_index,
+        SearchResult::InsertAt(_) => return Err(PageError::KeyNotFound),
+    };
+
+    let cell_offset = self.slot_offset(slot_index)?;
+    let cell_len = self.cell_len(slot_index)?;
+    self.remove_slot(slot_index)?;
+    self.reclaim_space(cell_offset, cell_len)?;
+    Ok(slot_index)
+}
+```
+
+This removes the slot-directory entry and then returns the local cell bytes to
+the page's free-space structures. It does not update ancestors directly and it
+does not touch sibling pages.
+
+`remove_slot` compacts the slot directory:
+
+```rust
+pub(crate) fn remove_slot(&mut self, slot_index: SlotId) -> PageResult<u16> {
+    self.validate_slot_index(slot_index)?;
+    let slot_count = self.slot_count();
+    let header_size = N::KIND.header_size();
+    let remove_at = format::slot_entry_offset(header_size, slot_index);
+    let removed = format::read_u16(self.bytes(), remove_at);
+    let tail_start = remove_at + format::SLOT_ENTRY_SIZE;
+    let tail_end = format::slot_entry_offset(header_size, slot_count);
+
+    self.bytes_mut().copy_within(tail_start..tail_end, remove_at);
+    let last_slot = format::slot_entry_offset(header_size, slot_count - 1);
+    self.bytes_mut()[last_slot..last_slot + format::SLOT_ENTRY_SIZE].fill(0);
+    self.set_slot_count(slot_count - 1);
+    Ok(removed)
+}
+```
+
+`reclaim_space` then turns the removed cell body into either gap space,
+fragmented bytes, or a freeblock:
+
+```rust
+pub(crate) fn reclaim_space(&mut self, cell_offset: u16, cell_len: usize) -> PageResult<()> {
+    if self.slot_count() == 0 {
+        self.reset_empty_page();
+        return Ok(());
+    }
+
+    let reclaim_start = cell_offset as usize;
+    if reclaim_start == self.content_start() as usize {
+        self.set_content_start((reclaim_start + cell_len) as u16);
+        self.absorb_freeblocks_into_gap()?;
+        return Ok(());
+    }
+
+    let reclaim_end = reclaim_start + cell_len;
+    ...
+    let merged_with_previous = previous.filter(|freeblock| freeblock.end() == reclaim_start);
+    let merged_with_next = next.filter(|freeblock| reclaim_end == freeblock.offset as usize);
+    ...
+}
+```
+
+The local page format has a slot directory growing upward and cell content
+growing downward. If the deleted cell is at the content-start boundary, reclaim
+can expand the contiguous gap. Otherwise, the deleted bytes join adjacent
+freeblocks where possible. Very small spans become fragmented bytes.
+
+## Step 3: Cursor State After Delete
+
+Immediately after the raw cell delete, the cursor is intentionally moved to page
+state:
+
+```rust
+self.set_page_state(leaf_page_id);
+```
+
+That means `current()` returns `None` after delete, even if the page still has
+nearby records. Subsequent movement uses page-level scan behavior:
+
+```rust
+fn step_record(&mut self, direction: ScanDirection) -> StorageResult<Option<Record>> {
+    match self.state {
+        CursorState::Exhausted => Ok(None),
+        CursorState::Page { page_id } => {
+            let leaf_page_id = direction.descend_to_edge_leaf(self, page_id)?;
+            self.edge_record_from_leaf(leaf_page_id, direction)
+        }
+        CursorState::Positioned { page_id, slot_index } => { ... }
+    }
+}
+```
+
+If rebalancing merges the deleted leaf into its left sibling, the rebalance code
+updates the cursor page state to the surviving left page. If it merges with the
+right sibling, the deleted leaf is the survivor and remains the cursor page. If
+the root shrinks, `shrink_root_if_empty` moves the cursor to the new root child.
+
+## Step 4: Detect Underoccupation
+
+Rebalancing is skipped for a root leaf and for leaves that remain sufficiently
+occupied:
+
+```rust
+fn rebalance_after_leaf_delete(
+    &mut self,
+    leaf_page_id: PageId,
+    tree_path: &[PathFrame],
+) -> StorageResult<()> {
+    if tree_path.is_empty() {
+        return Ok(());
+    }
+    if !self.leaf_page_underoccupied(leaf_page_id)? {
+        return Ok(());
+    }
+
+    let mut depth = tree_path.len() - 1;
+    let parent_page_id = tree_path[depth].page_id;
+    if !self.rebalance_leaf_page(leaf_page_id, parent_page_id)? {
+        return Ok(());
+    }
+
+    loop {
+        let page_id = tree_path[depth].page_id;
+        if page_id == self.root_page_id() {
+            self.shrink_root_if_empty()?;
+            return Ok(());
+        }
+        if !self.interior_page_underoccupied(page_id)? {
+            return Ok(());
+        }
+        ...
+    }
+}
+```
+
+The page-level occupancy check is based on live slot bytes plus live cell bytes:
+
+```rust
+pub fn is_underoccupied(&self) -> PageResult<bool> {
+    let header_size = N::KIND.header_size();
+    let slot_bytes = self.slot_count() as usize * format::SLOT_ENTRY_SIZE;
+    let occupied_variable_bytes = slot_bytes + self.live_cell_bytes()?;
+    let usable_variable_bytes = USABLE_SPACE_END - header_size;
+    Ok(occupied_variable_bytes * 2 < usable_variable_bytes)
+}
+```
+
+So a page is underoccupied when it uses less than half of the usable variable
+area. The root is special: it may be underoccupied without forcing a merge.
+
+## Step 5: Leaf Redistribution and Merge
+
+`rebalance_leaf_page` gets the deleted page's index in its parent, reads adjacent
+siblings, and tries several repair strategies:
+
+```rust
+fn rebalance_leaf_page(
+    &mut self,
+    leaf_page_id: PageId,
+    parent_page_id: PageId,
+) -> StorageResult<bool> {
+    let child_index = self.child_index_in_parent(parent_page_id, leaf_page_id)?;
+    let parent_children = self.read_interior_child_page_ids(parent_page_id)?;
+
+    if child_index > 0 {
+        let left_page_id = parent_children[child_index - 1];
+        let mut cells = self.read_leaf_cells(left_page_id)?;
+        cells.extend(self.read_leaf_cells(leaf_page_id)?);
+        if let Some(split_index) = Self::choose_leaf_rebalance_split(&cells) {
+            self.redistribute_leaf_pair(left_page_id, leaf_page_id, &cells, split_index)?;
+            return Ok(false);
+        }
+    }
+
+    if child_index + 1 < parent_children.len() {
+        let right_page_id = parent_children[child_index + 1];
+        let mut cells = self.read_leaf_cells(leaf_page_id)?;
+        cells.extend(self.read_leaf_cells(right_page_id)?);
+        if let Some(split_index) = Self::choose_leaf_rebalance_split(&cells) {
+            self.redistribute_leaf_pair(leaf_page_id, right_page_id, &cells, split_index)?;
+            return Ok(false);
+        }
+    }
+
+    ...
+}
+```
+
+The strategy order is:
+
+1. Try to redistribute with the left sibling while keeping both pages fit and
+   not underoccupied.
+2. Try the same with the right sibling.
+3. If redistribution cannot satisfy occupancy, try to merge with the left
+   sibling if the combined cells fit in one page.
+4. Try to merge with the right sibling if the combined cells fit.
+5. As a fallback, choose a split that merely fits both pages, even if one still
+   remains underoccupied.
+
+Redistribution rebuilds both pages from materialized cells and preserves the
+outer sibling links:
+
+```rust
+fn redistribute_leaf_pair(
+    &self,
+    left_page_id: PageId,
+    right_page_id: PageId,
+    cells: &[LeafSplitCell],
+    split_index: usize,
+) -> StorageResult<()> {
+    let (left_prev_page_id, _) = self.read_leaf_page_links(left_page_id)?;
+    let (_, right_next_page_id) = self.read_leaf_page_links(right_page_id)?;
+    self.rewrite_leaf_page(
+        left_page_id,
+        &cells[..split_index],
+        left_prev_page_id,
+        Some(right_page_id),
+    )?;
+    self.rewrite_leaf_page(
+        right_page_id,
+        &cells[split_index..],
+        Some(left_page_id),
+        right_next_page_id,
+    )
+}
+```
+
+A merge rewrites only the survivor, links it around the removed page, and fixes
+the next page's `prev` pointer:
+
+```rust
+fn merge_leaf_pages(
+    &self,
+    survivor_page_id: PageId,
+    removed_page_id: PageId,
+    cells: &[LeafSplitCell],
+) -> StorageResult<()> {
+    let (survivor_prev_page_id, _) = self.read_leaf_page_links(survivor_page_id)?;
+    let (_, removed_next_page_id) = self.read_leaf_page_links(removed_page_id)?;
+    self.rewrite_leaf_page(
+        survivor_page_id,
+        cells,
+        survivor_prev_page_id,
+        removed_next_page_id,
+    )?;
+    if let Some(next_page_id) = removed_next_page_id {
+        self.set_leaf_prev_page_id(next_page_id, Some(survivor_page_id))?;
+    }
+    Ok(())
+}
+```
+
+After a merge, the parent no longer has a valid child pointer for the removed
+page. `remove_child_from_parent` rebuilds the parent without that child:
+
+```rust
+fn remove_child_from_parent(
+    &self,
+    parent_page_id: PageId,
+    child_page_id: PageId,
+) -> StorageResult<()> {
+    let mut children = self.read_interior_child_entries(parent_page_id)?;
+    let child_index =
+        children.iter().position(|child| child.page_id == child_page_id).ok_or(...)?;
+    children.remove(child_index);
+    let (prev_page_id, next_page_id) = self.read_interior_page_links(parent_page_id)?;
+    self.rewrite_interior_page(parent_page_id, &children, prev_page_id, next_page_id)
+}
+```
+
+The return value from `rebalance_leaf_page` tells the caller whether a merge
+removed a child from the parent. Only that case may propagate underoccupation
+upward.
+
+## Step 6: Interior Redistribution and Merge
+
+Interior page repair mirrors leaf repair, but it works with child entries rather
+than leaf records. A `ChildEntry` is a child page id plus the maximum key
+reachable through that child:
+
+```rust
+struct ChildEntry {
+    page_id: PageId,
+    max_key: Option<Vec<u8>>,
+}
+```
+
+Child entries are recomputed from the current tree:
+
+```rust
+fn read_interior_child_entries(&self, page_id: PageId) -> StorageResult<Vec<ChildEntry>> {
+    let child_page_ids = self.read_interior_child_page_ids(page_id)?;
+    let mut children = Vec::with_capacity(child_page_ids.len());
+    for child_page_id in child_page_ids {
+        children.push(ChildEntry {
+            page_id: child_page_id,
+            max_key: self.subtree_max_key(child_page_id)?,
+        });
+    }
+    Ok(children)
+}
+```
+
+Interior pages are rebuilt from those child entries. All children except the
+last become separator cells; the last child becomes the header's rightmost
+child:
+
+```rust
+fn rewrite_interior_page(
+    &self,
+    page_id: PageId,
+    children: &[ChildEntry],
+    prev_page_id: Option<PageId>,
+    next_page_id: Option<PageId>,
+) -> StorageResult<()> {
+    let rightmost_child = children.last().ok_or(...)?;
+    let mut used_bytes = PageKind::RawInterior.header_size()
+        + (children.len() - 1) * page::format::SLOT_ENTRY_SIZE;
+    for child in &children[..children.len() - 1] {
+        let key = child
+            .max_key
+            .as_deref()
+            .ok_or_else(|| Self::missing_child_max_key_error(page_id))?;
+        used_bytes += self.interior_cell_local_size(key)?;
+    }
+    if used_bytes > page::format::USABLE_SPACE_END {
+        return Err(PageError::PageFull { ... }.into());
+    }
+
+    ...
+    let mut interior = RawInterior::<Write<'_>>::initialize_with_rightmost(
+        &mut page_image,
+        rightmost_child.page_id,
+    );
+    ...
+}
+```
+
+Interior rebalancing has the same strategy order as leaf rebalancing:
+
+```rust
+fn rebalance_interior_page(
+    &self,
+    interior_page_id: PageId,
+    parent_page_id: PageId,
+) -> StorageResult<bool> {
+    let child_index = self.child_index_in_parent(parent_page_id, interior_page_id)?;
+    let parent_children = self.read_interior_child_page_ids(parent_page_id)?;
+
+    if child_index > 0 {
+        let left_page_id = parent_children[child_index - 1];
+        let mut children = self.read_interior_child_entries(left_page_id)?;
+        children.extend(self.read_interior_child_entries(interior_page_id)?);
+        if let Some(split_index) = Self::choose_interior_rebalance_split(&children) {
+            self.redistribute_interior_pair(
+                left_page_id,
+                interior_page_id,
+                &children,
+                split_index,
+            )?;
+            return Ok(false);
+        }
+    }
+
+    ...
+}
+```
+
+Merging interior pages rewrites the survivor, updates the sibling link of the
+next interior page, and asks the parent to drop the removed child:
+
+```rust
+fn merge_interior_pages(
+    &self,
+    survivor_page_id: PageId,
+    removed_page_id: PageId,
+    children: &[ChildEntry],
+) -> StorageResult<()> {
+    let (survivor_prev_page_id, _) = self.read_interior_page_links(survivor_page_id)?;
+    let (_, removed_next_page_id) = self.read_interior_page_links(removed_page_id)?;
+    self.rewrite_interior_page(
+        survivor_page_id,
+        children,
+        survivor_prev_page_id,
+        removed_next_page_id,
+    )?;
+    if let Some(next_page_id) = removed_next_page_id {
+        self.set_interior_prev_page_id(next_page_id, Some(survivor_page_id))?;
+    }
+    Ok(())
+}
+```
+
+Interior sibling links are maintained even though normal point lookup descends
+from the root. They are still useful structural metadata and keep each tree
+level consistently linked.
+
+## Step 7: Separator Refresh
+
+Even if a merge does not propagate upward, deleting the largest key in a child
+can invalidate an ancestor separator. `refresh_path_separators` repairs this
+from the bottom of the original path upward:
+
+```rust
+fn refresh_path_separators(&self, tree_path: &[PathFrame]) -> StorageResult<()> {
+    if tree_path.is_empty() {
+        return Ok(());
+    }
+
+    let mut reachable = Vec::with_capacity(tree_path.len());
+    for (depth, frame) in tree_path.iter().enumerate() {
+        let is_reachable = if depth == 0 {
+            frame.page_id == self.root_page_id()
+        } else {
+            reachable[depth - 1]
+                && self.interior_page_has_child(tree_path[depth - 1].page_id, frame.page_id)?
+        };
+        reachable.push(is_reachable);
+    }
+
+    for (frame, is_reachable) in tree_path.iter().zip(reachable).rev() {
+        if is_reachable {
+            self.refresh_interior_page_separators(frame.page_id)?;
+        }
+    }
+
+    Ok(())
+}
+```
+
+The reachability check matters because a page in the old path may have been
+merged away. The refresh only rewrites pages still attached to the current root.
+
+`refresh_interior_page_separators` recomputes each child max and rewrites the
+page only if something actually changed:
+
+```rust
+fn refresh_interior_page_separators(&self, page_id: PageId) -> StorageResult<()> {
+    let children = self.read_interior_child_entries(page_id)?;
+    if self.interior_page_matches_children(page_id, &children)? {
+        return Ok(());
+    }
+
+    let (prev_page_id, next_page_id) = self.read_interior_page_links(page_id)?;
+    self.rewrite_interior_page(page_id, &children, prev_page_id, next_page_id)
+}
+```
+
+## Step 8: Root Shrinking
+
+An interior root with no separator cells has exactly one child: its rightmost
+child pointer. Delete collapses that root:
+
+```rust
+fn shrink_root_if_empty(&mut self) -> StorageResult<()> {
+    let root_page_id = self.root_page_id();
+    let pin = self.page_cache.fetch_page(root_page_id)?;
+    let child_page_id = {
+        let page = pin.read()?;
+        match read_page_kind(page.page(), root_page_id)? {
+            PageKind::RawLeaf => return Ok(()),
+            PageKind::RawInterior => {
+                let interior = RawInterior::<Read<'_>>::open(page.page())?;
+                if interior.slot_count() > 0 {
+                    return Ok(());
+                }
+                interior.rightmost_child()
+            }
+        }
+    };
+    self.root_page_id.set(child_page_id);
+    self.set_page_state(child_page_id);
+    Ok(())
+}
+```
+
+The old root page is not physically freed. The cursor's shared root id is simply
+updated to the sole child.
+
+## Overflow Payloads
+
+Large payloads are split between the cell body and overflow pages. The on-page
+format reserves an overflow pointer in every raw leaf and interior cell:
+
+```rust
+pub const MIN_INLINE_OVERFLOW_PAYLOAD_BYTES: usize = 64;
+pub const MAX_INLINE_OVERFLOW_PAYLOAD_BYTES: usize = 512;
+pub const OVERFLOW_NEXT_PAGE_ID_SIZE: usize = 8;
+```
+
+When inserting or rewriting a cell, the tree keeps at most 512 bytes inline and
+writes the remaining bytes to a newly allocated overflow chain:
+
+```rust
+fn payload_storage_parts(&self, payload: &[u8]) -> StorageResult<(Option<PageId>, Vec<u8>)> {
+    self.checked_payload_len(payload.len())?;
+    if !payload_uses_overflow(payload.len()) {
+        return Ok((None, payload.to_vec()));
+    }
+
+    let inline_payload = payload[..MAX_INLINE_OVERFLOW_PAYLOAD_BYTES].to_vec();
+    let first_overflow_page_id =
+        overflow::write_chain(&self.page_cache, &payload[MAX_INLINE_OVERFLOW_PAYLOAD_BYTES..])?
+            .ok_or_else(|| {
+                cell_corruption(self.root_page_id(), CorruptionKind::CellLengthOutOfBounds)
+            })?;
+    Ok((Some(first_overflow_page_id), inline_payload))
+}
+```
+
+Overflow pages form a singly linked list:
+
+```rust
+pub(crate) fn write_chain(page_cache: &PageCache, payload: &[u8]) -> StorageResult<Option<PageId>> {
+    if payload.is_empty() {
+        return Ok(None);
+    }
+
+    let mut first_page_id = None;
+    let mut previous_page_id = None;
+
+    for chunk in payload.chunks(OVERFLOW_PAYLOAD_SIZE) {
+        let (page_id, pin) = page_cache.new_page()?;
+        {
+            let mut page = pin.write()?;
+            page.page_mut().fill(0);
+            write_next_page_id(page.page_mut(), None);
+            page.page_mut()[OVERFLOW_NEXT_PAGE_ID_SIZE..OVERFLOW_NEXT_PAGE_ID_SIZE + chunk.len()]
+                .copy_from_slice(chunk);
+        }
+        ...
+    }
+
+    Ok(first_page_id)
+}
+```
+
+Delete itself does not read or free overflow pages when it removes the target
+cell. It only reclaims the local inline cell bytes. However, rebalancing and
+separator refresh materialize cells before rebuilding pages:
+
+```rust
+fn read_leaf_cells(&self, page_id: PageId) -> StorageResult<Vec<LeafSplitCell>> {
+    let slot_count = self.raw_leaf_slot_count(page_id)?;
+    let mut cells = Vec::with_capacity(slot_count as usize);
+    for slot_index in 0..slot_count {
+        let (key, value) = read_leaf_cell(&self.page_cache, page_id, slot_index)?;
+        cells.push(LeafSplitCell { key, value });
+    }
+    Ok(cells)
+}
+```
+
+`read_leaf_cell` and `read_interior_cell` call `materialize_payload`, which reads
+the overflow chain if one exists:
+
+```rust
+fn materialize_payload(
+    page_cache: &PageCache,
+    page_id: PageId,
+    inline_payload: Vec<u8>,
+    first_overflow_page_id: Option<PageId>,
+    payload_len: usize,
+) -> StorageResult<Vec<u8>> {
+    ...
+    match first_overflow_page_id {
+        Some(first_overflow_page_id) => {
+            let remaining = payload_len - payload.len();
+            payload.extend(overflow::read_chain(page_cache, first_overflow_page_id, remaining)?);
+        }
+        ...
+    }
+    ...
+}
+```
+
+When rebuilt pages are written, large surviving cells get new overflow chains.
+The current storage layer has `new_page` but no free-page or free-overflow-chain
+operation. As a result:
+
+- Deleting a record with overflow makes its old overflow chain unreachable.
+- Rewriting pages during redistribution, merge, or separator refresh can also
+  leave old overflow chains unreachable and allocate replacement chains.
+- The removed leaf/interior page from a merge is detached from the tree but not
+  returned to a free list.
+
+This is correct for lookup semantics but means delete is not space-reclaiming at
+the file level yet.
+
+## Edge Cases
+
+### Deleting from a root leaf
+
+If the tree has height one, `tree_path` is empty. The raw cell is removed and
+the page's local free space is reclaimed, but no sibling rebalance is attempted.
+If the last record is deleted, the root remains an empty leaf. `seek_to_first`
+then returns `false` and moves the cursor to `Exhausted`.
+
+### Deleting the largest key in a child
+
+The leaf may still be occupied enough to avoid merging, but an ancestor
+separator might now be stale. `refresh_path_separators` recomputes child maxima
+and rewrites affected reachable interior pages.
+
+### Merge removes a page on the original path
+
+After a merge, a path frame may refer to a detached page. Separator refresh first
+checks whether each path page is still reachable from the current root before
+rewriting it.
+
+### Parent underflows after a child merge
+
+`rebalance_leaf_page` and `rebalance_interior_page` return `true` when they
+remove a child from the parent. That is the signal for
+`rebalance_after_leaf_delete` to move one level upward and repair the parent if
+it is now underoccupied.
+
+### Empty interior root
+
+If propagation removes the final separator from the root, the root is replaced
+by its sole child. This can cascade only one level per call to
+`shrink_root_if_empty`, but delete calls it both during upward rebalance and
+again after separator refresh.
+
+### Oversized keys and values
+
+Leaf values and interior separator keys can overflow. Comparisons often compare
+the inline prefix first and only materialize overflow suffixes when necessary.
+During delete repair, page rebuilds materialize complete logical keys and values
+before choosing split points and writing new cells.
+
+### Page rewrite failure
+
+Interior rewrites are staged into a local `page_image` and assigned to the cache
+page only after preparation succeeds. This protects the page bytes from partial
+rewrites. The current overflow allocation path is still append-only, so overflow
+pages allocated during a failed rewrite attempt are not reclaimed.
+
+## Mental Model
+
+The delete implementation is best read as a rebuild-based algorithm:
+
+1. Remove the exact leaf cell locally.
+2. If occupancy is still acceptable, only refresh separators.
+3. If a page is underoccupied, materialize its cells or child entries together
+   with a sibling.
+4. Prefer redistribution that leaves both pages healthy.
+5. If possible, merge into one page and remove the detached child from the
+   parent.
+6. Propagate only when a merge reduced the parent child count.
+7. Recompute separators from subtree max keys rather than patching individual
+   separator bytes in place.
+
+This keeps the balancing logic simple and robust at the cost of extra
+materialization and, until free-list support exists, append-only overflow/page
+allocation during rewrites.

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -20,6 +20,8 @@ use crate::{
 const LEAF_CELL_PREFIX_SIZE: usize = 2 + 8 + 2 + 2;
 const INTERIOR_CELL_PREFIX_SIZE: usize = 2 + 8 + 8 + 2;
 
+type MaterializedLeafCell = (Box<[u8]>, Box<[u8]>);
+
 /// Outcome of trying to position a scan within or beyond one leaf page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LeafSeek {
@@ -481,7 +483,7 @@ fn materialize_leaf_cell(
     first_overflow_page_id: PageId,
     key_len: usize,
     value_len: usize,
-) -> StorageResult<(Box<[u8]>, Box<[u8]>)> {
+) -> StorageResult<MaterializedLeafCell> {
     let mut payload = materialize_payload(
         page_cache,
         page_id,

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -359,6 +359,22 @@ struct InteriorSplitCell {
     key: Vec<u8>,
 }
 
+/// Child pointer plus the maximum key reachable through that child.
+#[derive(Debug, Clone)]
+struct ChildEntry {
+    page_id: PageId,
+    max_key: Option<Vec<u8>>,
+}
+
+/// Fully prepared interior cell payload for an atomic page rewrite.
+#[derive(Debug, Clone)]
+struct PreparedInteriorCell {
+    left_child: PageId,
+    key_len: usize,
+    first_overflow_page_id: Option<PageId>,
+    inline_payload: Vec<u8>,
+}
+
 impl LeafSplitCell {
     /// Returns the key length this cell will occupy after the split.
     fn key_len(&self) -> usize {
@@ -1068,6 +1084,789 @@ impl TreeCursor {
         )?)
     }
 
+    fn missing_child_max_key_error(page_id: PageId) -> StorageError {
+        StorageError::Corruption(CorruptionError {
+            component: CorruptionComponent::InteriorPage,
+            page_id: Some(page_id),
+            kind: CorruptionKind::CellLengthOutOfBounds,
+        })
+    }
+
+    /// Returns the previous and next sibling pointers for a leaf page.
+    fn read_leaf_page_links(
+        &self,
+        page_id: PageId,
+    ) -> StorageResult<(Option<PageId>, Option<PageId>)> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
+        Ok((leaf.prev_page_id(), leaf.next_page_id()))
+    }
+
+    /// Returns the previous and next sibling pointers for an interior page.
+    fn read_interior_page_links(
+        &self,
+        page_id: PageId,
+    ) -> StorageResult<(Option<PageId>, Option<PageId>)> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        let interior = RawInterior::<Read<'_>>::open(page.page())?;
+        Ok((interior.prev_page_id(), interior.next_page_id()))
+    }
+
+    /// Materializes all leaf cells in slot order for rebalance planning.
+    fn read_leaf_cells(&self, page_id: PageId) -> StorageResult<Vec<LeafSplitCell>> {
+        let slot_count = self.raw_leaf_slot_count(page_id)?;
+        let mut cells = Vec::with_capacity(slot_count as usize);
+        for slot_index in 0..slot_count {
+            let (key, value) = read_leaf_cell(&self.page_cache, page_id, slot_index)?;
+            cells.push(LeafSplitCell { key, value });
+        }
+        Ok(cells)
+    }
+
+    /// Returns the largest key in a leaf page, or `None` when the page is empty.
+    fn read_leaf_max_key(&self, page_id: PageId) -> StorageResult<Option<Vec<u8>>> {
+        let slot_count = self.raw_leaf_slot_count(page_id)?;
+        if slot_count == 0 {
+            return Ok(None);
+        }
+
+        read_leaf_cell(&self.page_cache, page_id, slot_count - 1).map(|(key, _)| Some(key))
+    }
+
+    /// Reads child page ids from an interior page in logical left-to-right order.
+    fn read_interior_child_page_ids(&self, page_id: PageId) -> StorageResult<Vec<PageId>> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        let interior = RawInterior::<Read<'_>>::open(page.page())?;
+        let mut children = Vec::with_capacity(interior.slot_count() as usize + 1);
+        for slot_index in 0..interior.slot_count() {
+            let (left_child, _, _, _) = interior.cell_payload_parts(slot_index)?;
+            children.push(left_child);
+        }
+        children.push(interior.rightmost_child());
+        Ok(children)
+    }
+
+    /// Returns whether `child_page_id` is still linked from `parent_page_id`.
+    fn interior_page_has_child(
+        &self,
+        parent_page_id: PageId,
+        child_page_id: PageId,
+    ) -> StorageResult<bool> {
+        Ok(self.read_interior_child_page_ids(parent_page_id)?.contains(&child_page_id))
+    }
+
+    /// Returns the largest key reachable from the subtree rooted at `page_id`.
+    fn subtree_max_key(&self, page_id: PageId) -> StorageResult<Option<Vec<u8>>> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let next = {
+            let page = pin.read()?;
+            match read_page_kind(page.page(), page_id)? {
+                PageKind::RawLeaf => {
+                    drop(page);
+                    drop(pin);
+                    return self.read_leaf_max_key(page_id);
+                }
+                PageKind::RawInterior => {
+                    let interior = RawInterior::<Read<'_>>::open(page.page())?;
+                    interior.rightmost_child()
+                }
+            }
+        };
+        drop(pin);
+        self.subtree_max_key(next)
+    }
+
+    /// Collects ordered child entries for an interior page with refreshed max keys.
+    fn read_interior_child_entries(&self, page_id: PageId) -> StorageResult<Vec<ChildEntry>> {
+        let child_page_ids = self.read_interior_child_page_ids(page_id)?;
+        let mut children = Vec::with_capacity(child_page_ids.len());
+        for child_page_id in child_page_ids {
+            children.push(ChildEntry {
+                page_id: child_page_id,
+                max_key: self.subtree_max_key(child_page_id)?,
+            });
+        }
+        Ok(children)
+    }
+
+    /// Locates a child page within its parent's ordered child list.
+    fn child_index_in_parent(
+        &self,
+        parent_page_id: PageId,
+        child_page_id: PageId,
+    ) -> StorageResult<usize> {
+        self.read_interior_child_page_ids(parent_page_id)?
+            .iter()
+            .position(|&candidate| candidate == child_page_id)
+            .ok_or({
+                StorageError::Corruption(CorruptionError {
+                    component: CorruptionComponent::InteriorPage,
+                    page_id: Some(parent_page_id),
+                    kind: CorruptionKind::CellLengthOutOfBounds,
+                })
+            })
+    }
+
+    /// Reinitializes a leaf page with `cells` and updated sibling links.
+    fn rewrite_leaf_page(
+        &self,
+        page_id: PageId,
+        cells: &[LeafSplitCell],
+        prev_page_id: Option<PageId>,
+        next_page_id: Option<PageId>,
+    ) -> StorageResult<()> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let mut guard = pin.write()?;
+        let mut leaf = RawLeaf::<Write<'_>>::initialize(guard.page_mut());
+        leaf.set_prev_page_id(prev_page_id);
+        leaf.set_next_page_id(next_page_id);
+        for cell in cells {
+            let slot_index = leaf.slot_count();
+            self.insert_leaf_payload_at(&mut leaf, slot_index, cell.key(), cell.value())?;
+        }
+        Ok(())
+    }
+
+    /// Reinitializes an interior page from ordered `children` and sibling links.
+    fn rewrite_interior_page(
+        &self,
+        page_id: PageId,
+        children: &[ChildEntry],
+        prev_page_id: Option<PageId>,
+        next_page_id: Option<PageId>,
+    ) -> StorageResult<()> {
+        let rightmost_child = children.last().ok_or({
+            StorageError::Corruption(CorruptionError {
+                component: CorruptionComponent::InteriorPage,
+                page_id: Some(page_id),
+                kind: CorruptionKind::CellLengthOutOfBounds,
+            })
+        })?;
+        let mut used_bytes = PageKind::RawInterior.header_size()
+            + (children.len() - 1) * page::format::SLOT_ENTRY_SIZE;
+        for child in &children[..children.len() - 1] {
+            let key = child
+                .max_key
+                .as_deref()
+                .ok_or_else(|| Self::missing_child_max_key_error(page_id))?;
+            used_bytes += self.interior_cell_local_size(key)?;
+        }
+        if used_bytes > page::format::USABLE_SPACE_END {
+            return Err(PageError::PageFull {
+                needed: used_bytes,
+                available: page::format::USABLE_SPACE_END,
+            }
+            .into());
+        }
+
+        let mut prepared_cells = Vec::with_capacity(children.len() - 1);
+        for child in &children[..children.len() - 1] {
+            let key = child
+                .max_key
+                .as_deref()
+                .ok_or_else(|| Self::missing_child_max_key_error(page_id))?;
+            let (first_overflow_page_id, inline_payload) = self.payload_storage_parts(key)?;
+            prepared_cells.push(PreparedInteriorCell {
+                left_child: child.page_id,
+                key_len: key.len(),
+                first_overflow_page_id,
+                inline_payload,
+            });
+        }
+
+        let mut page_image = [0; PAGE_SIZE];
+        {
+            let mut interior = RawInterior::<Write<'_>>::initialize_with_rightmost(
+                &mut page_image,
+                rightmost_child.page_id,
+            );
+            interior.set_prev_page_id(prev_page_id);
+            interior.set_next_page_id(next_page_id);
+            for cell in &prepared_cells {
+                let slot_index = interior.slot_count();
+                interior.insert_payload_at(
+                    slot_index,
+                    cell.left_child,
+                    cell.key_len,
+                    cell.first_overflow_page_id,
+                    &cell.inline_payload,
+                )?;
+            }
+        }
+
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let mut guard = pin.write()?;
+        *guard.page_mut() = page_image;
+        Ok(())
+    }
+
+    /// Returns whether an interior page already matches refreshed child maxima.
+    fn interior_page_matches_children(
+        &self,
+        page_id: PageId,
+        children: &[ChildEntry],
+    ) -> StorageResult<bool> {
+        let current_children = self.read_interior_child_page_ids(page_id)?;
+        if current_children.len() != children.len()
+            || current_children
+                .iter()
+                .zip(children)
+                .any(|(&current, desired)| current != desired.page_id)
+        {
+            return Ok(false);
+        }
+
+        for (slot_index, child) in children[..children.len() - 1].iter().enumerate() {
+            let expected_key = child
+                .max_key
+                .as_deref()
+                .ok_or_else(|| Self::missing_child_max_key_error(page_id))?;
+            let (_, actual_key) = read_interior_cell(&self.page_cache, page_id, slot_index as u16)?;
+            if actual_key != expected_key {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Refreshes one interior page only when one of its separators changed.
+    fn refresh_interior_page_separators(&self, page_id: PageId) -> StorageResult<()> {
+        let children = self.read_interior_child_entries(page_id)?;
+        if self.interior_page_matches_children(page_id, &children)? {
+            return Ok(());
+        }
+
+        let (prev_page_id, next_page_id) = self.read_interior_page_links(page_id)?;
+        self.rewrite_interior_page(page_id, &children, prev_page_id, next_page_id)
+    }
+
+    /// Returns whether a leaf page is below the minimum occupancy target.
+    fn leaf_page_underoccupied(&self, page_id: PageId) -> StorageResult<bool> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        let leaf = RawLeaf::<Read<'_>>::open(page.page())?;
+        Ok(leaf.is_underoccupied()?)
+    }
+
+    /// Returns whether an interior page is below the minimum occupancy target.
+    fn interior_page_underoccupied(&self, page_id: PageId) -> StorageResult<bool> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        let interior = RawInterior::<Read<'_>>::open(page.page())?;
+        Ok(interior.is_underoccupied()?)
+    }
+
+    /// Returns whether a leaf rebuilt from `cells` would be underoccupied.
+    fn leaf_cells_underoccupied(cells: &[LeafSplitCell]) -> bool {
+        let occupied_variable_bytes = cells.len() * page::format::SLOT_ENTRY_SIZE
+            + cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
+        let usable_variable_bytes =
+            page::format::USABLE_SPACE_END - PageKind::RawLeaf.header_size();
+        occupied_variable_bytes * 2 < usable_variable_bytes
+    }
+
+    /// Chooses a split index that keeps both leaf siblings fit and occupied.
+    fn choose_leaf_rebalance_split(cells: &[LeafSplitCell]) -> Option<usize> {
+        let total_cell_len = cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
+        let mut left_cell_len = 0;
+        let mut best = None;
+
+        for split_index in 1..cells.len() {
+            left_cell_len += cells[split_index - 1].encoded_size();
+            if !Self::leaf_cells_fit(&cells[..split_index])
+                || !Self::leaf_cells_fit(&cells[split_index..])
+                || Self::leaf_cells_underoccupied(&cells[..split_index])
+                || Self::leaf_cells_underoccupied(&cells[split_index..])
+            {
+                continue;
+            }
+
+            let right_cell_len = total_cell_len - left_cell_len;
+            let imbalance = left_cell_len.abs_diff(right_cell_len);
+            if best.is_none_or(|(best_imbalance, _)| imbalance < best_imbalance) {
+                best = Some((imbalance, split_index));
+            }
+        }
+
+        best.map(|(_, split_index)| split_index)
+    }
+
+    /// Chooses a split index that keeps both leaf siblings within page capacity.
+    fn choose_leaf_fitting_split(cells: &[LeafSplitCell]) -> Option<usize> {
+        let total_cell_len = cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
+        let mut left_cell_len = 0;
+        let mut best = None;
+
+        for split_index in 1..cells.len() {
+            left_cell_len += cells[split_index - 1].encoded_size();
+            if !Self::leaf_cells_fit(&cells[..split_index])
+                || !Self::leaf_cells_fit(&cells[split_index..])
+            {
+                continue;
+            }
+
+            let right_cell_len = total_cell_len - left_cell_len;
+            let imbalance = left_cell_len.abs_diff(right_cell_len);
+            if best.is_none_or(|(best_imbalance, _)| imbalance < best_imbalance) {
+                best = Some((imbalance, split_index));
+            }
+        }
+
+        best.map(|(_, split_index)| split_index)
+    }
+
+    /// Returns whether `children` can be encoded in one interior page.
+    fn interior_children_fit(children: &[ChildEntry]) -> bool {
+        if children.is_empty() {
+            return false;
+        }
+        let mut cell_bytes = 0;
+        for child in &children[..children.len() - 1] {
+            let Some(key) = child.max_key.as_ref() else {
+                return false;
+            };
+            cell_bytes += INTERIOR_CELL_PREFIX_SIZE + local_payload_len(key.len());
+        }
+        let used_bytes = PageKind::RawInterior.header_size()
+            + (children.len() - 1) * page::format::SLOT_ENTRY_SIZE
+            + cell_bytes;
+        used_bytes <= page::format::USABLE_SPACE_END
+    }
+
+    /// Returns whether an interior page rebuilt from `children` would be underoccupied.
+    fn interior_children_underoccupied(children: &[ChildEntry]) -> bool {
+        let mut cell_bytes = 0;
+        for child in &children[..children.len().saturating_sub(1)] {
+            let Some(key) = child.max_key.as_ref() else {
+                return true;
+            };
+            cell_bytes += INTERIOR_CELL_PREFIX_SIZE + local_payload_len(key.len());
+        }
+        let occupied_variable_bytes =
+            children.len().saturating_sub(1) * page::format::SLOT_ENTRY_SIZE + cell_bytes;
+        let usable_variable_bytes =
+            page::format::USABLE_SPACE_END - PageKind::RawInterior.header_size();
+        occupied_variable_bytes * 2 < usable_variable_bytes
+    }
+
+    /// Chooses a split index that keeps both interior siblings fit and occupied.
+    fn choose_interior_rebalance_split(children: &[ChildEntry]) -> Option<usize> {
+        let mut best = None;
+        for split_index in 1..children.len() {
+            let left = &children[..split_index];
+            let right = &children[split_index..];
+            if !Self::interior_children_fit(left)
+                || !Self::interior_children_fit(right)
+                || Self::interior_children_underoccupied(left)
+                || Self::interior_children_underoccupied(right)
+            {
+                continue;
+            }
+
+            let imbalance = split_index.abs_diff(children.len() - split_index);
+            if best.is_none_or(|(best_imbalance, _)| imbalance < best_imbalance) {
+                best = Some((imbalance, split_index));
+            }
+        }
+        best.map(|(_, split_index)| split_index)
+    }
+
+    /// Chooses a split index that keeps both interior siblings within page capacity.
+    fn choose_interior_fitting_split(children: &[ChildEntry]) -> Option<usize> {
+        let mut best = None;
+        for split_index in 1..children.len() {
+            let left = &children[..split_index];
+            let right = &children[split_index..];
+            if !Self::interior_children_fit(left) || !Self::interior_children_fit(right) {
+                continue;
+            }
+
+            let imbalance = split_index.abs_diff(children.len() - split_index);
+            if best.is_none_or(|(best_imbalance, _)| imbalance < best_imbalance) {
+                best = Some((imbalance, split_index));
+            }
+        }
+        best.map(|(_, split_index)| split_index)
+    }
+
+    /// Updates the previous-sibling link for a leaf page.
+    fn set_leaf_prev_page_id(
+        &self,
+        page_id: PageId,
+        prev_page_id: Option<PageId>,
+    ) -> StorageResult<()> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let mut guard = pin.write()?;
+        let mut leaf = RawLeaf::<Write<'_>>::open(guard.page_mut())?;
+        leaf.set_prev_page_id(prev_page_id);
+        Ok(())
+    }
+
+    /// Updates the previous-sibling link for an interior page.
+    fn set_interior_prev_page_id(
+        &self,
+        page_id: PageId,
+        prev_page_id: Option<PageId>,
+    ) -> StorageResult<()> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let mut guard = pin.write()?;
+        let mut interior = RawInterior::<Write<'_>>::open(guard.page_mut())?;
+        interior.set_prev_page_id(prev_page_id);
+        Ok(())
+    }
+
+    /// Removes `child_page_id` from `parent_page_id` and rewrites the parent.
+    fn remove_child_from_parent(
+        &self,
+        parent_page_id: PageId,
+        child_page_id: PageId,
+    ) -> StorageResult<()> {
+        let mut children = self.read_interior_child_entries(parent_page_id)?;
+        let child_index =
+            children.iter().position(|child| child.page_id == child_page_id).ok_or({
+                StorageError::Corruption(CorruptionError {
+                    component: CorruptionComponent::InteriorPage,
+                    page_id: Some(parent_page_id),
+                    kind: CorruptionKind::CellLengthOutOfBounds,
+                })
+            })?;
+        children.remove(child_index);
+        let (prev_page_id, next_page_id) = self.read_interior_page_links(parent_page_id)?;
+        self.rewrite_interior_page(parent_page_id, &children, prev_page_id, next_page_id)
+    }
+
+    /// Rewrites adjacent leaf siblings after redistributing their combined cells.
+    fn redistribute_leaf_pair(
+        &self,
+        left_page_id: PageId,
+        right_page_id: PageId,
+        cells: &[LeafSplitCell],
+        split_index: usize,
+    ) -> StorageResult<()> {
+        let (left_prev_page_id, _) = self.read_leaf_page_links(left_page_id)?;
+        let (_, right_next_page_id) = self.read_leaf_page_links(right_page_id)?;
+        self.rewrite_leaf_page(
+            left_page_id,
+            &cells[..split_index],
+            left_prev_page_id,
+            Some(right_page_id),
+        )?;
+        self.rewrite_leaf_page(
+            right_page_id,
+            &cells[split_index..],
+            Some(left_page_id),
+            right_next_page_id,
+        )
+    }
+
+    /// Merges two adjacent leaf pages into `survivor_page_id`.
+    fn merge_leaf_pages(
+        &self,
+        survivor_page_id: PageId,
+        removed_page_id: PageId,
+        cells: &[LeafSplitCell],
+    ) -> StorageResult<()> {
+        let (survivor_prev_page_id, _) = self.read_leaf_page_links(survivor_page_id)?;
+        let (_, removed_next_page_id) = self.read_leaf_page_links(removed_page_id)?;
+        self.rewrite_leaf_page(
+            survivor_page_id,
+            cells,
+            survivor_prev_page_id,
+            removed_next_page_id,
+        )?;
+        if let Some(next_page_id) = removed_next_page_id {
+            self.set_leaf_prev_page_id(next_page_id, Some(survivor_page_id))?;
+        }
+        Ok(())
+    }
+
+    /// Rebalances an underoccupied leaf against siblings.
+    ///
+    /// Returns `true` when a merge removed one child from the parent page.
+    fn rebalance_leaf_page(
+        &mut self,
+        leaf_page_id: PageId,
+        parent_page_id: PageId,
+    ) -> StorageResult<bool> {
+        let child_index = self.child_index_in_parent(parent_page_id, leaf_page_id)?;
+        let parent_children = self.read_interior_child_page_ids(parent_page_id)?;
+
+        if child_index > 0 {
+            let left_page_id = parent_children[child_index - 1];
+            let mut cells = self.read_leaf_cells(left_page_id)?;
+            cells.extend(self.read_leaf_cells(leaf_page_id)?);
+            if let Some(split_index) = Self::choose_leaf_rebalance_split(&cells) {
+                self.redistribute_leaf_pair(left_page_id, leaf_page_id, &cells, split_index)?;
+                return Ok(false);
+            }
+        }
+
+        if child_index + 1 < parent_children.len() {
+            let right_page_id = parent_children[child_index + 1];
+            let mut cells = self.read_leaf_cells(leaf_page_id)?;
+            cells.extend(self.read_leaf_cells(right_page_id)?);
+            if let Some(split_index) = Self::choose_leaf_rebalance_split(&cells) {
+                self.redistribute_leaf_pair(leaf_page_id, right_page_id, &cells, split_index)?;
+                return Ok(false);
+            }
+        }
+
+        if child_index > 0 {
+            let left_page_id = parent_children[child_index - 1];
+            let mut cells = self.read_leaf_cells(left_page_id)?;
+            cells.extend(self.read_leaf_cells(leaf_page_id)?);
+            if Self::leaf_cells_fit(&cells) {
+                self.merge_leaf_pages(left_page_id, leaf_page_id, &cells)?;
+                self.remove_child_from_parent(parent_page_id, leaf_page_id)?;
+                self.set_page_state(left_page_id);
+                return Ok(true);
+            }
+            if let Some(split_index) = Self::choose_leaf_fitting_split(&cells) {
+                self.redistribute_leaf_pair(left_page_id, leaf_page_id, &cells, split_index)?;
+                return Ok(false);
+            }
+        }
+
+        if child_index + 1 < parent_children.len() {
+            let right_page_id = parent_children[child_index + 1];
+            let mut cells = self.read_leaf_cells(leaf_page_id)?;
+            cells.extend(self.read_leaf_cells(right_page_id)?);
+            if Self::leaf_cells_fit(&cells) {
+                self.merge_leaf_pages(leaf_page_id, right_page_id, &cells)?;
+                self.remove_child_from_parent(parent_page_id, right_page_id)?;
+                self.set_page_state(leaf_page_id);
+                return Ok(true);
+            }
+            if let Some(split_index) = Self::choose_leaf_fitting_split(&cells) {
+                self.redistribute_leaf_pair(leaf_page_id, right_page_id, &cells, split_index)?;
+                return Ok(false);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Rewrites adjacent interior siblings after redistributing their children.
+    fn redistribute_interior_pair(
+        &self,
+        left_page_id: PageId,
+        right_page_id: PageId,
+        children: &[ChildEntry],
+        split_index: usize,
+    ) -> StorageResult<()> {
+        let (left_prev_page_id, _) = self.read_interior_page_links(left_page_id)?;
+        let (_, right_next_page_id) = self.read_interior_page_links(right_page_id)?;
+        self.rewrite_interior_page(
+            left_page_id,
+            &children[..split_index],
+            left_prev_page_id,
+            Some(right_page_id),
+        )?;
+        self.rewrite_interior_page(
+            right_page_id,
+            &children[split_index..],
+            Some(left_page_id),
+            right_next_page_id,
+        )
+    }
+
+    /// Merges two adjacent interior pages into `survivor_page_id`.
+    fn merge_interior_pages(
+        &self,
+        survivor_page_id: PageId,
+        removed_page_id: PageId,
+        children: &[ChildEntry],
+    ) -> StorageResult<()> {
+        let (survivor_prev_page_id, _) = self.read_interior_page_links(survivor_page_id)?;
+        let (_, removed_next_page_id) = self.read_interior_page_links(removed_page_id)?;
+        self.rewrite_interior_page(
+            survivor_page_id,
+            children,
+            survivor_prev_page_id,
+            removed_next_page_id,
+        )?;
+        if let Some(next_page_id) = removed_next_page_id {
+            self.set_interior_prev_page_id(next_page_id, Some(survivor_page_id))?;
+        }
+        Ok(())
+    }
+
+    /// Rebalances an underoccupied interior page against siblings.
+    ///
+    /// Returns `true` when a merge removed one child from the parent page.
+    fn rebalance_interior_page(
+        &self,
+        interior_page_id: PageId,
+        parent_page_id: PageId,
+    ) -> StorageResult<bool> {
+        let child_index = self.child_index_in_parent(parent_page_id, interior_page_id)?;
+        let parent_children = self.read_interior_child_page_ids(parent_page_id)?;
+
+        if child_index > 0 {
+            let left_page_id = parent_children[child_index - 1];
+            let mut children = self.read_interior_child_entries(left_page_id)?;
+            children.extend(self.read_interior_child_entries(interior_page_id)?);
+            if let Some(split_index) = Self::choose_interior_rebalance_split(&children) {
+                self.redistribute_interior_pair(
+                    left_page_id,
+                    interior_page_id,
+                    &children,
+                    split_index,
+                )?;
+                return Ok(false);
+            }
+        }
+
+        if child_index + 1 < parent_children.len() {
+            let right_page_id = parent_children[child_index + 1];
+            let mut children = self.read_interior_child_entries(interior_page_id)?;
+            children.extend(self.read_interior_child_entries(right_page_id)?);
+            if let Some(split_index) = Self::choose_interior_rebalance_split(&children) {
+                self.redistribute_interior_pair(
+                    interior_page_id,
+                    right_page_id,
+                    &children,
+                    split_index,
+                )?;
+                return Ok(false);
+            }
+        }
+
+        if child_index > 0 {
+            let left_page_id = parent_children[child_index - 1];
+            let mut children = self.read_interior_child_entries(left_page_id)?;
+            children.extend(self.read_interior_child_entries(interior_page_id)?);
+            if Self::interior_children_fit(&children) {
+                self.merge_interior_pages(left_page_id, interior_page_id, &children)?;
+                self.remove_child_from_parent(parent_page_id, interior_page_id)?;
+                return Ok(true);
+            }
+            if let Some(split_index) = Self::choose_interior_fitting_split(&children) {
+                self.redistribute_interior_pair(
+                    left_page_id,
+                    interior_page_id,
+                    &children,
+                    split_index,
+                )?;
+                return Ok(false);
+            }
+        }
+
+        if child_index + 1 < parent_children.len() {
+            let right_page_id = parent_children[child_index + 1];
+            let mut children = self.read_interior_child_entries(interior_page_id)?;
+            children.extend(self.read_interior_child_entries(right_page_id)?);
+            if Self::interior_children_fit(&children) {
+                self.merge_interior_pages(interior_page_id, right_page_id, &children)?;
+                self.remove_child_from_parent(parent_page_id, right_page_id)?;
+                return Ok(true);
+            }
+            if let Some(split_index) = Self::choose_interior_fitting_split(&children) {
+                self.redistribute_interior_pair(
+                    interior_page_id,
+                    right_page_id,
+                    &children,
+                    split_index,
+                )?;
+                return Ok(false);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Replaces an empty interior root with its sole child.
+    fn shrink_root_if_empty(&mut self) -> StorageResult<()> {
+        let root_page_id = self.root_page_id();
+        let pin = self.page_cache.fetch_page(root_page_id)?;
+        let child_page_id = {
+            let page = pin.read()?;
+            match read_page_kind(page.page(), root_page_id)? {
+                PageKind::RawLeaf => return Ok(()),
+                PageKind::RawInterior => {
+                    let interior = RawInterior::<Read<'_>>::open(page.page())?;
+                    if interior.slot_count() > 0 {
+                        return Ok(());
+                    }
+                    interior.rightmost_child()
+                }
+            }
+        };
+        self.root_page_id.set(child_page_id);
+        self.set_page_state(child_page_id);
+        Ok(())
+    }
+
+    /// Refreshes separators along the still-reachable delete path.
+    fn refresh_path_separators(&self, tree_path: &[PathFrame]) -> StorageResult<()> {
+        if tree_path.is_empty() {
+            return Ok(());
+        }
+
+        let mut reachable = Vec::with_capacity(tree_path.len());
+        for (depth, frame) in tree_path.iter().enumerate() {
+            let is_reachable = if depth == 0 {
+                frame.page_id == self.root_page_id()
+            } else {
+                reachable[depth - 1]
+                    && self.interior_page_has_child(tree_path[depth - 1].page_id, frame.page_id)?
+            };
+            reachable.push(is_reachable);
+        }
+
+        for (frame, is_reachable) in tree_path.iter().zip(reachable).rev() {
+            if is_reachable {
+                self.refresh_interior_page_separators(frame.page_id)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Runs post-delete rebalancing from the modified leaf toward the root.
+    fn rebalance_after_leaf_delete(
+        &mut self,
+        leaf_page_id: PageId,
+        tree_path: &[PathFrame],
+    ) -> StorageResult<()> {
+        if tree_path.is_empty() {
+            return Ok(());
+        }
+        if !self.leaf_page_underoccupied(leaf_page_id)? {
+            return Ok(());
+        }
+
+        let mut depth = tree_path.len() - 1;
+        let parent_page_id = tree_path[depth].page_id;
+        if !self.rebalance_leaf_page(leaf_page_id, parent_page_id)? {
+            return Ok(());
+        }
+
+        loop {
+            let page_id = tree_path[depth].page_id;
+            if page_id == self.root_page_id() {
+                self.shrink_root_if_empty()?;
+                return Ok(());
+            }
+            if !self.interior_page_underoccupied(page_id)? {
+                return Ok(());
+            }
+            if depth == 0 {
+                return Ok(());
+            }
+
+            let parent_page_id = tree_path[depth - 1].page_id;
+            if !self.rebalance_interior_page(page_id, parent_page_id)? {
+                return Ok(());
+            }
+            depth -= 1;
+        }
+    }
+
     /// Inserts a new raw key/value record into the tree.
     pub fn insert(&mut self, key: &[u8], value: &[u8]) -> StorageResult<()> {
         let (leaf_page_id, tree_path) = self.leaf_page_path_for_key(key)?;
@@ -1106,9 +1905,19 @@ impl TreeCursor {
 
     /// Deletes the record identified by `key`.
     pub fn delete(&mut self, key: &[u8]) -> StorageResult<()> {
-        let _ = &self.page_cache;
-        let _ = key;
-        todo!("tree delete is not implemented yet")
+        let (leaf_page_id, tree_path) = self.leaf_page_path_for_key(key)?;
+        {
+            let leaf_pin_guard = self.page_cache.fetch_page(leaf_page_id)?;
+            let mut leaf_guard = leaf_pin_guard.write()?;
+            let mut page = RawLeaf::<Write<'_>>::open(leaf_guard.page_mut())?;
+            page.delete(key)?;
+        }
+
+        self.set_page_state(leaf_page_id);
+        self.rebalance_after_leaf_delete(leaf_page_id, &tree_path)?;
+        self.refresh_path_separators(&tree_path)?;
+        self.shrink_root_if_empty()?;
+        Ok(())
     }
 
     /// Positions the cursor on the first record whose key is greater than or
@@ -1637,6 +2446,7 @@ mod tests {
 
     use super::*;
     use crate::disk_manager::DiskManager;
+    use crate::error::LimitExceededError;
 
     const KEY_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=192;
     const VALUE_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=PAGE_SIZE * 3;

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -2453,6 +2453,7 @@ mod tests {
     use super::*;
     use crate::disk_manager::DiskManager;
     use crate::error::LimitExceededError;
+    use crate::memory_page_store::MemoryPageStore;
 
     const KEY_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=192;
     const VALUE_LEN_RANGE: std::ops::RangeInclusive<usize> = 8..=PAGE_SIZE * 3;
@@ -2498,7 +2499,13 @@ mod tests {
         );
     }
 
-    fn tree_height(cursor: &TreeCursor) -> StorageResult<usize> {
+    fn memory_tree_cursor(cache_frames: usize) -> TreeCursor<MemoryPageStore> {
+        let page_cache = PageCache::new(MemoryPageStore::new(), cache_frames).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        TreeCursor::new(page_cache, root_page_id)
+    }
+
+    fn tree_height<S: PageStore>(cursor: &TreeCursor<S>) -> StorageResult<usize> {
         let mut height = 1;
         let mut page_id = cursor.root_page_id();
 
@@ -2532,11 +2539,7 @@ mod tests {
     // proving leaf splits, repeated interior split propagation, exact-key
     // lookups, and forward/backward sorted cursor scans.
     fn random_insert_get_simulation_with_oversized_values_reaches_four_levels() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 256).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(256);
         let mut rng = Rng::with_seed(0xd47a_ba5e_b7ee_2026);
         let mut expected = BTreeMap::new();
         let mut cells = Vec::new();
@@ -2591,11 +2594,7 @@ mod tests {
 
     #[test]
     fn random_insert_delete_simulation_empties_tree_after_random_delete_order() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 256).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(256);
         let mut rng = Rng::with_seed(0x9dd0_c312_741f_2026);
         let mut expected = BTreeMap::new();
 
@@ -2637,11 +2636,7 @@ mod tests {
 
     #[test]
     fn insert_get_supports_oversized_keys_promoted_to_interior_pages() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 256).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(256);
         let mut expected = BTreeMap::new();
 
         for index in 0..48 {
@@ -2662,9 +2657,7 @@ mod tests {
 
     #[test]
     fn failed_interior_rewrite_leaves_page_unchanged() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 16).unwrap();
+        let page_cache = PageCache::new(MemoryPageStore::new(), 16).unwrap();
         let (page_id, pin) = page_cache.new_page().unwrap();
         {
             let mut guard = pin.write().unwrap();
@@ -2731,11 +2724,7 @@ mod tests {
 
     #[test]
     fn inline_record_is_page_resident() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 4).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(4);
 
         cursor.insert(b"alpha", b"value").unwrap();
 
@@ -2746,11 +2735,7 @@ mod tests {
 
     #[test]
     fn overflow_record_is_materialized() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 4).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(4);
         let value = vec![42; PAGE_SIZE];
 
         cursor.insert(b"alpha", &value).unwrap();
@@ -2762,11 +2747,7 @@ mod tests {
 
     #[test]
     fn inline_record_converts_to_owned_snapshot() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 4).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(4);
 
         cursor.insert(b"alpha", b"value").unwrap();
 
@@ -2781,11 +2762,7 @@ mod tests {
 
     #[test]
     fn binary_search_supports_inline_key_with_overflow_value() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 8).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(8);
         let value = vec![7; PAGE_SIZE];
 
         cursor.insert(b"alpha", b"small").unwrap();
@@ -2799,11 +2776,7 @@ mod tests {
 
     #[test]
     fn binary_search_supports_oversized_key_with_overflow_value() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 16).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(16);
         let key = oversized_key(7);
         let value = vec![11; PAGE_SIZE];
 
@@ -2815,11 +2788,7 @@ mod tests {
 
     #[test]
     fn binary_search_supports_oversized_interior_separator_keys() {
-        let file = NamedTempFile::new().unwrap();
-        let disk_manager = DiskManager::new(file.path()).unwrap();
-        let page_cache = PageCache::new(disk_manager, 256).unwrap();
-        let root_page_id = initialize_empty_root(&page_cache).unwrap();
-        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut cursor = memory_tree_cursor(256);
         let mut expected = BTreeMap::new();
 
         for index in 0..48 {
@@ -2837,7 +2806,11 @@ mod tests {
         }
     }
 
-    fn assert_record_matches(record: &Record, expected_key: &[u8], expected_value: &[u8]) {
+    fn assert_record_matches<S: PageStore>(
+        record: &Record<S>,
+        expected_key: &[u8],
+        expected_value: &[u8],
+    ) {
         record
             .with_key_value(|actual_key, actual_value| {
                 assert_eq!(actual_key, expected_key);
@@ -2857,7 +2830,10 @@ mod tests {
         });
     }
 
-    fn assert_forward_scan_matches(cursor: &mut TreeCursor, expected: &BTreeMap<Vec<u8>, Vec<u8>>) {
+    fn assert_forward_scan_matches<S: PageStore>(
+        cursor: &mut TreeCursor<S>,
+        expected: &BTreeMap<Vec<u8>, Vec<u8>>,
+    ) {
         assert!(cursor.seek_to_first().unwrap(), "tree should not be empty");
 
         let mut expected_entries = expected.iter();
@@ -2876,7 +2852,10 @@ mod tests {
         assert_eq!(scanned, expected.len());
     }
 
-    fn assert_reverse_scan_matches(cursor: &mut TreeCursor, expected: &BTreeMap<Vec<u8>, Vec<u8>>) {
+    fn assert_reverse_scan_matches<S: PageStore>(
+        cursor: &mut TreeCursor<S>,
+        expected: &BTreeMap<Vec<u8>, Vec<u8>>,
+    ) {
         let (last_key, _) = expected.iter().next_back().unwrap();
         let last_record = cursor.get(last_key).unwrap().expect("last key should be present");
 

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -8,6 +8,7 @@ use std::{cell::Cell, cmp::Ordering, fmt, ops::Range, rc::Rc};
 
 use crate::{
     PAGE_SIZE, PageId,
+    disk_manager::DiskManager,
     error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
     overflow,
     page::{
@@ -15,6 +16,7 @@ use crate::{
         format::{KIND_OFFSET, MAX_INLINE_OVERFLOW_PAYLOAD_BYTES, PageKind},
     },
     page_cache::{PageCache, PageWriteGuard, PinGuard},
+    page_store::PageStore,
 };
 
 const LEAF_CELL_PREFIX_SIZE: usize = 2 + 8 + 2 + 2;
@@ -44,9 +46,9 @@ enum ScanDirection {
 
 impl ScanDirection {
     /// Descends from `start_page_id` to the leaf at the edge implied by `self`.
-    fn descend_to_edge_leaf(
+    fn descend_to_edge_leaf<S: PageStore>(
         self,
-        cursor: &TreeCursor,
+        cursor: &TreeCursor<S>,
         start_page_id: PageId,
     ) -> StorageResult<PageId> {
         match self {
@@ -106,8 +108,8 @@ impl ScanDirection {
     }
 }
 
-enum RecordStorage {
-    PageResident { pin: PinGuard, key_range: Range<usize>, value_range: Range<usize> },
+enum RecordStorage<S: PageStore = DiskManager> {
+    PageResident { pin: PinGuard<S>, key_range: Range<usize>, value_range: Range<usize> },
     Materialized { key: Box<[u8]>, value: Box<[u8]> },
 }
 
@@ -118,10 +120,10 @@ enum RecordStorage {
 /// callbacks. Records for cells with overflow payload are materialized into
 /// fixed-size heap allocations. Use [`OwnedRecord`] when a stable snapshot is
 /// needed across later tree mutations.
-pub struct Record {
+pub struct Record<S: PageStore = DiskManager> {
     page_id: PageId,
     slot_index: u16,
-    storage: RecordStorage,
+    storage: RecordStorage<S>,
 }
 
 /// Stable, owned raw record snapshot.
@@ -158,10 +160,10 @@ impl<'a> RecordView<'a> {
     }
 }
 
-impl Record {
+impl<S: PageStore> Record<S> {
     /// Builds a record view from one raw leaf-page slot.
     pub(crate) fn new(
-        page_cache: &PageCache,
+        page_cache: &PageCache<S>,
         page_id: PageId,
         slot_index: u16,
     ) -> StorageResult<Self> {
@@ -282,7 +284,7 @@ impl fmt::Debug for OwnedRecord {
     }
 }
 
-impl fmt::Debug for Record {
+impl<S: PageStore> fmt::Debug for Record<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Record")
             .field("page_id", &self.page_id)
@@ -312,8 +314,8 @@ pub enum CursorState {
 
 /// Public handle to a single raw B+-tree rooted at `root_page_id`.
 #[derive(Clone)]
-pub struct TreeCursor {
-    page_cache: PageCache,
+pub struct TreeCursor<S: PageStore = DiskManager> {
+    page_cache: PageCache<S>,
     root_page_id: Rc<Cell<PageId>>,
     state: CursorState,
 }
@@ -447,8 +449,8 @@ fn cell_corruption(page_id: PageId, kind: CorruptionKind) -> StorageError {
     })
 }
 
-fn materialize_payload(
-    page_cache: &PageCache,
+fn materialize_payload<S: PageStore>(
+    page_cache: &PageCache<S>,
     page_id: PageId,
     inline_payload: Vec<u8>,
     first_overflow_page_id: Option<PageId>,
@@ -476,8 +478,8 @@ fn materialize_payload(
     Ok(payload)
 }
 
-fn materialize_leaf_cell(
-    page_cache: &PageCache,
+fn materialize_leaf_cell<S: PageStore>(
+    page_cache: &PageCache<S>,
     page_id: PageId,
     inline_payload: Vec<u8>,
     first_overflow_page_id: PageId,
@@ -499,8 +501,8 @@ fn materialize_leaf_cell(
     Ok((payload.into_boxed_slice(), value.into_boxed_slice()))
 }
 
-fn read_leaf_cell(
-    page_cache: &PageCache,
+fn read_leaf_cell<S: PageStore>(
+    page_cache: &PageCache<S>,
     page_id: PageId,
     slot_index: u16,
 ) -> StorageResult<(Vec<u8>, Vec<u8>)> {
@@ -529,8 +531,8 @@ fn read_leaf_cell(
     Ok((key, value))
 }
 
-fn read_interior_cell(
-    page_cache: &PageCache,
+fn read_interior_cell<S: PageStore>(
+    page_cache: &PageCache<S>,
     page_id: PageId,
     slot_index: u16,
 ) -> StorageResult<(PageId, Vec<u8>)> {
@@ -579,8 +581,8 @@ fn compare_key_prefix(
     Ok(None)
 }
 
-fn materialize_overflow_key(
-    page_cache: &PageCache,
+fn materialize_overflow_key<S: PageStore>(
+    page_cache: &PageCache<S>,
     page_id: PageId,
     mut inline_key: Vec<u8>,
     first_overflow_page_id: Option<PageId>,
@@ -599,9 +601,9 @@ fn materialize_overflow_key(
     Ok(inline_key)
 }
 
-impl TreeCursor {
+impl<S: PageStore> TreeCursor<S> {
     /// Creates a cursor anchored at `root_page_id` in page-level state.
-    pub(crate) fn new(page_cache: PageCache, root_page_id: PageId) -> Self {
+    pub(crate) fn new(page_cache: PageCache<S>, root_page_id: PageId) -> Self {
         Self {
             page_cache,
             root_page_id: Rc::new(Cell::new(root_page_id)),
@@ -655,7 +657,7 @@ impl TreeCursor {
     }
 
     /// Materializes one record from a positioned raw leaf slot.
-    fn record_at(&self, page_id: PageId, slot_index: u16) -> StorageResult<Record> {
+    fn record_at(&self, page_id: PageId, slot_index: u16) -> StorageResult<Record<S>> {
         Record::new(&self.page_cache, page_id, slot_index)
     }
 
@@ -928,7 +930,7 @@ impl TreeCursor {
         &mut self,
         start_page_id: PageId,
         direction: ScanDirection,
-    ) -> StorageResult<Option<Record>> {
+    ) -> StorageResult<Option<Record<S>>> {
         let mut page_id = start_page_id;
 
         loop {
@@ -955,7 +957,7 @@ impl TreeCursor {
     }
 
     /// Advances or rewinds the cursor by one logical record.
-    fn step_record(&mut self, direction: ScanDirection) -> StorageResult<Option<Record>> {
+    fn step_record(&mut self, direction: ScanDirection) -> StorageResult<Option<Record<S>>> {
         match self.state {
             CursorState::Exhausted => Ok(None),
             CursorState::Page { page_id } => {
@@ -992,7 +994,7 @@ impl TreeCursor {
     ///
     /// The cursor ends on the matching record when found, or on the leaf page
     /// where `key` would be inserted when absent.
-    pub fn get(&mut self, key: &[u8]) -> StorageResult<Option<Record>> {
+    pub fn get(&mut self, key: &[u8]) -> StorageResult<Option<Record<S>>> {
         let page_id = self.leaf_page_for_key(key)?;
         let slot_index = match self.search_leaf_slot(page_id, key)? {
             SearchResult::Found(slot_index) => Some(slot_index),
@@ -1899,7 +1901,7 @@ impl TreeCursor {
     }
 
     /// Replaces the value stored for an existing `key`.
-    pub fn update(&mut self, key: &[u8], value: &[u8]) -> StorageResult<Record> {
+    pub fn update(&mut self, key: &[u8], value: &[u8]) -> StorageResult<Record<S>> {
         let _ = &self.page_cache;
         let _ = (key, value);
         todo!("tree update is not implemented yet")
@@ -1963,7 +1965,7 @@ impl TreeCursor {
     }
 
     /// Reads the currently selected record, if any.
-    pub fn current(&self) -> StorageResult<Option<Record>> {
+    pub fn current(&self) -> StorageResult<Option<Record<S>>> {
         match self.state {
             CursorState::Positioned { page_id, slot_index } => {
                 self.record_at(page_id, slot_index).map(Some)
@@ -1978,7 +1980,7 @@ impl TreeCursor {
     }
 
     /// Advances to the next record in sorted key order.
-    pub fn next_record(&mut self) -> StorageResult<Option<Record>> {
+    pub fn next_record(&mut self) -> StorageResult<Option<Record<S>>> {
         self.step_record(ScanDirection::Forward)
     }
 
@@ -1988,7 +1990,7 @@ impl TreeCursor {
     }
 
     /// Moves to the previous record in sorted key order.
-    pub fn prev_record(&mut self) -> StorageResult<Option<Record>> {
+    pub fn prev_record(&mut self) -> StorageResult<Option<Record<S>>> {
         self.step_record(ScanDirection::Backward)
     }
 
@@ -2384,7 +2386,9 @@ impl TreeCursor {
 }
 
 /// Allocates and initializes a brand-new empty raw root leaf page.
-pub(crate) fn initialize_empty_root(page_cache: &PageCache) -> StorageResult<PageId> {
+pub(crate) fn initialize_empty_root<S: PageStore>(
+    page_cache: &PageCache<S>,
+) -> StorageResult<PageId> {
     let (page_id, pin) = page_cache.new_page()?;
     let mut page = pin.write()?;
     let _ = RawLeaf::<Write<'_>>::initialize(page.page_mut());
@@ -2393,7 +2397,7 @@ pub(crate) fn initialize_empty_root(page_cache: &PageCache) -> StorageResult<Pag
 
 /// Verifies that `root_page_id` names a raw leaf or raw interior page.
 pub(crate) fn validate_root_page(
-    page_cache: &PageCache,
+    page_cache: &PageCache<impl PageStore>,
     root_page_id: PageId,
 ) -> StorageResult<()> {
     let pin = page_cache.fetch_page(root_page_id)?;

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -2583,6 +2583,43 @@ mod tests {
         assert_eq!(expected.len(), cells.len());
     }
 
+    #[test]
+    fn random_insert_delete_simulation_empties_tree_after_random_delete_order() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 256).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut rng = Rng::with_seed(0x9dd0_c312_741f_2026);
+        let mut expected = BTreeMap::new();
+
+        const INSERT_COUNT: usize = 200;
+        for _ in 0..INSERT_COUNT {
+            let (key, value) = random_unique_cell(&mut rng, &expected);
+            assert_supported_cell(&key, &value);
+            cursor.insert(&key, &value).unwrap();
+            expected.insert(key, value);
+        }
+        assert!(!expected.is_empty(), "simulation should create at least one record");
+
+        let mut delete_order: Vec<Vec<u8>> = expected.keys().cloned().collect();
+        let sorted_order = delete_order.clone();
+        rng.shuffle(&mut delete_order);
+        while delete_order == sorted_order {
+            rng.shuffle(&mut delete_order);
+        }
+
+        for key in &delete_order {
+            cursor.delete(key).unwrap();
+        }
+
+        assert!(!cursor.seek_to_first().unwrap(), "tree should be empty after deleting all keys");
+        assert!(cursor.current().unwrap().is_none(), "empty tree cursor should have no current");
+        for key in expected.keys() {
+            assert!(cursor.get(key).unwrap().is_none(), "deleted key should not be found");
+        }
+    }
+
     fn oversized_key(index: u16) -> Vec<u8> {
         let mut key = vec![0; PAGE_SIZE + 256];
         key[..2].copy_from_slice(&index.to_be_bytes());
@@ -2615,6 +2652,75 @@ mod tests {
             assert_record_matches(&record, key, value);
         }
         assert_forward_scan_matches(&mut cursor, &expected);
+    }
+
+    #[test]
+    fn failed_interior_rewrite_leaves_page_unchanged() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 16).unwrap();
+        let (page_id, pin) = page_cache.new_page().unwrap();
+        {
+            let mut guard = pin.write().unwrap();
+            let mut interior =
+                RawInterior::<Write<'_>>::initialize_with_rightmost(guard.page_mut(), 2);
+            interior.insert(b"stable", 0).unwrap();
+        }
+        drop(pin);
+
+        let cursor = TreeCursor::new(page_cache.clone(), page_id);
+        let original_page = {
+            let pin = page_cache.fetch_page(page_id).unwrap();
+            let page = pin.read().unwrap();
+            *page.page()
+        };
+        let children: Vec<_> = (0..16)
+            .map(|index| ChildEntry {
+                page_id: 100 + index,
+                max_key: Some(vec![index as u8; PAGE_SIZE]),
+            })
+            .collect();
+
+        let result = cursor.rewrite_interior_page(page_id, &children, None, None);
+
+        assert!(matches!(
+            result,
+            Err(StorageError::LimitExceeded(LimitExceededError::PageFull { .. }))
+        ));
+        let rewritten_page = {
+            let pin = page_cache.fetch_page(page_id).unwrap();
+            let page = pin.read().unwrap();
+            *page.page()
+        };
+        assert_eq!(rewritten_page, original_page);
+    }
+
+    #[test]
+    fn unchanged_path_separator_refresh_does_not_grow_file() {
+        let file = NamedTempFile::new().unwrap();
+        let disk_manager = DiskManager::new(file.path()).unwrap();
+        let page_cache = PageCache::new(disk_manager, 256).unwrap();
+        let root_page_id = initialize_empty_root(&page_cache).unwrap();
+        let mut cursor = TreeCursor::new(page_cache, root_page_id);
+        let mut expected = BTreeMap::new();
+
+        for index in 0..96 {
+            let key = oversized_key(index);
+            let value = format!("value-{index}").into_bytes();
+            cursor.insert(&key, &value).unwrap();
+            expected.insert(key, value);
+        }
+
+        let key = expected.keys().next().expect("test setup should create records");
+        let (_, tree_path) = cursor.leaf_page_path_for_key(key).unwrap();
+        assert!(!tree_path.is_empty(), "large keys should force interior separators");
+        cursor.refresh_path_separators(&tree_path).unwrap();
+        let file_len_before = file.path().metadata().unwrap().len();
+
+        cursor.refresh_path_separators(&tree_path).unwrap();
+
+        let file_len_after = file.path().metadata().unwrap().len();
+        assert_eq!(file_len_after, file_len_before);
     }
 
     #[test]

--- a/crates/databas_core/src/btree.rs
+++ b/crates/databas_core/src/btree.rs
@@ -8,7 +8,6 @@ use std::{cell::Cell, cmp::Ordering, fmt, ops::Range, rc::Rc};
 
 use crate::{
     PAGE_SIZE, PageId,
-    disk_manager::DiskManager,
     error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
     overflow,
     page::{
@@ -108,7 +107,7 @@ impl ScanDirection {
     }
 }
 
-enum RecordStorage<S: PageStore = DiskManager> {
+enum RecordStorage<S: PageStore> {
     PageResident { pin: PinGuard<S>, key_range: Range<usize>, value_range: Range<usize> },
     Materialized { key: Box<[u8]>, value: Box<[u8]> },
 }
@@ -120,7 +119,7 @@ enum RecordStorage<S: PageStore = DiskManager> {
 /// callbacks. Records for cells with overflow payload are materialized into
 /// fixed-size heap allocations. Use [`OwnedRecord`] when a stable snapshot is
 /// needed across later tree mutations.
-pub struct Record<S: PageStore = DiskManager> {
+pub struct Record<S: PageStore> {
     page_id: PageId,
     slot_index: u16,
     storage: RecordStorage<S>,
@@ -314,7 +313,7 @@ pub enum CursorState {
 
 /// Public handle to a single raw B+-tree rooted at `root_page_id`.
 #[derive(Clone)]
-pub struct TreeCursor<S: PageStore = DiskManager> {
+pub struct TreeCursor<S: PageStore> {
     page_cache: PageCache<S>,
     root_page_id: Rc<Cell<PageId>>,
     state: CursorState,

--- a/crates/databas_core/src/disk_manager.rs
+++ b/crates/databas_core/src/disk_manager.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use crate::{
-    error::{DiskManagerError, DiskManagerResult},
+    error::{DiskManagerError, DiskManagerResult, PageStoreResult},
+    page_store::PageStore,
     {PAGE_SIZE, PageId},
 };
 
@@ -84,6 +85,24 @@ impl DiskManager {
     /// Calculate disk offset for page `page_id`.
     fn page_offset(page_id: PageId) -> u64 {
         page_id * (PAGE_SIZE as u64)
+    }
+}
+
+impl PageStore for DiskManager {
+    fn new_page(&mut self) -> PageStoreResult<PageId> {
+        Self::new_page(self).map_err(Into::into)
+    }
+
+    fn read_page(&mut self, page_id: PageId, buf: &mut [u8; PAGE_SIZE]) -> PageStoreResult<()> {
+        Self::read_page(self, page_id, buf).map_err(Into::into)
+    }
+
+    fn write_page(&mut self, page_id: PageId, buf: &[u8; PAGE_SIZE]) -> PageStoreResult<()> {
+        Self::write_page(self, page_id, buf).map_err(Into::into)
+    }
+
+    fn sync(&mut self) -> PageStoreResult<()> {
+        self.file.sync_all().map_err(Into::into)
     }
 }
 

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -149,7 +149,7 @@ pub(crate) enum DiskManagerError {
 pub(crate) type DiskManagerResult<T> = Result<T, DiskManagerError>;
 
 #[derive(Debug, Error)]
-pub(crate) enum PageStoreError {
+pub enum PageStoreError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("invalid page id: {page_id}")]
@@ -158,7 +158,7 @@ pub(crate) enum PageStoreError {
     InvalidFileSize { size: u64 },
 }
 
-pub(crate) type PageStoreResult<T> = Result<T, PageStoreError>;
+pub type PageStoreResult<T> = Result<T, PageStoreError>;
 
 #[derive(Debug, Error)]
 pub(crate) enum PageCacheError {

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -149,6 +149,18 @@ pub(crate) enum DiskManagerError {
 pub(crate) type DiskManagerResult<T> = Result<T, DiskManagerError>;
 
 #[derive(Debug, Error)]
+pub(crate) enum PageStoreError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid page id: {page_id}")]
+    InvalidPageId { page_id: PageId },
+    #[error("invalid file size (not multiple of page size): {size}")]
+    InvalidFileSize { size: u64 },
+}
+
+pub(crate) type PageStoreResult<T> = Result<T, PageStoreError>;
+
+#[derive(Debug, Error)]
 pub(crate) enum PageCacheError {
     #[error("disk manager error: {0}")]
     Disk(#[from] DiskManagerError),
@@ -182,6 +194,32 @@ impl From<DiskManagerError> for StorageError {
                 page_id: None,
                 kind: CorruptionKind::InvalidFileSize { size, page_size: PAGE_SIZE },
             }),
+        }
+    }
+}
+
+impl From<PageStoreError> for StorageError {
+    fn from(err: PageStoreError) -> Self {
+        match err {
+            PageStoreError::Io(err) => Self::Io(err),
+            PageStoreError::InvalidPageId { page_id } => {
+                Self::InvalidArgument(InvalidArgumentError::InvalidPageId { page_id })
+            }
+            PageStoreError::InvalidFileSize { size } => Self::Corruption(CorruptionError {
+                component: CorruptionComponent::DatabaseFile,
+                page_id: None,
+                kind: CorruptionKind::InvalidFileSize { size, page_size: PAGE_SIZE },
+            }),
+        }
+    }
+}
+
+impl From<DiskManagerError> for PageStoreError {
+    fn from(err: DiskManagerError) -> Self {
+        match err {
+            DiskManagerError::Io(err) => Self::Io(err),
+            DiskManagerError::InvalidPageId { page_id } => Self::InvalidPageId { page_id },
+            DiskManagerError::InvalidFileSize { size } => Self::InvalidFileSize { size },
         }
     }
 }

--- a/crates/databas_core/src/error.rs
+++ b/crates/databas_core/src/error.rs
@@ -162,8 +162,8 @@ pub(crate) type PageStoreResult<T> = Result<T, PageStoreError>;
 
 #[derive(Debug, Error)]
 pub(crate) enum PageCacheError {
-    #[error("disk manager error: {0}")]
-    Disk(#[from] DiskManagerError),
+    #[error("page store error: {0}")]
+    Store(#[from] PageStoreError),
     #[error("no evictable frame available")]
     NoEvictableFrame,
     #[error("page {page_id} is pinned")]
@@ -227,7 +227,7 @@ impl From<DiskManagerError> for PageStoreError {
 impl From<PageCacheError> for StorageError {
     fn from(err: PageCacheError) -> Self {
         match err {
-            PageCacheError::Disk(err) => err.into(),
+            PageCacheError::Store(err) => err.into(),
             PageCacheError::NoEvictableFrame => {
                 Self::LimitExceeded(LimitExceededError::CacheCapacityExhausted)
             }

--- a/crates/databas_core/src/lib.rs
+++ b/crates/databas_core/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod page_store;
 pub mod pager;
 
 pub use btree::{CursorState, OwnedRecord, Record, RecordView, TreeCursor};
+pub use page_store::PageStore;
 pub use pager::{Pager, PagerOptions};
 
 pub(crate) const PAGE_SIZE: usize = 4096;

--- a/crates/databas_core/src/lib.rs
+++ b/crates/databas_core/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod overflow;
 pub(crate) mod page;
 pub(crate) mod page_cache;
 pub(crate) mod page_replacement;
+pub(crate) mod page_store;
 pub mod pager;
 
 pub use btree::{CursorState, OwnedRecord, Record, RecordView, TreeCursor};

--- a/crates/databas_core/src/lib.rs
+++ b/crates/databas_core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod btree;
 pub(crate) mod disk_manager;
 pub mod error;
+pub(crate) mod memory_page_store;
 pub(crate) mod overflow;
 pub(crate) mod page;
 pub(crate) mod page_cache;

--- a/crates/databas_core/src/memory_page_store.rs
+++ b/crates/databas_core/src/memory_page_store.rs
@@ -1,0 +1,95 @@
+use crate::{
+    error::{PageStoreError, PageStoreResult},
+    page_store::PageStore,
+    {PAGE_SIZE, PageId},
+};
+
+/// In-memory page store for tests and volatile database usage.
+pub(crate) struct MemoryPageStore {
+    pages: Vec<[u8; PAGE_SIZE]>,
+}
+
+impl MemoryPageStore {
+    pub(crate) fn new() -> Self {
+        Self { pages: Vec::new() }
+    }
+}
+
+impl Default for MemoryPageStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PageStore for MemoryPageStore {
+    fn new_page(&mut self) -> PageStoreResult<PageId> {
+        let page_id = self.pages.len() as PageId;
+        self.pages.push([0u8; PAGE_SIZE]);
+        Ok(page_id)
+    }
+
+    fn read_page(&mut self, page_id: PageId, buf: &mut [u8; PAGE_SIZE]) -> PageStoreResult<()> {
+        let page =
+            self.pages.get(page_id as usize).ok_or(PageStoreError::InvalidPageId { page_id })?;
+        *buf = *page;
+        Ok(())
+    }
+
+    fn write_page(&mut self, page_id: PageId, buf: &[u8; PAGE_SIZE]) -> PageStoreResult<()> {
+        let page = self
+            .pages
+            .get_mut(page_id as usize)
+            .ok_or(PageStoreError::InvalidPageId { page_id })?;
+        *page = *buf;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_page_allocates_sequential_ids() {
+        let mut store = MemoryPageStore::new();
+        assert_eq!(store.new_page().unwrap(), 0);
+        assert_eq!(store.new_page().unwrap(), 1);
+        assert_eq!(store.new_page().unwrap(), 2);
+    }
+
+    #[test]
+    fn newly_allocated_pages_are_zero_initialized() {
+        let mut store = MemoryPageStore::new();
+        let page_id = store.new_page().unwrap();
+        let mut page = [1u8; PAGE_SIZE];
+        store.read_page(page_id, &mut page).unwrap();
+        assert_eq!(page, [0u8; PAGE_SIZE]);
+    }
+
+    #[test]
+    fn read_and_write_round_trip() {
+        let mut store = MemoryPageStore::new();
+        let page_id = store.new_page().unwrap();
+        let mut write = [0u8; PAGE_SIZE];
+        write[0] = 7;
+        write[PAGE_SIZE - 1] = 9;
+        store.write_page(page_id, &write).unwrap();
+
+        let mut read = [0u8; PAGE_SIZE];
+        store.read_page(page_id, &mut read).unwrap();
+        assert_eq!(read, write);
+    }
+
+    #[test]
+    fn invalid_page_id_returns_error() {
+        let mut store = MemoryPageStore::new();
+        let mut read = [0u8; PAGE_SIZE];
+        let write = [0u8; PAGE_SIZE];
+
+        let read_result = store.read_page(99, &mut read);
+        assert!(matches!(read_result, Err(PageStoreError::InvalidPageId { page_id: 99 })));
+
+        let write_result = store.write_page(99, &write);
+        assert!(matches!(write_result, Err(PageStoreError::InvalidPageId { page_id: 99 })));
+    }
+}

--- a/crates/databas_core/src/overflow.rs
+++ b/crates/databas_core/src/overflow.rs
@@ -5,6 +5,7 @@ use crate::{
     error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
     page::format::{self, NO_OVERFLOW_PAGE_ID, OVERFLOW_NEXT_PAGE_ID_SIZE},
     page_cache::PageCache,
+    page_store::PageStore,
 };
 
 pub(crate) const OVERFLOW_PAYLOAD_SIZE: usize = PAGE_SIZE - OVERFLOW_NEXT_PAGE_ID_SIZE;
@@ -26,7 +27,10 @@ fn overflow_corruption(page_id: Option<PageId>, kind: CorruptionKind) -> Storage
 }
 
 /// Writes `payload` into a newly allocated overflow chain.
-pub(crate) fn write_chain(page_cache: &PageCache, payload: &[u8]) -> StorageResult<Option<PageId>> {
+pub(crate) fn write_chain<S: PageStore>(
+    page_cache: &PageCache<S>,
+    payload: &[u8],
+) -> StorageResult<Option<PageId>> {
     if payload.is_empty() {
         return Ok(None);
     }
@@ -63,7 +67,7 @@ pub(crate) fn write_chain(page_cache: &PageCache, payload: &[u8]) -> StorageResu
 
 /// Reads exactly `expected_len` bytes from an overflow chain.
 pub(crate) fn read_chain(
-    page_cache: &PageCache,
+    page_cache: &PageCache<impl PageStore>,
     first_page_id: PageId,
     expected_len: usize,
 ) -> StorageResult<Vec<u8>> {
@@ -117,7 +121,7 @@ pub(crate) fn read_chain(
 /// the requested bytes. It is used by key comparisons that only need the key
 /// suffix from a larger overflow payload.
 pub(crate) fn read_chain_prefix(
-    page_cache: &PageCache,
+    page_cache: &PageCache<impl PageStore>,
     first_page_id: PageId,
     expected_len: usize,
 ) -> StorageResult<Vec<u8>> {

--- a/crates/databas_core/src/page/core.rs
+++ b/crates/databas_core/src/page/core.rs
@@ -254,6 +254,22 @@ where
         Ok(total)
     }
 
+    pub(crate) fn live_cell_bytes(&self) -> PageResult<usize> {
+        let mut total = 0;
+        for slot_index in 0..self.slot_count() {
+            total += self.cell_len(slot_index)?;
+        }
+        Ok(total)
+    }
+
+    pub fn is_underoccupied(&self) -> PageResult<bool> {
+        let header_size = N::KIND.header_size();
+        let slot_bytes = self.slot_count() as usize * format::SLOT_ENTRY_SIZE;
+        let occupied_variable_bytes = slot_bytes + self.live_cell_bytes()?;
+        let usable_variable_bytes = USABLE_SPACE_END - header_size;
+        Ok(occupied_variable_bytes * 2 < usable_variable_bytes)
+    }
+
     pub(crate) fn slot_directory_end(&self) -> usize {
         N::KIND.header_size() + self.slot_count() as usize * format::SLOT_ENTRY_SIZE
     }

--- a/crates/databas_core/src/page/interior.rs
+++ b/crates/databas_core/src/page/interior.rs
@@ -319,6 +319,14 @@ where
         Ok(slot_index)
     }
 
+    /// Deletes one separator cell by slot index and reclaims its local page space.
+    pub(crate) fn delete_slot(&mut self, slot_index: SlotId) -> PageResult<()> {
+        let cell_offset = self.slot_offset(slot_index)?;
+        let cell_len = self.cell_len(slot_index)?;
+        self.remove_slot(slot_index)?;
+        self.reclaim_space(cell_offset, cell_len)
+    }
+
     /// Rewrites the left-child pointer for an existing separator key.
     pub fn update(&mut self, key: &[u8], left_child: PageId) -> PageResult<()> {
         let slot_index = match self.search(key)? {

--- a/crates/databas_core/src/page/leaf.rs
+++ b/crates/databas_core/src/page/leaf.rs
@@ -317,6 +317,7 @@ where
         let cell_offset = self.slot_offset(slot_index)?;
         let cell_len = self.cell_len(slot_index)?;
         self.remove_slot(slot_index)?;
+        // Do we need to reclaim space after every cell delete?
         self.reclaim_space(cell_offset, cell_len)?;
         Ok(slot_index)
     }
@@ -342,5 +343,40 @@ where
         self.set_slot_offset(slot_index, new_offset)?;
         self.reclaim_space(old_offset, old_len)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::page::Write;
+
+    use super::*;
+
+    #[test]
+    fn test_page_underoccupied() {
+        let mut bytes = [0; PAGE_SIZE];
+        let mut page = Page::<Write<'_>, Leaf>::init(&mut bytes);
+
+        assert!(page.is_underoccupied().unwrap(), "An empty leaf page should be underoccupied.");
+
+        const N: usize = USABLE_SPACE_END / 5;
+        let (k, v) = ([1_u8; N], [2_u8; N]);
+        page.insert(&k, &v).unwrap();
+
+        assert!(
+            page.is_underoccupied().unwrap(),
+            "An empty leaf page should still be underoccupied after a 'small' insert."
+        );
+
+        let (k, v) = ([3_u8; N], [4_u8; N]);
+        page.insert(&k, &v).unwrap();
+
+        assert!(
+            !page.is_underoccupied().unwrap(),
+            "An empty leaf page should not be underoccupied after more than half the page is full. free {} {} {}",
+            page.total_reclaimable_space().unwrap(),
+            USABLE_SPACE_END,
+            USABLE_SPACE_END / 4
+        );
     }
 }

--- a/crates/databas_core/src/page_cache.rs
+++ b/crates/databas_core/src/page_cache.rs
@@ -27,6 +27,7 @@ use crate::{
     error::{PageCacheError, PageCacheResult},
     page::{NodeMarker, Page, PageResult, Read, Write},
     page_replacement::ClockPolicy,
+    page_store::PageStore,
     {PAGE_SIZE, PageId},
 };
 
@@ -57,16 +58,16 @@ struct CacheMeta {
     replacement: ClockPolicy,
 }
 
-struct PageCacheInner {
-    disk_manager: RefCell<DiskManager>,
+struct PageCacheInner<S: PageStore> {
+    store: RefCell<S>,
     meta: RefCell<CacheMeta>,
     frames: Vec<Frame>,
 }
 
-impl PageCacheInner {
+impl<S: PageStore> PageCacheInner<S> {
     /// Attempts to flush all dirty unpinned frames and ignores write errors.
     fn flush_best_effort_on_drop(&mut self) {
-        let disk_manager = self.disk_manager.get_mut();
+        let store = self.store.get_mut();
         for frame in &mut self.frames {
             if !frame.dirty.get() || frame.pin_count.get() > 0 {
                 continue;
@@ -76,14 +77,14 @@ impl PageCacheInner {
                 continue;
             };
 
-            if disk_manager.write_page(page_id, frame.data.get_mut()).is_ok() {
+            if store.write_page(page_id, frame.data.get_mut()).is_ok() {
                 frame.dirty.set(false);
             }
         }
     }
 }
 
-impl Drop for PageCacheInner {
+impl<S: PageStore> Drop for PageCacheInner<S> {
     /// Performs best-effort flushing for dirty unpinned frames when the last
     /// cache handle and all outstanding pins have been dropped.
     fn drop(&mut self) {
@@ -98,23 +99,28 @@ impl Drop for PageCacheInner {
 /// cache operations. Use [`PinGuard`] to keep pages resident and use
 /// [`PageReadGuard`] or [`PageWriteGuard`] for temporary access to the page
 /// bytes.
-#[derive(Clone)]
-pub(crate) struct PageCache {
-    inner: Rc<PageCacheInner>,
+pub(crate) struct PageCache<S: PageStore = DiskManager> {
+    inner: Rc<PageCacheInner<S>>,
 }
 
-impl PageCache {
+impl<S: PageStore> Clone for PageCache<S> {
+    fn clone(&self) -> Self {
+        Self { inner: Rc::clone(&self.inner) }
+    }
+}
+
+impl<S: PageStore> PageCache<S> {
     /// Creates a new page cache with a fixed number of preallocated frames.
     ///
     /// Returns an error when `frame_count` is zero.
-    pub(crate) fn new(disk_manager: DiskManager, frame_count: usize) -> PageCacheResult<Self> {
+    pub(crate) fn new(store: S, frame_count: usize) -> PageCacheResult<Self> {
         if frame_count == 0 {
             return Err(PageCacheError::InvalidFrameCount { frame_count });
         }
 
         Ok(Self {
             inner: Rc::new(PageCacheInner {
-                disk_manager: RefCell::new(disk_manager),
+                store: RefCell::new(store),
                 meta: RefCell::new(CacheMeta {
                     page_table: HashMap::new(),
                     replacement: ClockPolicy::new(frame_count),
@@ -128,7 +134,7 @@ impl PageCache {
     ///
     /// Cache hits update replacement state and increment pin count.
     /// Cache misses use CLOCK replacement and may evict a dirty page.
-    pub(crate) fn fetch_page(&self, page_id: PageId) -> PageCacheResult<PinGuard> {
+    pub(crate) fn fetch_page(&self, page_id: PageId) -> PageCacheResult<PinGuard<S>> {
         if let Some(frame_id) = self.resident_frame_id(page_id)? {
             let frame = &self.inner.frames[frame_id];
             frame.pin_count.set(frame.pin_count.get().checked_add(1).expect("pin count overflow"));
@@ -145,9 +151,9 @@ impl PageCache {
     ///
     /// A victim frame is selected before allocation so a full pinned cache
     /// returns `NoEvictableFrame` without growing the file.
-    pub(crate) fn new_page(&self) -> PageCacheResult<(PageId, PinGuard)> {
+    pub(crate) fn new_page(&self) -> PageCacheResult<(PageId, PinGuard<S>)> {
         let frame_id = self.select_victim_frame().ok_or(PageCacheError::NoEvictableFrame)?;
-        let page_id = self.inner.disk_manager.borrow_mut().new_page()?;
+        let page_id = self.inner.store.borrow_mut().new_page()?;
         self.replace_frame(frame_id, page_id)?;
         Ok((page_id, PinGuard::new(Rc::clone(&self.inner), frame_id, page_id)))
     }
@@ -232,7 +238,7 @@ impl PageCache {
         let old_page_id = frame.page_id.get();
 
         let mut data = [0u8; PAGE_SIZE];
-        self.inner.disk_manager.borrow_mut().read_page(new_page_id, &mut data)?;
+        self.inner.store.borrow_mut().read_page(new_page_id, &mut data)?;
 
         {
             let mut frame_data = frame.data.try_borrow_mut().map_err(|_| {
@@ -271,7 +277,7 @@ impl PageCache {
             .data
             .try_borrow()
             .map_err(|_| PageCacheError::PageImmutableBorrowConflict { page_id })?;
-        self.inner.disk_manager.borrow_mut().write_page(page_id, &page)?;
+        self.inner.store.borrow_mut().write_page(page_id, &page)?;
         frame.dirty.set(false);
         Ok(())
     }
@@ -285,15 +291,15 @@ impl PageCache {
 /// borrow the page contents temporarily.
 ///
 /// Dropping the guard decrements the frame pin count.
-pub(crate) struct PinGuard {
-    page_cache: Rc<PageCacheInner>,
+pub(crate) struct PinGuard<S: PageStore = DiskManager> {
+    page_cache: Rc<PageCacheInner<S>>,
     frame_id: FrameId,
     page_id: PageId,
 }
 
-impl PinGuard {
+impl<S: PageStore> PinGuard<S> {
     /// Creates a new pin guard for a specific frame.
-    fn new(page_cache: Rc<PageCacheInner>, frame_id: FrameId, page_id: PageId) -> Self {
+    fn new(page_cache: Rc<PageCacheInner<S>>, frame_id: FrameId, page_id: PageId) -> Self {
         Self { page_cache, frame_id, page_id }
     }
 
@@ -331,7 +337,7 @@ impl PinGuard {
     }
 }
 
-impl Drop for PinGuard {
+impl<S: PageStore> Drop for PinGuard<S> {
     /// Decrements the frame pin count when the guard leaves scope.
     fn drop(&mut self) {
         let frame = &self.page_cache.frames[self.frame_id];

--- a/crates/databas_core/src/page_store.rs
+++ b/crates/databas_core/src/page_store.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Backend abstraction for fixed-size page allocation and I/O.
-pub(crate) trait PageStore {
+pub trait PageStore {
     /// Allocates a new page and returns its page ID.
     fn new_page(&mut self) -> PageStoreResult<PageId>;
 

--- a/crates/databas_core/src/page_store.rs
+++ b/crates/databas_core/src/page_store.rs
@@ -1,0 +1,21 @@
+use crate::{
+    error::PageStoreResult,
+    {PAGE_SIZE, PageId},
+};
+
+/// Backend abstraction for fixed-size page allocation and I/O.
+pub(crate) trait PageStore {
+    /// Allocates a new page and returns its page ID.
+    fn new_page(&mut self) -> PageStoreResult<PageId>;
+
+    /// Reads page `page_id` into `buf`.
+    fn read_page(&mut self, page_id: PageId, buf: &mut [u8; PAGE_SIZE]) -> PageStoreResult<()>;
+
+    /// Writes `buf` to page `page_id`.
+    fn write_page(&mut self, page_id: PageId, buf: &[u8; PAGE_SIZE]) -> PageStoreResult<()>;
+
+    /// Optional durability barrier.
+    fn sync(&mut self) -> PageStoreResult<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
- **temp: add delete tree op docs**
- **Implement B+-tree delete operation**
- **Implement tests for tree delete operation**
- **Fix btree leaf cell type complexity**
- **storage: add PageStore trait and shared store error type**
- **storage: implement PageStore for DiskManager**
- **storage: make PageCache generic over PageStore**
- **storage: add in-memory PageStore backend**
- **btree: generalize cursor internals over PageStore**
- **btree: run stress tests against MemoryPageStore backend**
- **api: expose PageStore and remove private generic defaults**
