### PR TITLE
Add a database header page and public Database handle

### DIFF
--- a/examples/table_index_query.rs
+++ b/examples/table_index_query.rs
@@ -1,12 +1,13 @@
 use databas::core::{
-    CatalogManager, ColumnSchema, DataType, EncodedTupleView, Tuple, TupleRef, TupleSchema, Value,
+    ColumnSchema, DataType, Database, EncodedTupleView, Tuple, TupleRef, TupleSchema, Value,
     ValueRef,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let db_file = tempfile::NamedTempFile::new()?;
-    let catalog = CatalogManager::open(db_file.path())?;
-    catalog.create_table(
+    let db_dir = tempfile::tempdir()?;
+    let db_path = db_dir.path().join("example.db");
+    let database = Database::create(&db_path)?;
+    database.create_table(
         "users",
         TupleSchema {
             columns: vec![
@@ -31,10 +32,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
         },
     )?;
-    catalog.create_index("idx_users_email", "users", &["email"])?;
+    database.create_index("idx_users_email", "users", &["email"])?;
 
-    let mut users = catalog.table_cursor_by_name("users")?;
-    let mut users_by_email = catalog.index_cursor_by_name("idx_users_email")?;
+    let mut users = database.table_cursor_by_name("users")?;
+    let mut users_by_email = database.index_cursor_by_name("idx_users_email")?;
 
     let row_id = 1;
     let tuple_row_id = 1;

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -11,11 +11,11 @@ use crate::{
 };
 
 /// Root page id of the `sys_tables` catalog table.
-pub const SYS_TABLES_ROOT_PAGE_ID: PageId = 0;
+pub const SYS_TABLES_ROOT_PAGE_ID: PageId = 1;
 /// Root page id of the `sys_indexes` catalog table.
-pub const SYS_INDEXES_ROOT_PAGE_ID: PageId = 1;
+pub const SYS_INDEXES_ROOT_PAGE_ID: PageId = 2;
 /// Root page id of the `sys_columns` catalog table.
-pub const SYS_COLUMNS_ROOT_PAGE_ID: PageId = 2;
+pub const SYS_COLUMNS_ROOT_PAGE_ID: PageId = 3;
 
 /// Stable object id assigned to the `sys_tables` catalog table.
 pub const SYS_TABLES_TABLE_ID: RowId = 1;

--- a/src/core/catalog_manager.rs
+++ b/src/core/catalog_manager.rs
@@ -14,10 +14,10 @@ use crate::core::{
         ConstraintError, CorruptionComponent, CorruptionError, CorruptionKind,
         InvalidArgumentError, StorageError, StorageResult,
     },
-    pager::{Pager, PagerOptions},
+    pager::Pager,
 };
 
-/// Public storage-engine entry point for one database file.
+/// Internal catalog manager for one database file.
 ///
 /// `CatalogManager` owns the low-level pager and manages catalog metadata for
 /// table and index B+-trees.
@@ -27,17 +27,26 @@ pub struct CatalogManager {
 }
 
 impl CatalogManager {
-    /// Opens a catalog manager with default pager options.
-    pub fn open(path: impl AsRef<Path>) -> StorageResult<Self> {
-        let pager = Pager::open(path)?;
+    /// Creates a catalog manager with default pager options.
+    pub(crate) fn create(path: impl AsRef<Path>) -> StorageResult<Self> {
+        let pager = Pager::create(path)?;
         let manager = Self { pager };
         manager.initialize_or_validate_system_catalog()?;
         Ok(manager)
     }
 
-    /// Opens a catalog manager with explicit pager cache settings.
-    pub fn open_with_options(path: impl AsRef<Path>, options: PagerOptions) -> StorageResult<Self> {
-        let pager = Pager::open_with_options(path, options)?;
+    /// Opens a catalog manager, creating an empty database file if needed.
+    #[cfg(test)]
+    pub fn open(path: impl AsRef<Path>) -> StorageResult<Self> {
+        let pager = Pager::open_or_create(path)?;
+        let manager = Self { pager };
+        manager.initialize_or_validate_system_catalog()?;
+        Ok(manager)
+    }
+
+    /// Opens a catalog manager with default pager options.
+    pub(crate) fn open_existing(path: impl AsRef<Path>) -> StorageResult<Self> {
+        let pager = Pager::open(path)?;
         let manager = Self { pager };
         manager.initialize_or_validate_system_catalog()?;
         Ok(manager)
@@ -46,11 +55,6 @@ impl CatalogManager {
     /// Returns the database-file path associated with this manager.
     pub fn path(&self) -> &Path {
         self.pager.path()
-    }
-
-    /// Returns the pager options used when this manager was opened.
-    pub fn options(&self) -> PagerOptions {
-        self.pager.options()
     }
 
     /// Flushes all dirty, currently unpinned pages to disk.
@@ -176,8 +180,9 @@ impl CatalogManager {
 
     fn initialize_or_validate_system_catalog(&self) -> StorageResult<()> {
         match self.pager.opened_page_count() {
-            0 => self.initialize_system_catalog(),
-            1..=2 => Err(missing_system_catalog_root(self.pager.opened_page_count())),
+            0 => Err(crate::core::database_header::missing_header()),
+            1 => self.initialize_system_catalog(),
+            2..=3 => Err(missing_system_catalog_root(self.pager.opened_page_count())),
             _ => self.validate_system_catalog(),
         }
     }
@@ -410,6 +415,7 @@ mod tests {
             SYS_COLUMNS_TABLE_ID, SYS_INDEXES_TABLE_ID, SYS_TABLES_TABLE_ID, TableCatalogRow,
             system_column_rows,
         },
+        database_header::DatabaseHeader,
         disk_manager::DiskManager,
     };
 
@@ -418,7 +424,7 @@ mod tests {
         let file = NamedTempFile::new().unwrap();
         let manager = CatalogManager::open(file.path()).unwrap();
 
-        assert_eq!(manager.pager.create_table_tree().unwrap().root_page_id(), 3);
+        assert_eq!(manager.pager.create_table_tree().unwrap().root_page_id(), 4);
 
         let mut tables = manager.pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID).unwrap();
         assert_table_catalog_row(
@@ -483,6 +489,8 @@ mod tests {
         {
             let mut disk_manager = DiskManager::new(file.path()).unwrap();
             assert_eq!(disk_manager.new_page().unwrap(), 0);
+            disk_manager.write_page(0, &DatabaseHeader::encode_page()).unwrap();
+            assert_eq!(disk_manager.new_page().unwrap(), 1);
         }
 
         let error = match CatalogManager::open(file.path()) {
@@ -493,7 +501,7 @@ mod tests {
             error,
             StorageError::Corruption(CorruptionError {
                 component: CorruptionComponent::Catalog,
-                kind: CorruptionKind::MissingSystemCatalogRoot { page_id: 1 },
+                kind: CorruptionKind::MissingSystemCatalogRoot { page_id: 2 },
                 ..
             })
         ));
@@ -509,7 +517,7 @@ mod tests {
 
         assert_eq!(table.table_id, 4);
         assert_eq!(table.name, "users");
-        assert_eq!(table.root_page_id, 3);
+        assert_eq!(table.root_page_id, 4);
         assert_eq!(table.row, row_schema);
         assert_eq!(
             manager.table_cursor_by_name("users").unwrap().root_page_id(),
@@ -549,7 +557,7 @@ mod tests {
         assert_eq!(index.index_id, 5);
         assert_eq!(index.name, "idx_users_email");
         assert_eq!(index.table_id, table.table_id);
-        assert_eq!(index.root_page_id, 4);
+        assert_eq!(index.root_page_id, 5);
         assert_eq!(index.columns.len(), 1);
         assert_eq!(index.columns[0].source_column_ordinal, 2);
         assert_eq!(index.columns[0].column.name, "email");

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -1,0 +1,99 @@
+use std::path::Path;
+
+use crate::core::{
+    IndexSchema, TableCursor, TableSchema, TupleSchema, catalog_manager::CatalogManager,
+    cursor::IndexCursor, error::StorageResult,
+};
+
+/// Public database handle for one database file.
+#[derive(Clone)]
+pub struct Database {
+    catalog: CatalogManager,
+}
+
+impl Database {
+    /// Creates a new database file.
+    pub fn create(path: impl AsRef<Path>) -> StorageResult<Self> {
+        Ok(Self { catalog: CatalogManager::create(path)? })
+    }
+
+    /// Opens an existing database file.
+    pub fn open(path: impl AsRef<Path>) -> StorageResult<Self> {
+        Ok(Self { catalog: CatalogManager::open_existing(path)? })
+    }
+
+    /// Returns the database-file path associated with this database.
+    pub fn path(&self) -> &Path {
+        self.catalog.path()
+    }
+
+    /// Flushes all dirty, currently unpinned pages to disk.
+    pub fn flush(&self) -> StorageResult<()> {
+        self.catalog.flush()
+    }
+
+    /// Creates a table and records its schema in the system catalog.
+    pub fn create_table(&self, name: &str, row: TupleSchema) -> StorageResult<TableSchema> {
+        self.catalog.create_table(name, row)
+    }
+
+    /// Creates a secondary index and records its schema in the system catalog.
+    pub fn create_index(
+        &self,
+        name: &str,
+        table_name: &str,
+        columns: &[&str],
+    ) -> StorageResult<IndexSchema> {
+        self.catalog.create_index(name, table_name, columns)
+    }
+
+    /// Returns a typed cursor for the table named `name`.
+    pub fn table_cursor_by_name(&self, name: &str) -> StorageResult<TableCursor> {
+        self.catalog.table_cursor_by_name(name)
+    }
+
+    /// Returns a typed cursor for the index named `name`.
+    pub fn index_cursor_by_name(&self, name: &str) -> StorageResult<IndexCursor> {
+        self.catalog.index_cursor_by_name(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::{NamedTempFile, tempdir};
+
+    use super::*;
+    use crate::core::error::{CorruptionError, CorruptionKind, StorageError};
+
+    #[test]
+    fn create_initializes_database_that_can_be_opened() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.db");
+
+        let database = Database::create(&path).unwrap();
+        database.flush().unwrap();
+
+        let reopened = Database::open(&path).unwrap();
+        assert_eq!(reopened.path(), path);
+    }
+
+    #[test]
+    fn create_rejects_existing_file() {
+        let file = NamedTempFile::new().unwrap();
+
+        assert!(Database::create(file.path()).is_err());
+    }
+
+    #[test]
+    fn open_rejects_empty_file_without_header() {
+        let file = NamedTempFile::new().unwrap();
+
+        assert!(matches!(
+            Database::open(file.path()),
+            Err(StorageError::Corruption(CorruptionError {
+                kind: CorruptionKind::MissingDatabaseHeader,
+                ..
+            }))
+        ));
+    }
+}

--- a/src/core/database_header.rs
+++ b/src/core/database_header.rs
@@ -1,0 +1,106 @@
+use crate::core::{
+    PAGE_SIZE, PageId,
+    error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
+};
+
+pub(crate) const DATABASE_HEADER_PAGE_ID: PageId = 0;
+
+const MAGIC: &[u8; 8] = b"DATABAS\0";
+const FORMAT_VERSION: u16 = 1;
+const HEADER_LEN: usize = 12;
+
+/// Fixed-format database file header stored on page 0.
+pub(crate) struct DatabaseHeader;
+
+impl DatabaseHeader {
+    pub(crate) fn encode_page() -> [u8; PAGE_SIZE] {
+        let mut page = [0u8; PAGE_SIZE];
+        page[0..8].copy_from_slice(MAGIC);
+        page[8..10].copy_from_slice(&FORMAT_VERSION.to_le_bytes());
+        page[10..12].copy_from_slice(&(PAGE_SIZE as u16).to_le_bytes());
+        page
+    }
+
+    pub(crate) fn validate_page(page: &[u8; PAGE_SIZE]) -> StorageResult<()> {
+        if &page[0..8] != MAGIC {
+            let mut actual = [0u8; 8];
+            actual.copy_from_slice(&page[0..8]);
+            return Err(corrupt_header(CorruptionKind::InvalidDatabaseMagic {
+                expected: *MAGIC,
+                actual,
+            }));
+        }
+
+        let version = u16::from_le_bytes([page[8], page[9]]);
+        if version != FORMAT_VERSION {
+            return Err(corrupt_header(CorruptionKind::UnsupportedDatabaseVersion {
+                expected: FORMAT_VERSION,
+                actual: version,
+            }));
+        }
+
+        let page_size = u16::from_le_bytes([page[10], page[11]]) as usize;
+        if page_size != PAGE_SIZE {
+            return Err(corrupt_header(CorruptionKind::InvalidDatabasePageSize {
+                expected: PAGE_SIZE,
+                actual: page_size,
+            }));
+        }
+
+        if page[HEADER_LEN..].iter().any(|byte| *byte != 0) {
+            return Err(corrupt_header(CorruptionKind::DatabaseHeaderReservedBytesNotZero));
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) fn missing_header() -> StorageError {
+    corrupt_header(CorruptionKind::MissingDatabaseHeader)
+}
+
+fn corrupt_header(kind: CorruptionKind) -> StorageError {
+    StorageError::Corruption(CorruptionError {
+        component: CorruptionComponent::DatabaseFile,
+        page_id: Some(DATABASE_HEADER_PAGE_ID),
+        kind,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encoded_header_validates() {
+        DatabaseHeader::validate_page(&DatabaseHeader::encode_page()).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_magic() {
+        let mut page = DatabaseHeader::encode_page();
+        page[0] = b'X';
+
+        assert!(matches!(
+            DatabaseHeader::validate_page(&page),
+            Err(StorageError::Corruption(CorruptionError {
+                kind: CorruptionKind::InvalidDatabaseMagic { .. },
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn rejects_nonzero_reserved_bytes() {
+        let mut page = DatabaseHeader::encode_page();
+        page[HEADER_LEN] = 1;
+
+        assert!(matches!(
+            DatabaseHeader::validate_page(&page),
+            Err(StorageError::Corruption(CorruptionError {
+                kind: CorruptionKind::DatabaseHeaderReservedBytesNotZero,
+                ..
+            }))
+        ));
+    }
+}

--- a/src/core/disk_manager.rs
+++ b/src/core/disk_manager.rs
@@ -17,15 +17,30 @@ pub struct DiskManager {
 }
 
 impl DiskManager {
-    /// Create a new `DiskManager` from a path to a file.
+    /// Create a new `DiskManager` from a path to a file, creating it if needed.
+    #[cfg(test)]
     pub(crate) fn new(path: &Path) -> Result<Self, DiskManagerError> {
-        let file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(false)
-            .append(false)
-            .open(path)?;
+        Self::open_with_options(
+            OpenOptions::new().create(true).read(true).write(true).truncate(false).append(false),
+            path,
+        )
+    }
+
+    /// Create a new database file and fail if it already exists.
+    pub(crate) fn create_new(path: &Path) -> Result<Self, DiskManagerError> {
+        Self::open_with_options(
+            OpenOptions::new().create_new(true).read(true).write(true).append(false),
+            path,
+        )
+    }
+
+    /// Open an existing database file.
+    pub(crate) fn open_existing(path: &Path) -> Result<Self, DiskManagerError> {
+        Self::open_with_options(OpenOptions::new().read(true).write(true).append(false), path)
+    }
+
+    fn open_with_options(options: &mut OpenOptions, path: &Path) -> Result<Self, DiskManagerError> {
+        let file = options.open(path)?;
 
         let file_metadata = file.metadata()?;
         let file_size = file_metadata.len();

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -49,6 +49,16 @@ pub enum CorruptionComponent {
 pub enum CorruptionKind {
     #[error("invalid file size {size} for page size {page_size}")]
     InvalidFileSize { size: u64, page_size: usize },
+    #[error("missing database header")]
+    MissingDatabaseHeader,
+    #[error("invalid database magic: expected {expected:?}, got {actual:?}")]
+    InvalidDatabaseMagic { expected: [u8; 8], actual: [u8; 8] },
+    #[error("unsupported database version: expected {expected}, got {actual}")]
+    UnsupportedDatabaseVersion { expected: u16, actual: u16 },
+    #[error("invalid database page size: expected {expected}, got {actual}")]
+    InvalidDatabasePageSize { expected: usize, actual: usize },
+    #[error("database header reserved bytes are not zeroed")]
+    DatabaseHeaderReservedBytesNotZero,
     #[error("unknown page kind: raw tag {actual}")]
     UnknownPageKind { actual: u8 },
     #[error("invalid page kind: expected {expected}, got raw tag {actual}")]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,7 +1,9 @@
 pub mod btree;
 pub mod catalog;
-pub mod catalog_manager;
+mod catalog_manager;
 pub mod cursor;
+pub mod database;
+pub(crate) mod database_header;
 pub mod disk_manager;
 pub mod error;
 #[cfg(test)]
@@ -21,10 +23,10 @@ pub use catalog::{
     SYS_INDEXES_ROOT_PAGE_ID, SYS_INDEXES_TABLE_ID, SYS_TABLES_ROOT_PAGE_ID, SYS_TABLES_TABLE_ID,
     TableCatalogRow, TableSchema, TupleSchema,
 };
-pub use catalog_manager::CatalogManager;
 pub use cursor::{
     IndexCursor, IndexEntry, IndexEntryRef, TableCursor, TableRecord, TableRecordRef,
 };
+pub use database::Database;
 pub use page_store::PageStore;
 pub use pager::PagerOptions;
 pub use tuple::{EncodedTupleView, Tuple, TupleRef, TupleView, Value, ValueRef};

--- a/src/core/pager.rs
+++ b/src/core/pager.rs
@@ -4,6 +4,7 @@ use crate::core::{
     PageId,
     btree::{TreeCursor, initialize_empty_root, validate_root_page},
     cursor::{IndexCursor, TableCursor},
+    database_header::{DATABASE_HEADER_PAGE_ID, DatabaseHeader, missing_header},
     disk_manager::DiskManager,
     error::StorageResult,
     page_cache::PageCache,
@@ -11,7 +12,7 @@ use crate::core::{
 
 const DEFAULT_PAGE_CACHE_SIZE: usize = 64;
 
-/// Configuration for [`crate::core::CatalogManager`].
+/// Configuration for [`crate::core::Database`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PagerOptions {
     /// Number of frames to preallocate in the page cache.
@@ -32,36 +33,77 @@ impl Default for PagerOptions {
 pub(crate) struct Pager {
     path: PathBuf,
     page_cache: PageCache,
-    options: PagerOptions,
     opened_page_count: u64,
 }
 
 impl Pager {
-    /// Opens a pager with default options.
+    /// Creates a new database file and initializes its database header.
+    pub(crate) fn create(path: impl AsRef<Path>) -> StorageResult<Self> {
+        Self::create_with_options(path, PagerOptions::default())
+    }
+
+    /// Creates a new database file with explicit cache settings.
+    pub(crate) fn create_with_options(
+        path: impl AsRef<Path>,
+        options: PagerOptions,
+    ) -> StorageResult<Self> {
+        let path = path.as_ref().to_path_buf();
+        let mut disk_manager = DiskManager::create_new(&path)?;
+        initialize_header_page(&mut disk_manager)?;
+        Self::from_disk_manager(path, disk_manager, options)
+    }
+
+    /// Opens an existing pager with default options.
     pub(crate) fn open(path: impl AsRef<Path>) -> StorageResult<Self> {
         Self::open_with_options(path, PagerOptions::default())
     }
 
-    /// Opens a pager with explicit cache settings.
+    /// Opens an existing pager with explicit cache settings.
     pub(crate) fn open_with_options(
         path: impl AsRef<Path>,
         options: PagerOptions,
     ) -> StorageResult<Self> {
         let path = path.as_ref().to_path_buf();
-        let disk_manager = DiskManager::new(&path)?;
+        let mut disk_manager = DiskManager::open_existing(&path)?;
+        validate_header_page(&mut disk_manager)?;
+        Self::from_disk_manager(path, disk_manager, options)
+    }
+
+    /// Opens a pager, creating and initializing an empty file if needed.
+    #[cfg(test)]
+    pub(crate) fn open_or_create(path: impl AsRef<Path>) -> StorageResult<Self> {
+        Self::open_or_create_with_options(path, PagerOptions::default())
+    }
+
+    /// Opens a pager with explicit cache settings, creating an empty file if needed.
+    #[cfg(test)]
+    pub(crate) fn open_or_create_with_options(
+        path: impl AsRef<Path>,
+        options: PagerOptions,
+    ) -> StorageResult<Self> {
+        let path = path.as_ref().to_path_buf();
+        let mut disk_manager = DiskManager::new(&path)?;
+        if disk_manager.page_count() == 0 {
+            initialize_header_page(&mut disk_manager)?;
+        } else {
+            validate_header_page(&mut disk_manager)?;
+        }
+        Self::from_disk_manager(path, disk_manager, options)
+    }
+
+    fn from_disk_manager(
+        path: PathBuf,
+        disk_manager: DiskManager,
+        options: PagerOptions,
+    ) -> StorageResult<Self> {
         let opened_page_count = disk_manager.page_count();
         let page_cache = PageCache::new(disk_manager, options.cache_frames)?;
-        Ok(Self { path, page_cache, options, opened_page_count })
+        Ok(Self { path, page_cache, opened_page_count })
     }
 
     /// Returns the database-file path associated with this pager.
     pub(crate) fn path(&self) -> &Path {
         &self.path
-    }
-
-    /// Returns the options used when this pager was opened.
-    pub(crate) fn options(&self) -> PagerOptions {
-        self.options
     }
 
     /// Returns the page count observed when this pager was opened.
@@ -100,6 +142,23 @@ impl Pager {
     }
 }
 
+fn initialize_header_page(disk_manager: &mut DiskManager) -> StorageResult<()> {
+    let page_id = disk_manager.new_page()?;
+    debug_assert_eq!(page_id, DATABASE_HEADER_PAGE_ID);
+    disk_manager.write_page(DATABASE_HEADER_PAGE_ID, &DatabaseHeader::encode_page())?;
+    Ok(())
+}
+
+fn validate_header_page(disk_manager: &mut DiskManager) -> StorageResult<()> {
+    if disk_manager.page_count() == 0 {
+        return Err(missing_header());
+    }
+
+    let mut page = [0u8; crate::core::PAGE_SIZE];
+    disk_manager.read_page(DATABASE_HEADER_PAGE_ID, &mut page)?;
+    DatabaseHeader::validate_page(&page)
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::NamedTempFile;
@@ -109,16 +168,16 @@ mod tests {
     #[test]
     fn opens_database_and_manages_table_and_index_trees() {
         let file = NamedTempFile::new().unwrap();
-        let pager = Pager::open(file.path()).unwrap();
+        let pager = Pager::open_or_create(file.path()).unwrap();
 
-        assert_eq!(pager.opened_page_count(), 0);
-        assert_eq!(pager.create_table_tree().unwrap().root_page_id(), 0);
-        assert_eq!(pager.create_index_tree().unwrap().root_page_id(), 1);
+        assert_eq!(pager.opened_page_count(), 1);
+        assert_eq!(pager.create_table_tree().unwrap().root_page_id(), 1);
+        assert_eq!(pager.create_index_tree().unwrap().root_page_id(), 2);
         pager.flush().unwrap();
 
         let pager = Pager::open(file.path()).unwrap();
-        assert_eq!(pager.opened_page_count(), 2);
-        assert_eq!(pager.table_cursor(0).unwrap().root_page_id(), 0);
-        assert_eq!(pager.index_cursor(1).unwrap().root_page_id(), 1);
+        assert_eq!(pager.opened_page_count(), 3);
+        assert_eq!(pager.table_cursor(1).unwrap().root_page_id(), 1);
+        assert_eq!(pager.index_cursor(2).unwrap().root_page_id(), 2);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,37 @@
+use std::{env, process};
+
+use databas::core::Database;
+
+fn main() {
+    let mut args = env::args();
+    let program = args.next().unwrap_or_else(|| "databas".to_owned());
+    let command = args.next();
+    let path = args.next();
+
+    if args.next().is_some() {
+        usage(&program);
+    }
+
+    let Some(command) = command else {
+        usage(&program);
+    };
+    let Some(path) = path else {
+        usage(&program);
+    };
+
+    let result = match command.as_str() {
+        "create" => Database::create(&path).and_then(|database| database.flush()),
+        "open" => Database::open(&path).and_then(|database| database.flush()),
+        _ => usage(&program),
+    };
+
+    if let Err(error) = result {
+        eprintln!("{error}");
+        process::exit(1);
+    }
+}
+
+fn usage(program: &str) -> ! {
+    eprintln!("usage: {program} create|open <database-file>");
+    process::exit(2);
+}


### PR DESCRIPTION
## Summary
- Reserve page 0 for a minimal database header with magic bytes, format version, and page-size validation
- Shift system catalog roots to pages 1-3 and update pager/catalog bootstrap logic accordingly
- Introduce a public `Database` type as the top-level entry point and add a minimal `create`/`open` CLI
- Update the example to use `Database` instead of `CatalogManager`

## Testing
- Added unit coverage for header encoding/validation, strict open behavior, and database create/open flows
- Ran `cargo fmt`
- Ran `cargo test`
- Verified the CLI can create and reopen a database file locally