### PR TITLE
Restrict ORDER BY terms to columns

### DIFF
--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -241,12 +241,14 @@ impl<'db> Planner<'db> {
         if let Some(order_by) = &query.order_by {
             let terms = order_by
                 .terms
-                .0
                 .iter()
-                .map(|expr| {
+                .map(|term| {
+                    let table = table.as_ref().ok_or_else(|| PlannerError::ColumnNotFound {
+                        column: term.column.to_owned(),
+                    })?;
                     Ok(SortTerm {
-                        expression: self.bind_expression(expr, table.as_ref())?,
-                        direction: order_by.order.clone(),
+                        expression: PlannedExpression::Column(bind_column(table, term.column)?),
+                        direction: term.order.clone(),
                     })
                 })
                 .collect::<PlannerResult<Vec<_>>>()?;

--- a/src/sql_parser/parser/stmt/select.rs
+++ b/src/sql_parser/parser/stmt/select.rs
@@ -24,9 +24,25 @@ impl Display for Ordering {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct OrderBy<'a> {
-    pub terms: ExpressionList<'a>,
+pub struct OrderByTerm<'a> {
+    pub column: &'a str,
     pub order: Option<Ordering>,
+}
+
+impl Display for OrderByTerm<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.column)?;
+
+        if let Some(ref order) = self.order {
+            write!(f, " {}", order)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct OrderBy<'a> {
+    pub terms: Vec<OrderByTerm<'a>>,
 }
 
 impl<'a> Parser<'a> {
@@ -37,7 +53,13 @@ impl<'a> Parser<'a> {
         };
         self.lexer.next();
         self.lexer.expect_token(TokenKind::Keyword(Keyword::By))?;
-        let terms = self.parse_expression_list()?;
+        let terms = self.parse_comma_separated_list(|p| p.parse_order_by_term())?;
+
+        Ok(Some(OrderBy { terms }))
+    }
+
+    fn parse_order_by_term(&mut self) -> Result<OrderByTerm<'a>, SQLError<'a>> {
+        let column = self.parse_identifier()?;
         let order = match self.lexer.peek() {
             Some(Ok(Token { kind: TokenKind::Keyword(Keyword::Asc), .. })) => {
                 self.lexer.next();
@@ -50,18 +72,14 @@ impl<'a> Parser<'a> {
             _ => None,
         };
 
-        Ok(Some(OrderBy { terms, order }))
+        Ok(OrderByTerm { column, order })
     }
 }
 
 impl Display for OrderBy<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.terms)?;
-
-        if let Some(ref order) = self.order {
-            write!(f, " {}", order)?;
-        }
-        Ok(())
+        let terms = self.terms.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
+        write!(f, "{terms}")
     }
 }
 #[derive(Debug, PartialEq)]
@@ -277,11 +295,10 @@ mod tests {
             table: Some("bar"),
             where_clause: Some(Expression::Identifier("baz")),
             order_by: Some(OrderBy {
-                terms: ExpressionList(vec![
-                    Expression::Identifier("qax"),
-                    Expression::Identifier("quux"),
-                ]),
-                order: Some(Ordering::Descending),
+                terms: vec![
+                    OrderByTerm { column: "qax", order: None },
+                    OrderByTerm { column: "quux", order: Some(Ordering::Descending) },
+                ],
             }),
             limit: None,
             offset: None,
@@ -296,8 +313,7 @@ mod tests {
             table: Some("bar"),
             where_clause: Some(Expression::Identifier("baz")),
             order_by: Some(OrderBy {
-                terms: ExpressionList(vec![Expression::Identifier("qax")]),
-                order: Some(Ordering::Ascending),
+                terms: vec![OrderByTerm { column: "qax", order: Some(Ordering::Ascending) }],
             }),
             limit: None,
             offset: None,
@@ -307,7 +323,13 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_select_query_rejects_order_by_expression() {
+        let s = "SELECT foo FROM bar ORDER BY qax + 1 ASC;";
+        let mut parser = Parser::new(s);
+        assert!(parser.stmt().is_err());
+    }
 
+    #[test]
     fn test_parse_select_query_with_limit() {
         let s = "SELECT foo FROM bar LIMIT 5;";
         let mut parser = Parser::new(s);
@@ -328,10 +350,7 @@ mod tests {
             columns: ExpressionList(vec![Expression::Identifier("foo")]),
             table: Some("bar"),
             where_clause: Some(Expression::Identifier("baz")),
-            order_by: Some(OrderBy {
-                terms: ExpressionList(vec![Expression::Identifier("qux")]),
-                order: None,
-            }),
+            order_by: Some(OrderBy { terms: vec![OrderByTerm { column: "qux", order: None }] }),
             limit: Some(10),
             offset: None,
         };

--- a/tests/sql_parser_roundtrip.rs
+++ b/tests/sql_parser_roundtrip.rs
@@ -141,13 +141,19 @@ fn draw_select(tc: &TestCase) -> String {
     }
     if draw_bool(tc) {
         sql.push_str(" ORDER BY ");
-        sql.push_str(&draw_expression_list(tc, 3, false).join(", "));
-        match draw_index(tc, 3) {
-            0 => {}
-            1 => sql.push_str(" ASC"),
-            2 => sql.push_str(" DESC"),
-            _ => unreachable!(),
-        }
+        let terms = (0..draw_non_empty_len(tc, 3))
+            .map(|_| {
+                let mut term = draw_identifier(tc).to_string();
+                match draw_index(tc, 3) {
+                    0 => {}
+                    1 => term.push_str(" ASC"),
+                    2 => term.push_str(" DESC"),
+                    _ => unreachable!(),
+                }
+                term
+            })
+            .collect::<Vec<_>>();
+        sql.push_str(&terms.join(", "));
     }
     if draw_bool(tc) {
         sql.push_str(" LIMIT ");


### PR DESCRIPTION
## Summary
- Narrow `ORDER BY` parsing to accept only column names with an optional per-term direction
- Represent each sort term explicitly in the parser AST
- Update planner binding and round-trip generation to match the simpler grammar

## Testing
- Added parser coverage for valid `ORDER BY` forms and rejection of expression terms
- Updated round-trip tests to generate column-based sort terms only
- Ran the full test suite successfully