### PR TITLE
Fix two SQL parser bugs using Hegel proptests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 /test_data
+.hegel/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,10 +21,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "databas"
 version = "0.1.0"
 dependencies = [
  "fastrand",
+ "hegeltest",
  "tempfile",
  "thiserror",
 ]
@@ -71,6 +114,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +144,32 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hegeltest"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc957550085352b9ab8f703c970d101bce71dbf5c259b56a80eed9290e08f9e"
+dependencies = [
+ "ciborium",
+ "crc32fast",
+ "hegeltest-macros",
+ "parking_lot",
+ "paste",
+ "serde",
+ "tempfile",
+]
+
+[[package]]
+name = "hegeltest-macros"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3663265b3ec7513317f09fb3024c049cc42d658e30604661900063f8c6a10575"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "id-arena"
@@ -134,6 +214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +239,35 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "prettyplease"
@@ -186,6 +304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +324,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -211,6 +344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -245,6 +379,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -455,6 +595,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ fastrand = "2.3.0"
 thiserror = "2.0.18"
 
 [dev-dependencies]
+hegeltest = "0.8.11"
 tempfile = "3.25.0"

--- a/src/sql_parser/lexer/token_kind.rs
+++ b/src/sql_parser/lexer/token_kind.rs
@@ -183,6 +183,7 @@ impl Display for NumberKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             NumberKind::Integer(value) => write!(f, "{}", value),
+            NumberKind::Float(value) if value.fract() == 0.0 => write!(f, "{value:.1}"),
             NumberKind::Float(value) => write!(f, "{}", value),
         }
     }

--- a/src/sql_parser/parser/expr.rs
+++ b/src/sql_parser/parser/expr.rs
@@ -56,14 +56,62 @@ impl From<bool> for Expression<'_> {
 
 impl Display for Expression<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.fmt_with_parent_op(f, None, ChildSide::Left)
+    }
+}
+
+#[derive(Copy, Clone)]
+enum ChildSide {
+    Left,
+    Right,
+}
+
+impl Expression<'_> {
+    fn fmt_with_parent_op(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        parent_op: Option<Op>,
+        side: ChildSide,
+    ) -> std::fmt::Result {
+        let needs_parens = match (self, parent_op) {
+            (Expression::BinaryOp((_, child_op, _)), Some(parent_op)) => {
+                let child_bp = child_op.infix_binding_power().map(|(l_bp, _)| l_bp).unwrap_or(0);
+                let parent_bp = parent_op.infix_binding_power().map(|(l_bp, _)| l_bp).unwrap_or(0);
+
+                child_bp < parent_bp || matches!(side, ChildSide::Right) && child_bp == parent_bp
+            }
+            _ => false,
+        };
+
+        if needs_parens {
+            write!(f, "(")?;
+        }
+
         match self {
             Expression::Literal(literal) => write!(f, "{}", literal),
             Expression::Identifier(ident) => write!(f, "{}", ident),
-            Expression::UnaryOp((op, expr)) => write!(f, "{}{}", op, expr),
-            Expression::BinaryOp((left, op, right)) => write!(f, "{} {} {}", left, op, right),
+            Expression::UnaryOp((op, expr)) => {
+                write!(f, "{}", op)?;
+                if matches!(**expr, Expression::BinaryOp(_)) {
+                    write!(f, "({})", expr)
+                } else {
+                    write!(f, "{}", expr)
+                }
+            }
+            Expression::BinaryOp((left, op, right)) => {
+                left.fmt_with_parent_op(f, Some(*op), ChildSide::Left)?;
+                write!(f, " {} ", op)?;
+                right.fmt_with_parent_op(f, Some(*op), ChildSide::Right)
+            }
             Expression::Wildcard => write!(f, "*"),
             Expression::AggregateFunction(agg) => write!(f, "{}", agg),
+        }?;
+
+        if needs_parens {
+            write!(f, ")")?;
         }
+
+        Ok(())
     }
 }
 

