### PR TITLE
Create on-disk schema catalogue

### DIFF
--- a/examples/table_index_query.rs
+++ b/examples/table_index_query.rs
@@ -4,8 +4,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db_file = tempfile::NamedTempFile::new()?;
     let pager = Pager::open(db_file.path())?;
 
-    let mut users = pager.create_table()?;
-    let mut users_by_email = pager.create_index()?;
+    let mut users = pager.create_table_tree()?;
+    let mut users_by_email = pager.create_index_tree()?;
 
     let row_id = 1;
     let tuple_row_id = 1;

--- a/src/core/btree.rs
+++ b/src/core/btree.rs
@@ -1999,7 +1999,7 @@ impl<S: PageStore> TreeCursor<S> {
         Ok(false)
     }
 
-    /// Replaces an empty interior root with its sole child.
+    /// Replaces an empty interior root with its sole child while preserving the root page id.
     fn shrink_root_if_empty(&mut self) -> StorageResult<()> {
         let root_page_id = self.root_page_id();
         let pin = self.page_cache.fetch_page(root_page_id)?;
@@ -2016,8 +2016,37 @@ impl<S: PageStore> TreeCursor<S> {
                 }
             }
         };
-        self.root_page_id.set(child_page_id);
-        self.set_page_state(child_page_id);
+
+        let child_pin = self.page_cache.fetch_page(child_page_id)?;
+        let child_snapshot = {
+            let child_page = child_pin.read()?;
+            *child_page.page()
+        };
+
+        let mut root_guard = pin.write()?;
+        *root_guard.page_mut() = child_snapshot;
+        drop(root_guard);
+
+        self.clear_root_sibling_links(root_page_id)?;
+        self.set_page_state(root_page_id);
+        Ok(())
+    }
+
+    fn clear_root_sibling_links(&self, root_page_id: PageId) -> StorageResult<()> {
+        let pin = self.page_cache.fetch_page(root_page_id)?;
+        let mut guard = pin.write()?;
+        match read_page_kind(guard.page(), root_page_id)? {
+            PageKind::RawLeaf => {
+                let mut leaf = guard.open_mut::<Leaf>()?;
+                leaf.set_prev_page_id(None);
+                leaf.set_next_page_id(None);
+            }
+            PageKind::RawInterior => {
+                let mut interior = guard.open_mut::<Interior>()?;
+                interior.set_prev_page_id(None);
+                interior.set_next_page_id(None);
+            }
+        }
         Ok(())
     }
 
@@ -2641,22 +2670,71 @@ impl<S: PageStore> TreeCursor<S> {
         })
     }
 
-    /// Creates a fresh root page after the old root split.
+    /// Installs a new interior root in the existing root page after the old root split.
     fn install_new_root(&mut self, pending: PendingSplit) -> StorageResult<()> {
-        let (root_page_id, root_page_guard) = self.page_cache.new_page()?;
-        let mut root_guard = root_page_guard.write()?;
+        let root_page_id = self.root_page_id();
+        debug_assert_eq!(
+            pending.left_page_id, root_page_id,
+            "root split must report the old root page as its left page"
+        );
+
+        let root_pin = self.page_cache.fetch_page(root_page_id)?;
+        let root_snapshot = {
+            let root_guard = root_pin.read()?;
+            *root_guard.page()
+        };
+
+        let (left_page_id, left_page_pin) = self.page_cache.new_page()?;
+        {
+            let mut left_guard = left_page_pin.write()?;
+            *left_guard.page_mut() = root_snapshot;
+        }
+        self.relink_copied_root_left_child(left_page_id, pending.right_page_id)?;
+
+        let mut root_guard = root_pin.write()?;
         let mut root_page = RawInterior::<Write<'_>>::initialize_with_rightmost(
             root_guard.page_mut(),
             pending.right_page_id,
         );
-        self.insert_interior_payload_at(
-            &mut root_page,
-            0,
-            pending.left_page_id,
-            &pending.separator,
-        )?;
-        self.root_page_id.set(root_page_id);
+        self.insert_interior_payload_at(&mut root_page, 0, left_page_id, &pending.separator)?;
+        self.remap_positioned_page(root_page_id, left_page_id);
         Ok(())