--- a/src/sql_parser/parser/op.rs
+++ b/src/sql_parser/parser/op.rs
@@ -33,7 +33,7 @@ impl<'a> TryFrom<Token<'a>> for Op {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Op {
     And,
     Or,

--- a/tests/sql_parser_roundtrip.rs
+++ b/tests/sql_parser_roundtrip.rs
@@ -179,7 +179,6 @@ fn create_table_queries_round_trip_through_display(tc: TestCase) {
 }
 
 #[test]
-#[ignore = "documents a parser/display round-trip bug; do not fix yet"]
 fn parenthesized_expression_display_loses_grouping() {
     let sql = "SELECT (alpha + beta) * gamma;";
     let parsed = parse_statement(sql);

--- a/tests/sql_parser_roundtrip.rs
+++ b/tests/sql_parser_roundtrip.rs
@@ -32,15 +32,20 @@ fn draw_i32(tc: &TestCase) -> i32 {
 }
 
 fn draw_atom(tc: &TestCase, allow_wildcard: bool) -> String {
-    let variant_count = if allow_wildcard { 4 } else { 3 };
+    let variant_count = if allow_wildcard { 5 } else { 4 };
     match draw_index(tc, variant_count) {
         0 => draw_identifier(tc).to_string(),
         1 => draw_i32(tc).to_string(),
-        2 => {
+        2 => format!(
+            "{}.{}",
+            draw_u32(tc),
+            tc.draw(gs::integers::<u32>().min_value(0).max_value(99))
+        ),
+        3 => {
             let lit = STRING_LITERALS[draw_index(tc, STRING_LITERALS.len())];
             format!("'{lit}'")
         }
-        3 => "*".to_string(),
+        4 => "*".to_string(),
         _ => unreachable!(),
     }
 }
@@ -189,7 +194,6 @@ fn parenthesized_expression_display_loses_grouping() {
 }
 
 #[test]
-#[ignore = "documents a parser/display round-trip bug; do not fix yet"]
 fn float_literals_with_zero_fraction_display_as_integers() {
     let sql = "SELECT 0.0;";
     let parsed = parse_statement(sql);

--- a/tests/sql_parser_roundtrip.rs
+++ b/tests/sql_parser_roundtrip.rs
@@ -1,0 +1,201 @@
+use databas::sql_parser::parser::{Parser, stmt::Statement};
+use hegel::TestCase;
+use hegel::generators as gs;
+
+const IDENTIFIERS: &[&str] =
+    &["alpha", "beta", "gamma", "delta", "epsilon", "customer_id", "order_total", "created_at"];
+
+const STRING_LITERALS: &[&str] = &["cake", "waffles", "coffee", "tea", "pending", "done"];
+
+fn draw_bool(tc: &TestCase) -> bool {
+    tc.draw(gs::booleans())
+}
+
+fn draw_index(tc: &TestCase, len: usize) -> usize {
+    tc.draw(gs::integers::<usize>().min_value(0).max_value(len - 1))
+}
+
+fn draw_identifier(tc: &TestCase) -> &'static str {
+    IDENTIFIERS[draw_index(tc, IDENTIFIERS.len())]
+}
+
+fn draw_non_empty_len(tc: &TestCase, max: usize) -> usize {
+    tc.draw(gs::integers::<usize>().min_value(1).max_value(max))
+}
+
+fn draw_u32(tc: &TestCase) -> u32 {
+    tc.draw(gs::integers::<u32>().min_value(0).max_value(1000))
+}
+
+fn draw_i32(tc: &TestCase) -> i32 {
+    tc.draw(gs::integers::<i32>().min_value(-1000).max_value(1000))
+}
+
+fn draw_atom(tc: &TestCase, allow_wildcard: bool) -> String {
+    let variant_count = if allow_wildcard { 4 } else { 3 };
+    match draw_index(tc, variant_count) {
+        0 => draw_identifier(tc).to_string(),
+        1 => draw_i32(tc).to_string(),
+        2 => {
+            let lit = STRING_LITERALS[draw_index(tc, STRING_LITERALS.len())];
+            format!("'{lit}'")
+        }
+        3 => "*".to_string(),
+        _ => unreachable!(),
+    }
+}
+
+fn draw_expression(tc: &TestCase, allow_wildcard: bool) -> String {
+    if draw_bool(tc) {
+        return draw_atom(tc, allow_wildcard);
+    }
+
+    let left = draw_atom(tc, false);
+    let right = draw_atom(tc, false);
+    let op = match draw_index(tc, 9) {
+        0 => "+",
+        1 => "-",
+        2 => "*",
+        3 => "/",
+        4 => "==",
+        5 => "!=",
+        6 => "<",
+        7 => "<=",
+        8 => "AND",
+        _ => unreachable!(),
+    };
+    format!("{left} {op} {right}")
+}
+
+fn draw_expression_list(tc: &TestCase, max_len: usize, allow_wildcard: bool) -> Vec<String> {
+    (0..draw_non_empty_len(tc, max_len)).map(|_| draw_expression(tc, allow_wildcard)).collect()
+}
+
+fn parse_statement(sql: &str) -> Statement<'_> {
+    Parser::new(sql).stmt().unwrap_or_else(|err| panic!("failed to parse `{sql}`: {err:?}"))
+}
+
+fn assert_round_trips(sql: &str) {
+    let parsed = parse_statement(sql);
+    let displayed = parsed.to_string();
+    let reparsed = parse_statement(&displayed);
+
+    assert_eq!(parsed, reparsed, "SQL did not round-trip: {sql}\ndisplayed as: {displayed}");
+}
+
+fn draw_insert(tc: &TestCase) -> String {
+    let table = draw_identifier(tc);
+    let column_count = draw_non_empty_len(tc, 4);
+    let columns = (0..column_count).map(|_| draw_identifier(tc)).collect::<Vec<_>>();
+    let row_count = draw_non_empty_len(tc, 4);
+    let rows = (0..row_count)
+        .map(|_| {
+            let values = (0..column_count).map(|_| draw_expression(tc, false)).collect::<Vec<_>>();
+            format!("({})", values.join(", "))
+        })
+        .collect::<Vec<_>>();
+
+    format!("INSERT INTO {table} ({}) VALUES {};", columns.join(", "), rows.join(", "))
+}
+
+fn draw_select(tc: &TestCase) -> String {
+    let columns = draw_expression_list(tc, 4, true).join(", ");
+    let mut sql = format!("SELECT {columns}");
+
+    if draw_bool(tc) {
+        sql.push_str(" FROM ");
+        sql.push_str(draw_identifier(tc));
+    }
+    if draw_bool(tc) {
+        sql.push_str(" WHERE ");
+        sql.push_str(&draw_expression(tc, false));
+    }
+    if draw_bool(tc) {
+        sql.push_str(" ORDER BY ");
+        sql.push_str(&draw_expression_list(tc, 3, false).join(", "));
+        match draw_index(tc, 3) {
+            0 => {}
+            1 => sql.push_str(" ASC"),
+            2 => sql.push_str(" DESC"),
+            _ => unreachable!(),
+        }
+    }
+    if draw_bool(tc) {
+        sql.push_str(" LIMIT ");
+        sql.push_str(&draw_u32(tc).to_string());
+    }
+    if draw_bool(tc) {
+        sql.push_str(" OFFSET ");
+        sql.push_str(&draw_u32(tc).to_string());
+    }
+
+    sql.push(';');
+    sql
+}
+
+fn draw_create_table(tc: &TestCase) -> String {
+    let table = draw_identifier(tc);
+    let columns = (0..draw_non_empty_len(tc, 5))
+        .map(|_| {
+            let column_type = match draw_index(tc, 3) {
+                0 => "INT",
+                1 => "FLOAT",
+                2 => "TEXT",
+                _ => unreachable!(),
+            };
+            let mut column = format!("{} {column_type}", draw_identifier(tc));
+            if draw_bool(tc) {
+                column.push_str(" PRIMARY KEY");
+            }
+            if draw_bool(tc) {
+                column.push_str(" NULLABLE");
+            }
+            column
+        })
+        .collect::<Vec<_>>();
+
+    format!("CREATE TABLE {table} ({});", columns.join(", "))
+}
+
+#[hegel::test(test_cases = 250)]
+fn insert_queries_round_trip_through_display(tc: TestCase) {
+    let sql = draw_insert(&tc);
+    tc.note(&sql);
+    assert_round_trips(&sql);
+}
+
+#[hegel::test(test_cases = 250)]
+fn select_queries_round_trip_through_display(tc: TestCase) {
+    let sql = draw_select(&tc);
+    tc.note(&sql);
+    assert_round_trips(&sql);
+}
+
+#[hegel::test(test_cases = 250)]
+fn create_table_queries_round_trip_through_display(tc: TestCase) {
+    let sql = draw_create_table(&tc);
+    tc.note(&sql);
+    assert_round_trips(&sql);
+}
+
+#[test]
+#[ignore = "documents a parser/display round-trip bug; do not fix yet"]
+fn parenthesized_expression_display_loses_grouping() {
+    let sql = "SELECT (alpha + beta) * gamma;";
+    let parsed = parse_statement(sql);
+    let displayed = parsed.to_string();
+    let reparsed = parse_statement(&displayed);
+
+    assert_eq!(parsed, reparsed, "displayed SQL: {displayed}");
+}
+
+#[test]
+#[ignore = "documents a parser/display round-trip bug; do not fix yet"]
+fn float_literals_with_zero_fraction_display_as_integers() {
+    let sql = "SELECT 0.0;";
+    let parsed = parse_statement(sql);
+    let displayed = parsed.to_string();
+    let reparsed = parse_statement(&displayed);
+
+    assert_eq!(parsed, reparsed, "displayed SQL: {displayed}");
+}


### PR DESCRIPTION
This PR introduces basic property-based tests for the SQL parser, using the [hegel](https://crates.io/crates/hegeltest) crate (see also the [Hegel library](https://hegel.dev/)).
Using these tests, we found two parser bugs.

1. `SELECT 0.0;` was parsed and displayed as `SELECT 0;`.
2. `SELECT (alpha + beta) * gamma;` was parsed and displayed without the parenthesis grouping.

These two bugs are fixed in this PR.