+    }
+
+    fn relink_copied_root_left_child(
+        &self,
+        left_page_id: PageId,
+        right_page_id: PageId,
+    ) -> StorageResult<()> {
+        let left_pin = self.page_cache.fetch_page(left_page_id)?;
+        let mut left_guard = left_pin.write()?;
+        match read_page_kind(left_guard.page(), left_page_id)? {
+            PageKind::RawLeaf => {
+                {
+                    let mut leaf = left_guard.open_mut::<Leaf>()?;
+                    leaf.set_prev_page_id(None);
+                    leaf.set_next_page_id(Some(right_page_id));
+                }
+                self.set_leaf_prev_page_id(right_page_id, Some(left_page_id))?;
+            }
+            PageKind::RawInterior => {
+                {
+                    let mut interior = left_guard.open_mut::<Interior>()?;
+                    interior.set_prev_page_id(None);
+                    interior.set_next_page_id(Some(right_page_id));
+                }
+                self.set_interior_prev_page_id(right_page_id, Some(left_page_id))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn remap_positioned_page(&mut self, from_page_id: PageId, to_page_id: PageId) {
+        if let CursorState::Positioned { page_id, slot_index } = self.state
+            && page_id == from_page_id
+        {
+            self.set_positioned_state(to_page_id, slot_index);
+        }
     }
 }
 
@@ -2807,6 +2885,54 @@ mod tests {
             height += 1;
             page_id = next_page_id;
         }
+    }
+
+    #[test]
+    fn root_page_id_stays_stable_after_root_splits() {
+        let mut cursor = memory_tree_cursor(256);
+        let root_page_id = cursor.root_page_id();
+        let mut expected = BTreeMap::new();
+
+        for index in 0..256_u16 {
+            let key = oversized_key(index);
+            let value = format!("value-{index}").into_bytes();
+            cursor.insert(&key, &value).unwrap();
+            expected.insert(key, value);
+            assert_eq!(cursor.root_page_id(), root_page_id);
+
+            if tree_height(&cursor).unwrap() >= 3 {
+                break;
+            }
+        }
+
+        assert!(tree_height(&cursor).unwrap() >= 3, "test setup should split an interior root");
+        for (key, value) in &expected {
+            let record = cursor.get(key).unwrap().expect("inserted key should be readable");
+            assert_record_matches(&record, key, value);
+        }
+    }
+
+    #[test]
+    fn root_page_id_stays_stable_after_root_shrink() {
+        let mut cursor = memory_tree_cursor(256);
+        let root_page_id = cursor.root_page_id();
+        let mut keys = Vec::new();
+
+        for index in 0..512_u32 {
+            let key = index.to_be_bytes().to_vec();
+            cursor.insert(&key, b"value").unwrap();
+            keys.push(key);
+        }
+        assert!(tree_height(&cursor).unwrap() >= 2, "test setup should split the root");
+
+        for key in keys {
+            cursor.delete(&key).unwrap();
+            assert_eq!(cursor.root_page_id(), root_page_id);
+        }
+
+        assert_eq!(cursor.root_page_id(), root_page_id);
+        assert_eq!(tree_height(&cursor).unwrap(), 1);
+        assert!(!cursor.seek_to_first().unwrap());
     }
 
     #[test]

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -1,0 +1,678 @@
+//! Internal schema catalog definitions and bootstrap helpers.
+
+use std::fmt;
+
+use crate::{
+    core::{PageId, RowId, Tuple, TupleRef, Value, ValueRef},
+    sql_parser::parser::stmt::{
+        create_index::CreateIndexQuery,
+        create_table::{ColumnConstraint, ColumnType, CreateTableQuery},
+    },
+};
+
+/// Root page id of the `sys_tables` catalog table.
+pub const SYS_TABLES_ROOT_PAGE_ID: PageId = 0;
+/// Root page id of the `sys_indexes` catalog table.
+pub const SYS_INDEXES_ROOT_PAGE_ID: PageId = 1;
+/// Root page id of the `sys_columns` catalog table.
+pub const SYS_COLUMNS_ROOT_PAGE_ID: PageId = 2;
+
+/// Stable object id assigned to the `sys_tables` catalog table.
+pub const SYS_TABLES_TABLE_ID: RowId = 1;
+/// Stable object id assigned to the `sys_indexes` catalog table.
+pub const SYS_INDEXES_TABLE_ID: RowId = 2;
+/// Stable object id assigned to the `sys_columns` catalog table.
+pub const SYS_COLUMNS_TABLE_ID: RowId = 3;
+
+const SYS_TABLES_NAME: &str = "sys_tables";
+const SYS_INDEXES_NAME: &str = "sys_indexes";
+const SYS_COLUMNS_NAME: &str = "sys_columns";
+
+/// Kind of schema object described by a row in `sys_columns`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CatalogObjectKind {
+    /// A table row schema.
+    Table,
+    /// A secondary-index key schema.
+    Index,
+}
+
+impl CatalogObjectKind {
+    /// Returns the integer tag stored in `sys_columns.object_kind`.
+    pub fn catalog_tag(self) -> i32 {
+        match self {
+            Self::Table => 1,
+            Self::Index => 2,
+        }
+    }
+
+    /// Decodes an integer tag stored in `sys_columns.object_kind`.
+    pub fn from_catalog_tag(tag: i32) -> Result<Self, CatalogError> {
+        match tag {
+            1 => Ok(Self::Table),
+            2 => Ok(Self::Index),
+            _ => Err(CatalogError::InvalidObjectKind { actual: tag }),
+        }
+    }
+}
+
+/// Logical column type recorded in the catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataType {
+    /// Signed 32-bit integer value.
+    Integer,
+    /// Floating-point value.
+    Float,
+    /// UTF-8 text value.
+    Text,
+    /// Boolean value.
+    Boolean,
+    /// Unsigned 64-bit integer value used for internal identifiers.
+    UnsignedInteger,
+}
+
+impl DataType {
+    /// Returns the integer tag stored in `sys_columns.data_type`.
+    pub fn catalog_tag(self) -> i32 {
+        match self {
+            Self::Integer => 1,
+            Self::Float => 2,
+            Self::Text => 3,
+            Self::Boolean => 4,
+            Self::UnsignedInteger => 5,
+        }
+    }
+
+    /// Decodes an integer tag stored in `sys_columns.data_type`.
+    pub fn from_catalog_tag(tag: i32) -> Result<Self, CatalogError> {
+        match tag {
+            1 => Ok(Self::Integer),
+            2 => Ok(Self::Float),
+            3 => Ok(Self::Text),
+            4 => Ok(Self::Boolean),
+            5 => Ok(Self::UnsignedInteger),
+            _ => Err(CatalogError::InvalidDataType { actual: tag }),
+        }
+    }
+
+    /// Maps a parsed SQL column type onto the storage catalog type.
+    pub fn from_sql(column_type: &ColumnType) -> Self {
+        match column_type {
+            ColumnType::Int => Self::Integer,
+            ColumnType::Float => Self::Float,
+            ColumnType::Text => Self::Text,
+        }
+    }
+}
+
+/// Schema metadata for one table or index column.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnSchema {
+    /// Column name as exposed to SQL.
+    pub name: String,
+    /// Logical type stored for values in this column.
+    pub data_type: DataType,
+    /// Whether this column accepts `NULL` values.
+    pub nullable: bool,
+    /// Whether this column participates in the object's primary key.
+    pub primary_key: bool,
+}
+
+/// Ordered schema for one encoded tuple.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TupleSchema {
+    /// Columns in tuple field order.
+    pub columns: Vec<ColumnSchema>,
+}
+
+/// Catalog schema for a table B+-tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableSchema {
+    /// Stable row id for this table object in `sys_tables`.
+    pub table_id: RowId,
+    /// Table name.
+    pub name: String,
+    /// Root page id of the table's B+-tree.
+    pub root_page_id: PageId,
+    /// Schema of table rows stored in the tree values.
+    pub row: TupleSchema,
+}
+
+/// One column of a secondary-index key and its source table column.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexColumnSchema {
+    /// Ordinal of the source column in the indexed table schema.
+    pub source_column_ordinal: u64,
+    /// Column metadata copied into the index key schema.
+    pub column: ColumnSchema,
+}
+
+/// Catalog schema for a secondary-index B+-tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSchema {
+    /// Stable row id for this index object in `sys_indexes`.
+    pub index_id: RowId,
+    /// Index name.
+    pub name: String,
+    /// Table object id that this index belongs to.
+    pub table_id: RowId,
+    /// Root page id of the index B+-tree.
+    pub root_page_id: PageId,
+    /// Whether duplicate key tuples are rejected.
+    pub unique: bool,
+    /// Ordered key columns stored in the index.
+    pub columns: Vec<IndexColumnSchema>,
+}
+
+/// Decoded row from `sys_tables`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableCatalogRow {
+    /// Stable table object id.
+    pub table_id: RowId,
+    /// Table name.
+    pub name: String,
+    /// Root page id of the table B+-tree.
+    pub root_page_id: PageId,
+}
+
+/// Decoded row from `sys_indexes`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexCatalogRow {
+    /// Stable index object id.
+    pub index_id: RowId,
+    /// Index name.
+    pub name: String,
+    /// Table object id that this index belongs to.
+    pub table_id: RowId,
+    /// Root page id of the index B+-tree.
+    pub root_page_id: PageId,
+    /// Whether duplicate key tuples are rejected.
+    pub unique: bool,
+}
+
+/// Decoded row from `sys_columns`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnCatalogRow {
+    /// Stable catalog row id for this column record.
+    pub column_id: RowId,
+    /// Kind of object whose tuple schema owns this column.
+    pub object_kind: CatalogObjectKind,
+    /// Object id from `sys_tables` or `sys_indexes`.
+    pub object_id: RowId,
+    /// Zero-based position of the column in its tuple schema.
+    pub ordinal: u64,
+    /// Column name.
+    pub name: String,
+    /// Logical data type.
+    pub data_type: DataType,
+    /// Whether this column accepts `NULL` values.
+    pub nullable: bool,
+    /// Whether this column participates in the object's primary key.
+    pub primary_key: bool,
+    /// Source table id for index columns, or `None` for table columns.
+    pub source_table_id: Option<RowId>,
+    /// Source table column ordinal for index columns, or `None` for table columns.
+    pub source_column_ordinal: Option<u64>,
+}
+
+/// Borrowed column schema used to define built-in system tables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemColumnSchema<'a> {
+    /// Column name.
+    pub name: &'a str,
+    /// Logical data type.
+    pub data_type: DataType,
+    /// Whether this column accepts `NULL` values.
+    pub nullable: bool,
+    /// Whether this column participates in the object's primary key.
+    pub primary_key: bool,
+}
+
+/// Borrowed tuple schema used to define built-in system tables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemTupleSchema<'a> {
+    /// Columns in tuple field order.
+    pub columns: &'a [SystemColumnSchema<'a>],
+}
+
+/// Borrowed schema for one built-in system table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemTableSchema<'a> {
+    /// Stable table object id.
+    pub table_id: RowId,
+    /// System table name.
+    pub name: &'a str,
+    /// Root page id reserved for this system table.
+    pub root_page_id: PageId,
+    /// Row schema of the system table.
+    pub row: SystemTupleSchema<'a>,
+}
+
+/// Borrowed row written to `sys_tables` while bootstrapping the catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemTableCatalogRow<'a> {
+    /// Stable table object id.
+    pub table_id: RowId,
+    /// System table name.
+    pub name: &'a str,
+    /// Root page id reserved for this system table.
+    pub root_page_id: PageId,
+}
+
+/// Borrowed row written to `sys_columns` while bootstrapping the catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemColumnCatalogRow<'a> {
+    /// Stable catalog row id for this column record.
+    pub column_id: RowId,
+    /// Kind of object whose tuple schema owns this column.
+    pub object_kind: CatalogObjectKind,
+    /// Object id from `sys_tables` or `sys_indexes`.
+    pub object_id: RowId,
+    /// Zero-based position of the column in its tuple schema.
+    pub ordinal: u64,
+    /// Column name.
+    pub name: &'a str,
+    /// Logical data type.
+    pub data_type: DataType,
+    /// Whether this column accepts `NULL` values.
+    pub nullable: bool,
+    /// Whether this column participates in the object's primary key.
+    pub primary_key: bool,
+    /// Source table id for index columns, or `None` for table columns.
+    pub source_table_id: Option<RowId>,
+    /// Source table column ordinal for index columns, or `None` for table columns.
+    pub source_column_ordinal: Option<u64>,
+}
+
+/// Errors raised while decoding or constructing catalog metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CatalogError {
+    /// A catalog tuple had the wrong number of fields.
+    InvalidFieldCount { expected: usize, actual: usize },
+    /// A catalog tuple field had an unexpected value type.
+    InvalidFieldType { index: usize, expected: &'static str },
+    /// A `sys_columns.data_type` tag is not recognized.
+    InvalidDataType { actual: i32 },
+    /// A `sys_columns.object_kind` tag is not recognized.
+    InvalidObjectKind { actual: i32 },
+    /// An index definition referenced a column absent from the target table.
+    UnknownIndexColumn { table: String, column: String },
+}
+
+impl fmt::Display for CatalogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFieldCount { expected, actual } => {
+                write!(f, "invalid catalog field count: expected {expected}, got {actual}")
+            }
+            Self::InvalidFieldType { index, expected } => {
+                write!(f, "invalid catalog field {index}: expected {expected}")
+            }
+            Self::InvalidDataType { actual } => write!(f, "invalid catalog data type {actual}"),
+            Self::InvalidObjectKind { actual } => {
+                write!(f, "invalid catalog object kind {actual}")
+            }
+            Self::UnknownIndexColumn { table, column } => {
+                write!(f, "index column {column} does not exist on table {table}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CatalogError {}
+
+impl TableSchema {
+    /// Builds a table schema from a parsed `CREATE TABLE` statement.
+    pub fn from_create_table(
+        table_id: RowId,
+        root_page_id: PageId,
+        query: &CreateTableQuery<'_>,
+    ) -> Self {
+        let columns = query
+            .columns
+            .iter()
+            .map(|column| ColumnSchema {
+                name: column.name.to_owned(),
+                data_type: DataType::from_sql(&column.column_type),
+                nullable: column.constraints.contains(&ColumnConstraint::Nullable),
+                primary_key: column.constraints.contains(&ColumnConstraint::PrimaryKey),
+            })
+            .collect();
+
+        Self {
+            table_id,
+            name: query.table_name.to_owned(),
+            root_page_id,
+            row: TupleSchema { columns },
+        }
+    }
+
+    /// Returns the `sys_tables` row describing this table.
+    pub fn catalog_row(&self) -> TableCatalogRow {
+        TableCatalogRow {
+            table_id: self.table_id,
+            name: self.name.clone(),
+            root_page_id: self.root_page_id,
+        }
+    }
+}
+
+impl IndexSchema {
+    /// Builds an index schema from a parsed `CREATE INDEX` statement and source table schema.
+    pub fn from_create_index(
+        index_id: RowId,
+        root_page_id: PageId,
+        table: &TableSchema,
+        query: &CreateIndexQuery<'_>,
+    ) -> Result<Self, CatalogError> {
+        let mut columns = Vec::new();
+        for column_name in &query.columns.0 {
+            let (source_column_ordinal, column) = table
+                .row
+                .columns
+                .iter()
+                .enumerate()
+                .find(|(_, column)| column.name == *column_name)
+                .ok_or_else(|| CatalogError::UnknownIndexColumn {
+                    table: table.name.clone(),
+                    column: (*column_name).to_owned(),
+                })?;
+            columns.push(IndexColumnSchema {
+                source_column_ordinal: source_column_ordinal as u64,
+                column: column.clone(),
+            });
+        }
+
+        Ok(Self {
+            index_id,
+            name: query.index_name.to_owned(),
+            table_id: table.table_id,
+            root_page_id,
+            unique: false,
+            columns,
+        })
+    }
+
+    /// Returns the tuple schema used to encode keys in this index.
+    pub fn key_schema(&self) -> TupleSchema {
+        TupleSchema { columns: self.columns.iter().map(|column| column.column.clone()).collect() }
+    }
+
+    /// Returns the `sys_indexes` row describing this index.
+    pub fn catalog_row(&self) -> IndexCatalogRow {
+        IndexCatalogRow {
+            index_id: self.index_id,
+            name: self.name.clone(),
+            table_id: self.table_id,
+            root_page_id: self.root_page_id,
+            unique: self.unique,
+        }
+    }
+}
+
+impl TableCatalogRow {
+    /// Encodes this catalog row as a storage tuple.
+    pub fn encode(&self) -> Tuple {
+        Tuple::new(vec![
+            Value::UnsignedInteger(self.table_id),
+            Value::String(self.name.clone()),
+            Value::UnsignedInteger(self.root_page_id),
+        ])
+    }
+
+    /// Decodes a `sys_tables` storage tuple.
+    pub fn decode(tuple: &Tuple) -> Result<Self, CatalogError> {
+        expect_field_count(tuple, 3)?;
+        Ok(Self {
+            table_id: expect_unsigned(tuple, 0)?,
+            name: expect_string(tuple, 1)?.to_owned(),
+            root_page_id: expect_unsigned(tuple, 2)?,
+        })
+    }
+}
+
+impl IndexCatalogRow {
+    /// Encodes this catalog row as a storage tuple.
+    pub fn encode(&self) -> Tuple {
+        Tuple::new(vec![
+            Value::UnsignedInteger(self.index_id),
+            Value::String(self.name.clone()),
+            Value::UnsignedInteger(self.table_id),
+            Value::UnsignedInteger(self.root_page_id),
+            Value::Boolean(self.unique),
+        ])
+    }
+
+    /// Decodes a `sys_indexes` storage tuple.
+    pub fn decode(tuple: &Tuple) -> Result<Self, CatalogError> {
+        expect_field_count(tuple, 5)?;
+        Ok(Self {
+            index_id: expect_unsigned(tuple, 0)?,
+            name: expect_string(tuple, 1)?.to_owned(),
+            table_id: expect_unsigned(tuple, 2)?,
+            root_page_id: expect_unsigned(tuple, 3)?,
+            unique: expect_bool(tuple, 4)?,
+        })
+    }
+}
+
+impl ColumnCatalogRow {
+    /// Encodes this catalog row as a storage tuple.
+    pub fn encode(&self) -> Tuple {
+        Tuple::new(vec![
+            Value::UnsignedInteger(self.column_id),
+            Value::Integer(self.object_kind.catalog_tag()),
+            Value::UnsignedInteger(self.object_id),
+            Value::UnsignedInteger(self.ordinal),
+            Value::String(self.name.clone()),
+            Value::Integer(self.data_type.catalog_tag()),
+            Value::Boolean(self.nullable),
+            Value::Boolean(self.primary_key),
+            optional_unsigned(self.source_table_id),
+            optional_unsigned(self.source_column_ordinal),
+        ])
+    }
+
+    /// Decodes a `sys_columns` storage tuple.
+    pub fn decode(tuple: &Tuple) -> Result<Self, CatalogError> {
+        expect_field_count(tuple, 10)?;
+        Ok(Self {
+            column_id: expect_unsigned(tuple, 0)?,
+            object_kind: CatalogObjectKind::from_catalog_tag(expect_integer(tuple, 1)?)?,
+            object_id: expect_unsigned(tuple, 2)?,
+            ordinal: expect_unsigned(tuple, 3)?,
+            name: expect_string(tuple, 4)?.to_owned(),
+            data_type: DataType::from_catalog_tag(expect_integer(tuple, 5)?)?,
+            nullable: expect_bool(tuple, 6)?,
+            primary_key: expect_bool(tuple, 7)?,
+            source_table_id: expect_optional_unsigned(tuple, 8)?,
+            source_column_ordinal: expect_optional_unsigned(tuple, 9)?,
+        })
+    }
+}
+
+impl SystemTableSchema<'_> {
+    pub(crate) fn catalog_row(&self) -> SystemTableCatalogRow<'_> {
+        SystemTableCatalogRow {
+            table_id: self.table_id,
+            name: self.name,
+            root_page_id: self.root_page_id,
+        }
+    }
+}
+
+impl SystemTableCatalogRow<'_> {
+    pub(crate) fn to_bytes(&self) -> std::io::Result<Vec<u8>> {
+        let values = [
+            ValueRef::UnsignedInteger(self.table_id),
+            ValueRef::String(self.name),
+            ValueRef::UnsignedInteger(self.root_page_id),
+        ];
+        TupleRef::new(&values).to_bytes()
+    }
+}
+
+impl SystemColumnCatalogRow<'_> {
+    pub(crate) fn to_bytes(&self) -> std::io::Result<Vec<u8>> {
+        let values = [
+            ValueRef::UnsignedInteger(self.column_id),
+            ValueRef::Integer(self.object_kind.catalog_tag()),
+            ValueRef::UnsignedInteger(self.object_id),
+            ValueRef::UnsignedInteger(self.ordinal),
+            ValueRef::String(self.name),
+            ValueRef::Integer(self.data_type.catalog_tag()),
+            ValueRef::Boolean(self.nullable),
+            ValueRef::Boolean(self.primary_key),
+            optional_unsigned_ref(self.source_table_id),
+            optional_unsigned_ref(self.source_column_ordinal),
+        ];
+        TupleRef::new(&values).to_bytes()
+    }
+}
+
+static SYS_TABLES_COLUMNS: &[SystemColumnSchema<'static>] = &[
+    column("table_id", DataType::UnsignedInteger, false, true),
+    column("name", DataType::Text, false, false),
+    column("root_page_id", DataType::UnsignedInteger, false, false),
+];
+
+static SYS_INDEXES_COLUMNS: &[SystemColumnSchema<'static>] = &[
+    column("index_id", DataType::UnsignedInteger, false, true),
+    column("name", DataType::Text, false, false),
+    column("table_id", DataType::UnsignedInteger, false, false),
+    column("root_page_id", DataType::UnsignedInteger, false, false),
+    column("unique", DataType::Boolean, false, false),
+];
+
+static SYS_COLUMNS_COLUMNS: &[SystemColumnSchema<'static>] = &[
+    column("column_id", DataType::UnsignedInteger, false, true),
+    column("object_kind", DataType::Integer, false, false),
+    column("object_id", DataType::UnsignedInteger, false, false),
+    column("ordinal", DataType::UnsignedInteger, false, false),
+    column("name", DataType::Text, false, false),
+    column("data_type", DataType::Integer, false, false),
+    column("nullable", DataType::Boolean, false, false),
+    column("primary_key", DataType::Boolean, false, false),
+    column("source_table_id", DataType::UnsignedInteger, true, false),
+    column("source_column_ordinal", DataType::UnsignedInteger, true, false),
+];
+
+/// Fixed schemas of all built-in system catalog tables.
+pub static SYSTEM_TABLE_SCHEMAS: &[SystemTableSchema<'static>] = &[
+    SystemTableSchema {
+        table_id: SYS_TABLES_TABLE_ID,
+        name: SYS_TABLES_NAME,
+        root_page_id: SYS_TABLES_ROOT_PAGE_ID,
+        row: SystemTupleSchema { columns: SYS_TABLES_COLUMNS },
+    },
+    SystemTableSchema {
+        table_id: SYS_INDEXES_TABLE_ID,
+        name: SYS_INDEXES_NAME,
+        root_page_id: SYS_INDEXES_ROOT_PAGE_ID,
+        row: SystemTupleSchema { columns: SYS_INDEXES_COLUMNS },
+    },
+    SystemTableSchema {
+        table_id: SYS_COLUMNS_TABLE_ID,
+        name: SYS_COLUMNS_NAME,
+        root_page_id: SYS_COLUMNS_ROOT_PAGE_ID,
+        row: SystemTupleSchema { columns: SYS_COLUMNS_COLUMNS },
+    },
+];
+
+/// Returns the fixed schemas of all built-in system catalog tables.
+pub fn system_table_schemas() -> &'static [SystemTableSchema<'static>] {
+    SYSTEM_TABLE_SCHEMAS
+}
+
+/// Returns the fixed `sys_columns` rows that describe the system catalog tables.
+pub fn system_column_rows() -> Vec<SystemColumnCatalogRow<'static>> {
+    let mut column_id = 1;
+    let mut rows = Vec::new();
+    for schema in system_table_schemas() {
+        for (ordinal, column) in schema.row.columns.iter().enumerate() {
+            rows.push(SystemColumnCatalogRow {
+                column_id,
+                object_kind: CatalogObjectKind::Table,
+                object_id: schema.table_id,
+                ordinal: ordinal as u64,
+                name: column.name,
+                data_type: column.data_type,
+                nullable: column.nullable,
+                primary_key: column.primary_key,
+                source_table_id: None,
+                source_column_ordinal: None,
+            });
+            column_id += 1;
+        }
+    }
+    rows
+}
+
+const fn column(
+    name: &'static str,
+    data_type: DataType,
+    nullable: bool,
+    primary_key: bool,
+) -> SystemColumnSchema<'static> {
+    SystemColumnSchema { name, data_type, nullable, primary_key }
+}
+
+fn optional_unsigned(value: Option<u64>) -> Value {
+    value.map(Value::UnsignedInteger).unwrap_or(Value::Null)
+}
+
+fn optional_unsigned_ref(value: Option<u64>) -> ValueRef<'static> {
+    value.map(ValueRef::UnsignedInteger).unwrap_or(ValueRef::Null)
+}
+
+fn expect_field_count(tuple: &Tuple, expected: usize) -> Result<(), CatalogError> {
+    let actual = tuple.len();
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(CatalogError::InvalidFieldCount { expected, actual })
+    }
+}
+
+fn expect_value(tuple: &Tuple, index: usize) -> Result<&Value, CatalogError> {
+    tuple
+        .values()
+        .get(index)
+        .ok_or(CatalogError::InvalidFieldCount { expected: index + 1, actual: tuple.len() })
+}
+
+fn expect_string(tuple: &Tuple, index: usize) -> Result<&str, CatalogError> {
+    match expect_value(tuple, index)? {
+        Value::String(value) => Ok(value),
+        _ => Err(CatalogError::InvalidFieldType { index, expected: "text" }),
+    }
+}
+
+fn expect_bool(tuple: &Tuple, index: usize) -> Result<bool, CatalogError> {
+    match expect_value(tuple, index)? {
+        Value::Boolean(value) => Ok(*value),
+        _ => Err(CatalogError::InvalidFieldType { index, expected: "boolean" }),
+    }
+}
+
+fn expect_integer(tuple: &Tuple, index: usize) -> Result<i32, CatalogError> {
+    match expect_value(tuple, index)? {
+        Value::Integer(value) => Ok(*value),
+        _ => Err(CatalogError::InvalidFieldType { index, expected: "integer" }),
+    }
+}
+
+fn expect_unsigned(tuple: &Tuple, index: usize) -> Result<u64, CatalogError> {
+    match expect_value(tuple, index)? {
+        Value::UnsignedInteger(value) => Ok(*value),
+        _ => Err(CatalogError::InvalidFieldType { index, expected: "unsigned integer" }),
+    }
+}
+
+fn expect_optional_unsigned(tuple: &Tuple, index: usize) -> Result<Option<u64>, CatalogError> {
+    match expect_value(tuple, index)? {
+        Value::Null => Ok(None),
+        Value::UnsignedInteger(value) => Ok(Some(*value)),
+        _ => Err(CatalogError::InvalidFieldType { index, expected: "nullable unsigned integer" }),
+    }
+}

--- a/src/core/disk_manager.rs
+++ b/src/core/disk_manager.rs
@@ -39,6 +39,10 @@ impl DiskManager {
         Ok(Self { file, page_count })
     }
 
+    pub(crate) fn page_count(&self) -> u64 {
+        self.page_count
+    }
+
     /// Extends the database file by one page.
     /// Returns page ID of the new page.
     pub(crate) fn new_page(&mut self) -> DiskManagerResult<PageId> {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -35,6 +35,7 @@ pub struct CorruptionError {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CorruptionComponent {
+    Catalog,
     DatabaseFile,
     DiskPage,
     OverflowPage,
@@ -88,12 +89,22 @@ pub enum CorruptionKind {
     OverflowChainTooShort { expected: usize, actual: usize },
     #[error("overflow chain has extra pages after {expected} bytes were read")]
     OverflowChainTooLong { expected: usize },
+    #[error("missing system catalog root page {page_id}")]
+    MissingSystemCatalogRoot { page_id: PageId },
+    #[error("unexpected system catalog root page: expected {expected}, got {actual}")]
+    UnexpectedSystemCatalogRoot { expected: PageId, actual: PageId },
+    #[error("invalid catalog row in {table}: {reason}")]
+    InvalidCatalogRow { table: &'static str, reason: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ConstraintError {
     #[error("duplicate key")]
     DuplicateKey,
+    #[error("duplicate table name: {name}")]
+    DuplicateTableName { name: String },
+    #[error("duplicate index name: {name}")]
+    DuplicateIndexName { name: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -102,6 +113,14 @@ pub enum InvalidArgumentError {
     InvalidPageId { page_id: PageId },
     #[error("key not found")]
     KeyNotFound,
+    #[error("table not found: {name}")]
+    TableNotFound { name: String },
+    #[error("index not found: {name}")]
+    IndexNotFound { name: String },
+    #[error("column {column} not found in table {table}")]
+    ColumnNotFound { table: String, column: String },
+    #[error("index column list cannot be empty")]
+    EmptyIndexColumns,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -376,6 +395,7 @@ fn map_cell_corruption(kind: CellCorruption) -> CorruptionKind {
 impl fmt::Display for CorruptionComponent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Catalog => write!(f, "catalog"),
             Self::DatabaseFile => write!(f, "database file"),
             Self::DiskPage => write!(f, "disk page"),
             Self::OverflowPage => write!(f, "overflow page"),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod btree;
+pub mod catalog;
 pub mod cursor;
 pub mod disk_manager;
 pub mod error;
@@ -13,6 +14,12 @@ pub mod pager;
 pub mod tuple;
 
 pub use btree::{CursorState, OwnedRecord, Record, RecordView, TreeCursor};
+pub use catalog::{
+    CatalogError, CatalogObjectKind, ColumnCatalogRow, ColumnSchema, DataType, IndexCatalogRow,
+    IndexColumnSchema, IndexSchema, SYS_COLUMNS_ROOT_PAGE_ID, SYS_COLUMNS_TABLE_ID,
+    SYS_INDEXES_ROOT_PAGE_ID, SYS_INDEXES_TABLE_ID, SYS_TABLES_ROOT_PAGE_ID, SYS_TABLES_TABLE_ID,
+    TableCatalogRow, TableSchema, TupleSchema,
+};
 pub use cursor::{
     IndexCursor, IndexEntry, IndexEntryRef, TableCursor, TableRecord, TableRecordRef,
 };

--- a/src/core/pager.rs
+++ b/src/core/pager.rs
@@ -362,13 +362,14 @@ impl Pager {
             return Ok(rows);
         }
 
+        let mut record = cursor
+            .current_owned()?
+            .expect("positioned catalog cursor should have a current record");
         loop {
-            let record = cursor
-                .current_owned()?
-                .expect("positioned catalog cursor should have a current record");
             rows.push(decode_catalog_record(catalog_table_name, record, &decode)?);
-            if cursor.next_owned_record()?.is_none() {
-                break;
+            match cursor.next_owned_record()? {
+                Some(next_record) => record = next_record,
+                None => break,
             }
         }
         Ok(rows)

--- a/src/core/pager.rs
+++ b/src/core/pager.rs
@@ -1,11 +1,20 @@
 use std::path::{Path, PathBuf};
 
 use crate::core::{
-    PageId,
-    btree::{TreeCursor, initialize_empty_root, validate_root_page},
+    CatalogError, IndexSchema, PageId, RowId, TableCatalogRow, TableRecord, TableSchema, Tuple,
+    TupleSchema,
+    btree::{OwnedRecord, TreeCursor, initialize_empty_root, validate_root_page},
+    catalog::{
+        CatalogObjectKind, ColumnCatalogRow, ColumnSchema, IndexCatalogRow, IndexColumnSchema,
+        SYS_COLUMNS_ROOT_PAGE_ID, SYS_INDEXES_ROOT_PAGE_ID, SYS_TABLES_ROOT_PAGE_ID,
+        system_column_rows, system_table_schemas,
+    },
     cursor::{IndexCursor, TableCursor},
     disk_manager::DiskManager,
-    error::StorageResult,
+    error::{
+        ConstraintError, CorruptionComponent, CorruptionError, CorruptionKind,
+        InvalidArgumentError, StorageError, StorageResult,
+    },
     page_cache::PageCache,
 };
 
@@ -45,8 +54,11 @@ impl Pager {
     pub fn open_with_options(path: impl AsRef<Path>, options: PagerOptions) -> StorageResult<Self> {
         let path = path.as_ref().to_path_buf();
         let disk_manager = DiskManager::new(&path)?;
+        let page_count = disk_manager.page_count();
         let page_cache = PageCache::new(disk_manager, options.cache_frames)?;
-        Ok(Self { path, page_cache, options })
+        let pager = Self { path, page_cache, options };
+        pager.initialize_or_validate_system_catalog(page_count)?;
+        Ok(pager)
     }
 
     /// Returns the database-file path associated with this pager.
@@ -65,16 +77,132 @@ impl Pager {
         Ok(())
     }
 
+    /// Creates a cataloged table, allocates its root page, and records its columns.
+    pub fn create_table(&self, name: &str, row: TupleSchema) -> StorageResult<TableSchema> {
+        if self.table_catalog_rows()?.iter().any(|row| row.name == name) {
+            return Err(StorageError::Constraint(ConstraintError::DuplicateTableName {
+                name: name.to_owned(),
+            }));
+        }
+
+        let table_id = self.next_object_id()?;
+        let mut column_id = self.next_column_id()?;
+        let root_page_id = self.create_table_tree()?.root_page_id();
+        let schema = TableSchema { table_id, name: name.to_owned(), root_page_id, row };
+
+        self.insert_table_catalog_row(&schema.catalog_row())?;
+        for (ordinal, column) in schema.row.columns.iter().enumerate() {
+            let row = ColumnCatalogRow {
+                column_id,
+                object_kind: CatalogObjectKind::Table,
+                object_id: table_id,
+                ordinal: ordinal as u64,
+                name: column.name.clone(),
+                data_type: column.data_type,
+                nullable: column.nullable,
+                primary_key: column.primary_key,
+                source_table_id: None,
+                source_column_ordinal: None,
+            };
+            self.insert_column_catalog_row(&row)?;
+            column_id += 1;
+        }
+
+        Ok(schema)
+    }
+
+    /// Creates a cataloged secondary index over columns from an existing table.
+    pub fn create_index(
+        &self,
+        name: &str,
+        table_name: &str,
+        columns: &[&str],
+    ) -> StorageResult<IndexSchema> {
+        if columns.is_empty() {
+            return Err(StorageError::InvalidArgument(InvalidArgumentError::EmptyIndexColumns));
+        }
+        if self.index_catalog_rows()?.iter().any(|row| row.name == name) {
+            return Err(StorageError::Constraint(ConstraintError::DuplicateIndexName {
+                name: name.to_owned(),
+            }));
+        }
+
+        let table = self.table_schema_by_name(table_name)?;
+        let index_id = self.next_object_id()?;
+        let mut column_id = self.next_column_id()?;
+        let mut index_columns = Vec::new();
+        let mut catalog_columns = Vec::new();
+
+        for (ordinal, column_name) in columns.iter().enumerate() {
+            let (source_column_ordinal, source_column) = table
+                .row
+                .columns
+                .iter()
+                .enumerate()
+                .find(|(_, column)| column.name == *column_name)
+                .ok_or_else(|| {
+                    StorageError::InvalidArgument(InvalidArgumentError::ColumnNotFound {
+                        table: table.name.clone(),
+                        column: (*column_name).to_owned(),
+                    })
+                })?;
+            index_columns.push(IndexColumnSchema {
+                source_column_ordinal: source_column_ordinal as u64,
+                column: source_column.clone(),
+            });
+            catalog_columns.push(ColumnCatalogRow {
+                column_id,
+                object_kind: CatalogObjectKind::Index,
+                object_id: index_id,
+                ordinal: ordinal as u64,
+                name: source_column.name.clone(),
+                data_type: source_column.data_type,
+                nullable: source_column.nullable,
+                primary_key: source_column.primary_key,
+                source_table_id: Some(table.table_id),
+                source_column_ordinal: Some(source_column_ordinal as u64),
+            });
+            column_id += 1;
+        }
+
+        let root_page_id = self.create_index_tree()?.root_page_id();
+        let schema = IndexSchema {
+            index_id,
+            name: name.to_owned(),
+            table_id: table.table_id,
+            root_page_id,
+            unique: false,
+            columns: index_columns,
+        };
+        self.insert_index_catalog_row(&schema.catalog_row())?;
+        for row in catalog_columns {
+            self.insert_column_catalog_row(&row)?;
+        }
+        Ok(schema)
+    }
+
     /// Creates a new empty table tree and returns a cursor rooted at it.
-    pub fn create_table(&self) -> StorageResult<TableCursor> {
+    pub fn create_table_tree(&self) -> StorageResult<TableCursor> {
         let root_page_id = initialize_empty_root(&self.page_cache)?;
         Ok(TableCursor::new(TreeCursor::new(self.page_cache.clone(), root_page_id)))
     }
 
     /// Creates a new empty secondary-index tree and returns a cursor rooted at it.
-    pub fn create_index(&self) -> StorageResult<IndexCursor> {
+    pub fn create_index_tree(&self) -> StorageResult<IndexCursor> {
         let root_page_id = initialize_empty_root(&self.page_cache)?;
         Ok(IndexCursor::new(TreeCursor::new(self.page_cache.clone(), root_page_id)))
+    }
+
+    /// Returns a typed cursor for the cataloged table named `name`.
+    pub fn table_cursor_by_name(&self, name: &str) -> StorageResult<TableCursor> {
+        let schema = self.table_schema_by_name(name)?;
+        self.table_cursor(schema.root_page_id)
+    }
+
+    /// Returns a typed cursor for the cataloged index named `name`.
+    pub fn index_cursor_by_name(&self, name: &str) -> StorageResult<IndexCursor> {
+        let schema = self.index_schema_by_name(name)?;
+        self.index_cursor(schema.root_page_id)
     }
 
     /// Returns a typed cursor rooted at an existing table tree.
@@ -87,5 +215,487 @@ impl Pager {
     pub fn index_cursor(&self, root_page_id: PageId) -> StorageResult<IndexCursor> {
         validate_root_page(&self.page_cache, root_page_id)?;
         Ok(IndexCursor::new(TreeCursor::new(self.page_cache.clone(), root_page_id)))
+    }
+
+    fn initialize_or_validate_system_catalog(&self, page_count: u64) -> StorageResult<()> {
+        match page_count {
+            0 => self.initialize_system_catalog(),
+            1..=2 => Err(missing_system_catalog_root(page_count)),
+            _ => self.validate_system_catalog(),
+        }
+    }
+
+    fn initialize_system_catalog(&self) -> StorageResult<()> {
+        self.initialize_system_root(SYS_TABLES_ROOT_PAGE_ID)?;
+        self.initialize_system_root(SYS_INDEXES_ROOT_PAGE_ID)?;
+        self.initialize_system_root(SYS_COLUMNS_ROOT_PAGE_ID)?;
+        self.seed_system_catalog()
+    }
+
+    /// Inserts the built-in system catalog rows into a freshly initialized database.
+    fn seed_system_catalog(&self) -> StorageResult<()> {
+        let mut tables = self.table_cursor(SYS_TABLES_ROOT_PAGE_ID)?;
+        let mut columns = self.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID)?;
+
+        for schema in system_table_schemas() {
+            let bytes = schema.catalog_row().to_bytes()?;
+            tables.insert(schema.table_id, &bytes)?;
+        }
+
+        for row in system_column_rows() {
+            let bytes = row.to_bytes()?;
+            columns.insert(row.column_id, &bytes)?;
+        }
+
+        Ok(())
+    }
+
+    fn initialize_system_root(&self, expected_page_id: PageId) -> StorageResult<()> {
+        let actual_page_id = initialize_empty_root(&self.page_cache)?;
+        if actual_page_id == expected_page_id {
+            Ok(())
+        } else {
+            Err(unexpected_system_catalog_root(expected_page_id, actual_page_id))
+        }
+    }
+
+    fn validate_system_catalog(&self) -> StorageResult<()> {
+        validate_root_page(&self.page_cache, SYS_TABLES_ROOT_PAGE_ID)?;
+        validate_root_page(&self.page_cache, SYS_INDEXES_ROOT_PAGE_ID)?;
+        validate_root_page(&self.page_cache, SYS_COLUMNS_ROOT_PAGE_ID)?;
+        Ok(())
+    }
+
+    fn table_schema_by_name(&self, name: &str) -> StorageResult<TableSchema> {
+        let table =
+            self.table_catalog_rows()?.into_iter().find(|row| row.name == name).ok_or_else(
+                || {
+                    StorageError::InvalidArgument(InvalidArgumentError::TableNotFound {
+                        name: name.to_owned(),
+                    })
+                },
+            )?;
+        let mut columns: Vec<_> = self
+            .column_catalog_rows()?
+            .into_iter()
+            .filter(|row| {
+                row.object_kind == CatalogObjectKind::Table && row.object_id == table.table_id
+            })
+            .collect();
+        columns.sort_by_key(|row| row.ordinal);
+
+        Ok(TableSchema {
+            table_id: table.table_id,
+            name: table.name,
+            root_page_id: table.root_page_id,
+            row: TupleSchema { columns: columns.into_iter().map(column_schema_from_row).collect() },
+        })
+    }
+
+    fn index_schema_by_name(&self, name: &str) -> StorageResult<IndexSchema> {
+        let index =
+            self.index_catalog_rows()?.into_iter().find(|row| row.name == name).ok_or_else(
+                || {
+                    StorageError::InvalidArgument(InvalidArgumentError::IndexNotFound {
+                        name: name.to_owned(),
+                    })
+                },
+            )?;
+        let mut columns: Vec<_> = self
+            .column_catalog_rows()?
+            .into_iter()
+            .filter(|row| {
+                row.object_kind == CatalogObjectKind::Index && row.object_id == index.index_id
+            })
+            .collect();
+        columns.sort_by_key(|row| row.ordinal);
+
+        Ok(IndexSchema {
+            index_id: index.index_id,
+            name: index.name,
+            table_id: index.table_id,
+            root_page_id: index.root_page_id,
+            unique: index.unique,
+            columns: columns
+                .into_iter()
+                .map(|row| IndexColumnSchema {
+                    source_column_ordinal: row.source_column_ordinal.unwrap_or(row.ordinal),
+                    column: column_schema_from_row(row),
+                })
+                .collect(),
+        })
+    }
+
+    fn next_object_id(&self) -> StorageResult<RowId> {
+        let max_table_id =
+            self.table_catalog_rows()?.into_iter().map(|row| row.table_id).max().unwrap_or(0);
+        let max_index_id =
+            self.index_catalog_rows()?.into_iter().map(|row| row.index_id).max().unwrap_or(0);
+        Ok(max_table_id.max(max_index_id) + 1)
+    }
+
+    fn next_column_id(&self) -> StorageResult<RowId> {
+        Ok(self.column_catalog_rows()?.into_iter().map(|row| row.column_id).max().unwrap_or(0) + 1)
+    }
+
+    fn table_catalog_rows(&self) -> StorageResult<Vec<TableCatalogRow>> {
+        self.scan_catalog_table(SYS_TABLES_ROOT_PAGE_ID, "sys_tables", TableCatalogRow::decode)
+    }
+
+    fn index_catalog_rows(&self) -> StorageResult<Vec<IndexCatalogRow>> {
+        self.scan_catalog_table(SYS_INDEXES_ROOT_PAGE_ID, "sys_indexes", IndexCatalogRow::decode)
+    }
+
+    fn column_catalog_rows(&self) -> StorageResult<Vec<ColumnCatalogRow>> {
+        self.scan_catalog_table(SYS_COLUMNS_ROOT_PAGE_ID, "sys_columns", ColumnCatalogRow::decode)
+    }
+
+    fn scan_catalog_table<T>(
+        &self,
+        root_page_id: PageId,
+        catalog_table_name: &'static str,
+        decode: impl Fn(&Tuple) -> Result<T, crate::core::CatalogError>,
+    ) -> StorageResult<Vec<T>> {
+        let mut cursor = TreeCursor::new(self.page_cache.clone(), root_page_id);
+        let mut rows = Vec::new();
+        if !cursor.seek_to_first()? {
+            return Ok(rows);
+        }
+
+        loop {
+            let record = cursor
+                .current_owned()?
+                .expect("positioned catalog cursor should have a current record");
+            rows.push(decode_catalog_record(catalog_table_name, record, &decode)?);
+            if cursor.next_owned_record()?.is_none() {
+                break;
+            }
+        }
+        Ok(rows)
+    }
+
+    fn insert_table_catalog_row(&self, row: &TableCatalogRow) -> StorageResult<()> {
+        self.insert_catalog_row(SYS_TABLES_ROOT_PAGE_ID, row.table_id, &row.encode())
+    }
+
+    fn insert_index_catalog_row(&self, row: &IndexCatalogRow) -> StorageResult<()> {
+        self.insert_catalog_row(SYS_INDEXES_ROOT_PAGE_ID, row.index_id, &row.encode())
+    }
+
+    fn insert_column_catalog_row(&self, row: &ColumnCatalogRow) -> StorageResult<()> {
+        self.insert_catalog_row(SYS_COLUMNS_ROOT_PAGE_ID, row.column_id, &row.encode())
+    }
+
+    fn insert_catalog_row(
+        &self,
+        root_page_id: PageId,
+        row_id: RowId,
+        tuple: &Tuple,
+    ) -> StorageResult<()> {
+        let mut cursor = TableCursor::new(TreeCursor::new(self.page_cache.clone(), root_page_id));
+        let bytes = tuple.to_bytes()?;
+        cursor.insert(row_id, &bytes)
+    }
+}
+
+fn missing_system_catalog_root(page_id: PageId) -> StorageError {
+    StorageError::Corruption(CorruptionError {
+        component: CorruptionComponent::Catalog,
+        page_id: Some(page_id),
+        kind: CorruptionKind::MissingSystemCatalogRoot { page_id },
+    })
+}
+
+fn unexpected_system_catalog_root(expected: PageId, actual: PageId) -> StorageError {
+    StorageError::Corruption(CorruptionError {
+        component: CorruptionComponent::Catalog,
+        page_id: Some(actual),
+        kind: CorruptionKind::UnexpectedSystemCatalogRoot { expected, actual },
+    })
+}
+
+fn decode_catalog_record<T>(
+    catalog_table_name: &'static str,
+    record: OwnedRecord,
+    decode: &impl Fn(&Tuple) -> Result<T, CatalogError>,
+) -> StorageResult<T> {
+    let record = TableRecord::try_from(record)?;
+    let tuple = Tuple::from_bytes(&record.record)
+        .map_err(|error| invalid_catalog_row(catalog_table_name, error))?;
+    decode(&tuple).map_err(|error| invalid_catalog_row(catalog_table_name, error))
+}
+
+fn invalid_catalog_row(table: &'static str, error: impl std::error::Error) -> StorageError {
+    StorageError::Corruption(CorruptionError {
+        component: CorruptionComponent::Catalog,
+        page_id: None,
+        kind: CorruptionKind::InvalidCatalogRow { table, reason: error.to_string() },
+    })
+}
+
+fn column_schema_from_row(row: ColumnCatalogRow) -> ColumnSchema {
+    ColumnSchema {
+        name: row.name,
+        data_type: row.data_type,
+        nullable: row.nullable,
+        primary_key: row.primary_key,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::core::{
+        ColumnCatalogRow, ColumnSchema, DataType, IndexCatalogRow, RowId, Tuple, TupleSchema,
+        catalog::{
+            SYS_COLUMNS_TABLE_ID, SYS_INDEXES_TABLE_ID, SYS_TABLES_TABLE_ID, TableCatalogRow,
+            system_column_rows,
+        },
+    };
+
+    #[test]
+    fn open_new_database_bootstraps_system_catalog_roots_and_rows() {
+        let file = NamedTempFile::new().unwrap();
+        let pager = Pager::open(file.path()).unwrap();
+
+        assert_eq!(pager.create_table_tree().unwrap().root_page_id(), 3);
+
+        let mut tables = pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID).unwrap();
+        assert_table_catalog_row(
+            &mut tables,
+            SYS_TABLES_TABLE_ID,
+            "sys_tables",
+            SYS_TABLES_ROOT_PAGE_ID,
+        );
+        assert_table_catalog_row(
+            &mut tables,
+            SYS_INDEXES_TABLE_ID,
+            "sys_indexes",
+            SYS_INDEXES_ROOT_PAGE_ID,
+        );
+        assert_table_catalog_row(
+            &mut tables,
+            SYS_COLUMNS_TABLE_ID,
+            "sys_columns",
+            SYS_COLUMNS_ROOT_PAGE_ID,
+        );
+
+        let mut columns = pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
+        for row in system_column_rows() {
+            let record =
+                columns.get(row.column_id).unwrap().expect("system column row should exist");
+            let tuple = Tuple::from_bytes(&record.record).unwrap();
+            let actual = crate::core::catalog::ColumnCatalogRow::decode(&tuple).unwrap();
+            assert_eq!(actual.column_id, row.column_id);
+            assert_eq!(actual.object_kind, row.object_kind);
+            assert_eq!(actual.object_id, row.object_id);
+            assert_eq!(actual.ordinal, row.ordinal);
+            assert_eq!(actual.name, row.name);
+            assert_eq!(actual.data_type, row.data_type);
+            assert_eq!(actual.nullable, row.nullable);
+            assert_eq!(actual.primary_key, row.primary_key);
+            assert_eq!(actual.source_table_id, row.source_table_id);
+            assert_eq!(actual.source_column_ordinal, row.source_column_ordinal);
+        }
+    }
+
+    #[test]
+    fn open_existing_database_validates_system_catalog() {
+        let file = NamedTempFile::new().unwrap();
+        {
+            let pager = Pager::open(file.path()).unwrap();
+            pager.flush().unwrap();
+        }
+
+        let pager = Pager::open(file.path()).unwrap();
+        let mut tables = pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID).unwrap();
+        assert_table_catalog_row(
+            &mut tables,
+            SYS_TABLES_TABLE_ID,
+            "sys_tables",
+            SYS_TABLES_ROOT_PAGE_ID,
+        );
+    }
+
+    #[test]
+    fn open_rejects_partial_system_catalog() {
+        let file = NamedTempFile::new().unwrap();
+        {
+            let mut disk_manager = DiskManager::new(file.path()).unwrap();
+            assert_eq!(disk_manager.new_page().unwrap(), 0);
+        }
+
+        let error = match Pager::open(file.path()) {
+            Ok(_) => panic!("partial catalog should be rejected"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            StorageError::Corruption(CorruptionError {
+                component: CorruptionComponent::Catalog,
+                kind: CorruptionKind::MissingSystemCatalogRoot { page_id: 1 },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn create_table_records_schema_in_catalog() {
+        let file = NamedTempFile::new().unwrap();
+        let pager = Pager::open(file.path()).unwrap();
+        let row_schema = users_schema();
+
+        let table = pager.create_table("users", row_schema.clone()).unwrap();
+
+        assert_eq!(table.table_id, 4);
+        assert_eq!(table.name, "users");
+        assert_eq!(table.root_page_id, 3);
+        assert_eq!(table.row, row_schema);
+        assert_eq!(pager.table_cursor_by_name("users").unwrap().root_page_id(), table.root_page_id);
+
+        let mut tables = pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID).unwrap();
+        assert_table_catalog_row(&mut tables, table.table_id, "users", table.root_page_id);
+
+        let first_user_column_id = system_column_rows().len() as RowId + 1;
+        let mut columns = pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
+        assert_column_catalog_row(
+            &mut columns,
+            ColumnCatalogRow {
+                column_id: first_user_column_id,
+                object_kind: CatalogObjectKind::Table,
+                object_id: table.table_id,
+                ordinal: 0,
+                name: "id".to_owned(),
+                data_type: DataType::Integer,
+                nullable: false,
+                primary_key: true,
+                source_table_id: None,
+                source_column_ordinal: None,
+            },
+        );
+    }
+
+    #[test]
+    fn create_index_records_explicit_name_and_source_columns_in_catalog() {
+        let file = NamedTempFile::new().unwrap();
+        let pager = Pager::open(file.path()).unwrap();
+        let table = pager.create_table("users", users_schema()).unwrap();
+
+        let index = pager.create_index("idx_users_email", "users", &["email"]).unwrap();
+
+        assert_eq!(index.index_id, 5);
+        assert_eq!(index.name, "idx_users_email");
+        assert_eq!(index.table_id, table.table_id);
+        assert_eq!(index.root_page_id, 4);
+        assert_eq!(index.columns.len(), 1);
+        assert_eq!(index.columns[0].source_column_ordinal, 2);
+        assert_eq!(index.columns[0].column.name, "email");
+        assert_eq!(
+            pager.index_cursor_by_name("idx_users_email").unwrap().root_page_id(),
+            index.root_page_id
+        );
+
+        let mut indexes = pager.table_cursor(SYS_INDEXES_ROOT_PAGE_ID).unwrap();
+        assert_index_catalog_row(
+            &mut indexes,
+            IndexCatalogRow {
+                index_id: index.index_id,
+                name: "idx_users_email".to_owned(),
+                table_id: table.table_id,
+                root_page_id: index.root_page_id,
+                unique: false,
+            },
+        );
+
+        let index_column_id =
+            system_column_rows().len() as RowId + table.row.columns.len() as RowId + 1;
+        let mut columns = pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
+        assert_column_catalog_row(
+            &mut columns,
+            ColumnCatalogRow {
+                column_id: index_column_id,
+                object_kind: CatalogObjectKind::Index,
+                object_id: index.index_id,
+                ordinal: 0,
+                name: "email".to_owned(),
+                data_type: DataType::Text,
+                nullable: false,
+                primary_key: false,
+                source_table_id: Some(table.table_id),
+                source_column_ordinal: Some(2),
+            },
+        );
+    }
+
+    #[test]
+    fn create_index_rejects_unknown_table_column() {
+        let file = NamedTempFile::new().unwrap();
+        let pager = Pager::open(file.path()).unwrap();
+        pager.create_table("users", users_schema()).unwrap();
+
+        let error = pager.create_index("idx_users_missing", "users", &["missing"]).unwrap_err();
+
+        assert!(matches!(
+            error,
+            StorageError::InvalidArgument(InvalidArgumentError::ColumnNotFound {
+                table,
+                column,
+            }) if table == "users" && column == "missing"
+        ));
+    }
+
+    fn assert_table_catalog_row(
+        tables: &mut TableCursor,
+        table_id: RowId,
+        name: &str,
+        root_page_id: PageId,
+    ) {
+        let record = tables.get(table_id).unwrap().expect("system table row should exist");
+        let tuple = Tuple::from_bytes(&record.record).unwrap();
+        assert_eq!(
+            TableCatalogRow::decode(&tuple).unwrap(),
+            TableCatalogRow { table_id, name: name.to_owned(), root_page_id }
+        );
+    }
+
+    fn assert_index_catalog_row(indexes: &mut TableCursor, expected: IndexCatalogRow) {
+        let record =
+            indexes.get(expected.index_id).unwrap().expect("index catalog row should exist");
+        let tuple = Tuple::from_bytes(&record.record).unwrap();
+        assert_eq!(IndexCatalogRow::decode(&tuple).unwrap(), expected);
+    }
+
+    fn assert_column_catalog_row(columns: &mut TableCursor, expected: ColumnCatalogRow) {
+        let record =
+            columns.get(expected.column_id).unwrap().expect("column catalog row should exist");
+        let tuple = Tuple::from_bytes(&record.record).unwrap();
+        assert_eq!(ColumnCatalogRow::decode(&tuple).unwrap(), expected);
+    }
+
+    fn users_schema() -> TupleSchema {
+        TupleSchema {
+            columns: vec![
+                ColumnSchema {
+                    name: "id".to_owned(),
+                    data_type: DataType::Integer,
+                    nullable: false,
+                    primary_key: true,
+                },
+                ColumnSchema {
+                    name: "name".to_owned(),
+                    data_type: DataType::Text,
+                    nullable: false,
+                    primary_key: false,
+                },
+                ColumnSchema {
+                    name: "email".to_owned(),
+                    data_type: DataType::Text,
+                    nullable: false,
+                    primary_key: false,
+                },
+            ],
+        }
     }
 }

--- a/src/core/tuple.rs
+++ b/src/core/tuple.rs
@@ -9,27 +9,35 @@ const TAG_STRING: u8 = 0x01;
 const TAG_BOOLEAN: u8 = 0x02;
 const TAG_INTEGER: u8 = 0x03;
 const TAG_FLOAT: u8 = 0x04;
+const TAG_NULL: u8 = 0x05;
+const TAG_UNSIGNED_INTEGER: u8 = 0x06;
 
+const NULL_LENGTH: u32 = 0;
 const BOOL_LENGTH: u32 = 1;
 const I32_LENGTH: u32 = size_of::<i32>() as u32;
 const F32_LENGTH: u32 = size_of::<f32>() as u32;
+const U64_LENGTH: u32 = size_of::<u64>() as u32;
 
 /// A single typed value stored in a [`Tuple`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
+    Null,
     String(String),
     Boolean(bool),
     Integer(i32),
     Float(f32),
+    UnsignedInteger(u64),
 }
 
 /// A borrowed typed value.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ValueRef<'a> {
+    Null,
     String(&'a str),
     Boolean(bool),
     Integer(i32),
     Float(f32),
+    UnsignedInteger(u64),
 }
 
 /// An ordered list of typed storage values.
@@ -242,6 +250,7 @@ impl<'a> EncodedTupleView<'a> {
 fn value_ref_from_field<'a>(bytes: &'a [u8], field: &ValueField) -> ValueRef<'a> {
     let payload = &bytes[field.value_range.clone()];
     match field.tag {
+        TAG_NULL => ValueRef::Null,
         TAG_STRING => {
             ValueRef::String(std::str::from_utf8(payload).expect("validated string payload"))
         }
@@ -252,6 +261,9 @@ fn value_ref_from_field<'a>(bytes: &'a [u8], field: &ValueField) -> ValueRef<'a>
         TAG_FLOAT => {
             ValueRef::Float(f32::from_le_bytes(payload.try_into().expect("validated f32 payload")))
         }
+        TAG_UNSIGNED_INTEGER => ValueRef::UnsignedInteger(u64::from_le_bytes(
+            payload.try_into().expect("validated u64 payload"),
+        )),
         _ => unreachable!("validated tuple value tag"),
     }
 }
@@ -289,10 +301,12 @@ impl<'a> IntoIterator for &'a Tuple {
 impl<'a> From<&'a Value> for ValueRef<'a> {
     fn from(value: &'a Value) -> Self {
         match value {
+            Value::Null => Self::Null,
             Value::String(value) => Self::String(value),
             Value::Boolean(value) => Self::Boolean(*value),
             Value::Integer(value) => Self::Integer(*value),
             Value::Float(value) => Self::Float(*value),
+            Value::UnsignedInteger(value) => Self::UnsignedInteger(*value),
         }
     }
 }
@@ -300,10 +314,12 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
 impl<'a> From<ValueRef<'a>> for Value {
     fn from(value: ValueRef<'a>) -> Self {
         match value {
+            ValueRef::Null => Self::Null,
             ValueRef::String(value) => Self::String(value.to_owned()),
             ValueRef::Boolean(value) => Self::Boolean(value),
             ValueRef::Integer(value) => Self::Integer(value),
             ValueRef::Float(value) => Self::Float(value),
+            ValueRef::UnsignedInteger(value) => Self::UnsignedInteger(value),
         }
     }
 }
@@ -370,6 +386,7 @@ where
 
 fn write_value_ref<W: Write>(writer: &mut W, value: ValueRef<'_>) -> io::Result<()> {
     match value {
+        ValueRef::Null => write_tlv_header(writer, TAG_NULL, NULL_LENGTH),
         ValueRef::String(value) => {
             let len = u32::try_from(value.len()).map_err(|_| {
                 io::Error::new(io::ErrorKind::InvalidInput, "string length exceeds u32::MAX")
@@ -389,6 +406,10 @@ fn write_value_ref<W: Write>(writer: &mut W, value: ValueRef<'_>) -> io::Result<
             write_tlv_header(writer, TAG_FLOAT, F32_LENGTH)?;
             writer.write_all(&value.to_le_bytes())
         }
+        ValueRef::UnsignedInteger(value) => {
+            write_tlv_header(writer, TAG_UNSIGNED_INTEGER, U64_LENGTH)?;
+            writer.write_all(&value.to_le_bytes())
+        }
     }
 }
 
@@ -399,6 +420,10 @@ fn write_tlv_header<W: Write>(writer: &mut W, tag: u8, len: u32) -> io::Result<(
 
 fn read_value<R: Read>(reader: &mut R, tag: u8, len: u32) -> io::Result<Value> {
     match tag {
+        TAG_NULL => {
+            validate_len(tag, len, NULL_LENGTH)?;
+            Ok(Value::Null)
+        }
         TAG_STRING => {
             let mut bytes = Vec::new();
             bytes.try_reserve_exact(len as usize).map_err(|source| {
@@ -434,6 +459,12 @@ fn read_value<R: Read>(reader: &mut R, tag: u8, len: u32) -> io::Result<Value> {
             reader.read_exact(&mut bytes)?;
             Ok(Value::Float(f32::from_le_bytes(bytes)))
         }
+        TAG_UNSIGNED_INTEGER => {
+            validate_len(tag, len, U64_LENGTH)?;
+            let mut bytes = [0; size_of::<u64>()];
+            reader.read_exact(&mut bytes)?;
+            Ok(Value::UnsignedInteger(u64::from_le_bytes(bytes)))
+        }
         actual => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("unknown tuple value tag: {actual}"),
@@ -443,6 +474,7 @@ fn read_value<R: Read>(reader: &mut R, tag: u8, len: u32) -> io::Result<Value> {
 
 fn validate_value_payload(tag: u8, payload: &[u8]) -> io::Result<()> {
     match tag {
+        TAG_NULL => validate_len(tag, payload.len() as u32, NULL_LENGTH),
         TAG_STRING => {
             std::str::from_utf8(payload).map_err(invalid_data)?;
             Ok(())
@@ -459,6 +491,7 @@ fn validate_value_payload(tag: u8, payload: &[u8]) -> io::Result<()> {
         }
         TAG_INTEGER => validate_len(tag, payload.len() as u32, I32_LENGTH),
         TAG_FLOAT => validate_len(tag, payload.len() as u32, F32_LENGTH),
+        TAG_UNSIGNED_INTEGER => validate_len(tag, payload.len() as u32, U64_LENGTH),
         actual => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("unknown tuple value tag: {actual}"),
@@ -523,10 +556,12 @@ mod tests {
     #[test]
     fn mixed_tuple_round_trips() {
         let tuple = Tuple::new(vec![
+            Value::Null,
             Value::String("hello".to_owned()),
             Value::Boolean(true),
             Value::Integer(-42),
             Value::Float(3.25),
+            Value::UnsignedInteger(u64::MAX),
         ]);
 
         let bytes = tuple.to_bytes().unwrap();
@@ -600,11 +635,12 @@ mod tests {
 
     #[test]
     fn rejects_invalid_fixed_lengths() {
-        for tag in [TAG_BOOLEAN, TAG_INTEGER, TAG_FLOAT] {
+        for tag in [TAG_NULL, TAG_BOOLEAN, TAG_INTEGER, TAG_FLOAT, TAG_UNSIGNED_INTEGER] {
             let mut bytes = Vec::new();
             bytes.extend_from_slice(&1u32.to_le_bytes());
             bytes.push(tag);
-            bytes.extend_from_slice(&0u32.to_le_bytes());
+            let invalid_len = if tag == TAG_NULL { 1_u32 } else { 0 };
+            bytes.extend_from_slice(&invalid_len.to_le_bytes());
 
             let error = read(&bytes).unwrap_err();
             assert_eq!(error.kind(), io::ErrorKind::InvalidData);
@@ -656,15 +692,17 @@ mod tests {
     #[test]
     fn tuple_ref_serializes_like_owned_tuple() {
         let borrowed_values = [
+            ValueRef::Null,
             ValueRef::String("hello"),
             ValueRef::Boolean(true),
             ValueRef::Integer(-42),
             ValueRef::Float(3.25),
+            ValueRef::UnsignedInteger(u64::MAX),
         ];
         let tuple_ref = TupleRef::new(&borrowed_values);
         let owned_tuple = Tuple::new(borrowed_values.into_iter().map(Value::from).collect());
 
-        assert_eq!(tuple_ref.len(), 4);
+        assert_eq!(tuple_ref.len(), 6);
         assert!(!tuple_ref.is_empty());
         assert_eq!(tuple_ref.values(), borrowed_values);
         assert_eq!(tuple_ref.to_bytes().unwrap(), owned_tuple.to_bytes().unwrap());
@@ -686,16 +724,18 @@ mod tests {
     #[test]
     fn tuple_view_parses_encoded_bytes_without_owning_values() {
         let tuple = Tuple::new(vec![
+            Value::Null,
             Value::String("hello".to_owned()),
             Value::Boolean(true),
             Value::Integer(-42),
             Value::Float(3.25),
+            Value::UnsignedInteger(u64::MAX),
         ]);
         let bytes = tuple.to_bytes().unwrap();
 
         let view = TupleView::parse(&bytes).unwrap();
 
-        assert_eq!(view.len(), 4);
+        assert_eq!(view.len(), 6);
         assert!(!view.is_empty());
         assert_eq!(view.bytes(), bytes);
         assert_eq!(view.values().collect::<Vec<_>>(), tuple.value_refs().collect::<Vec<_>>());


### PR DESCRIPTION
Adds a schema catalogue for storing metadata for tables, indexes, and columns on disk. The catalogue maintains three internal system tables: `sys_tables`, `sys_indexes`, and `sys_columns`. The trees for these tables are rooted at pages 0, 1, 2, respectively. 