### PR TITLE
Implement basic query execution for CREATE TABLE/INDEX, INSERT INTO, SELECT

### DIFF
--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -134,6 +134,8 @@ pub struct TableSchema {
     pub name: String,
     /// Root page id of the table's B+-tree.
     pub root_page_id: PageId,
+    /// Largest row id allocated for this table.
+    pub last_row_id: RowId,
     /// Schema of table rows stored in the tree values.
     pub row: TupleSchema,
 }
@@ -173,6 +175,8 @@ pub struct TableCatalogRow {
     pub name: String,
     /// Root page id of the table B+-tree.
     pub root_page_id: PageId,
+    /// Largest row id allocated for this table.
+    pub last_row_id: RowId,
 }
 
 /// Decoded row from `sys_indexes`.
@@ -244,6 +248,8 @@ pub struct SystemTableSchema<'a> {
     pub name: &'a str,
     /// Root page id reserved for this system table.
     pub root_page_id: PageId,
+    /// Largest row id allocated while bootstrapping this system table.
+    pub last_row_id: RowId,
     /// Row schema of the system table.
     pub row: SystemTupleSchema<'a>,
 }
@@ -257,6 +263,8 @@ pub struct SystemTableCatalogRow<'a> {
     pub name: &'a str,
     /// Root page id reserved for this system table.
     pub root_page_id: PageId,
+    /// Largest row id allocated while bootstrapping this system table.
+    pub last_row_id: RowId,
 }
 
 /// Borrowed row written to `sys_columns` while bootstrapping the catalog.
@@ -332,6 +340,7 @@ impl TableSchema {
             table_id,
             name: query.table_name.to_owned(),
             root_page_id,
+            last_row_id: 0,
             row: TupleSchema::from_create_table_query(query),
         }
     }
@@ -342,6 +351,7 @@ impl TableSchema {
             table_id: self.table_id,
             name: self.name.clone(),
             root_page_id: self.root_page_id,
+            last_row_id: self.last_row_id,
         }
     }
 }
@@ -424,16 +434,18 @@ impl TableCatalogRow {
             Value::UnsignedInteger(self.table_id),
             Value::String(self.name.clone()),
             Value::UnsignedInteger(self.root_page_id),
+            Value::UnsignedInteger(self.last_row_id),
         ])
     }
 
     /// Decodes a `sys_tables` storage tuple.
     pub fn decode(tuple: &Tuple) -> Result<Self, CatalogError> {
-        expect_field_count(tuple, 3)?;
+        expect_field_count(tuple, 4)?;
         Ok(Self {
             table_id: expect_unsigned(tuple, 0)?,
             name: expect_string(tuple, 1)?.to_owned(),
             root_page_id: expect_unsigned(tuple, 2)?,
+            last_row_id: expect_unsigned(tuple, 3)?,
         })
     }
 }
@@ -504,6 +516,7 @@ impl SystemTableSchema<'_> {
             table_id: self.table_id,
             name: self.name,
             root_page_id: self.root_page_id,
+            last_row_id: self.last_row_id,
         }
     }
 }
@@ -514,6 +527,7 @@ impl SystemTableCatalogRow<'_> {
             ValueRef::UnsignedInteger(self.table_id),
             ValueRef::String(self.name),
             ValueRef::UnsignedInteger(self.root_page_id),
+            ValueRef::UnsignedInteger(self.last_row_id),
         ];
         TupleRef::new(&values).to_bytes()
     }
@@ -541,6 +555,7 @@ static SYS_TABLES_COLUMNS: &[SystemColumnSchema<'static>] = &[
     column("table_id", DataType::UnsignedInteger, false, true),
     column("name", DataType::Text, false, false),
     column("root_page_id", DataType::UnsignedInteger, false, false),
+    column("last_row_id", DataType::UnsignedInteger, true, false),
 ];
 
 static SYS_INDEXES_COLUMNS: &[SystemColumnSchema<'static>] = &[
@@ -564,24 +579,31 @@ static SYS_COLUMNS_COLUMNS: &[SystemColumnSchema<'static>] = &[
     column("source_column_ordinal", DataType::UnsignedInteger, true, false),
 ];
 
+const SYSTEM_TABLE_ROW_COUNT: RowId = 3;
+const SYSTEM_COLUMN_ROW_COUNT: RowId =
+    (SYS_TABLES_COLUMNS.len() + SYS_INDEXES_COLUMNS.len() + SYS_COLUMNS_COLUMNS.len()) as RowId;
+
 /// Fixed schemas of all built-in system catalog tables.
 pub static SYSTEM_TABLE_SCHEMAS: &[SystemTableSchema<'static>] = &[
     SystemTableSchema {
         table_id: SYS_TABLES_TABLE_ID,
         name: SYS_TABLES_NAME,
         root_page_id: SYS_TABLES_ROOT_PAGE_ID,
+        last_row_id: SYSTEM_TABLE_ROW_COUNT,
         row: SystemTupleSchema { columns: SYS_TABLES_COLUMNS },
     },
     SystemTableSchema {
         table_id: SYS_INDEXES_TABLE_ID,
         name: SYS_INDEXES_NAME,
         root_page_id: SYS_INDEXES_ROOT_PAGE_ID,
+        last_row_id: 0,
         row: SystemTupleSchema { columns: SYS_INDEXES_COLUMNS },
     },
     SystemTableSchema {
         table_id: SYS_COLUMNS_TABLE_ID,
         name: SYS_COLUMNS_NAME,
         root_page_id: SYS_COLUMNS_ROOT_PAGE_ID,
+        last_row_id: SYSTEM_COLUMN_ROW_COUNT,
         row: SystemTupleSchema { columns: SYS_COLUMNS_COLUMNS },
     },
 ];

--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -555,7 +555,7 @@ static SYS_TABLES_COLUMNS: &[SystemColumnSchema<'static>] = &[
     column("table_id", DataType::UnsignedInteger, false, true),
     column("name", DataType::Text, false, false),
     column("root_page_id", DataType::UnsignedInteger, false, false),
-    column("last_row_id", DataType::UnsignedInteger, true, false),
+    column("last_row_id", DataType::UnsignedInteger, false, false),
 ];
 
 static SYS_INDEXES_COLUMNS: &[SystemColumnSchema<'static>] = &[

--- a/src/core/catalog_manager.rs
+++ b/src/core/catalog_manager.rs
@@ -12,7 +12,7 @@ use crate::core::{
     cursor::{IndexCursor, TableCursor},
     error::{
         ConstraintError, CorruptionComponent, CorruptionError, CorruptionKind,
-        InvalidArgumentError, StorageError, StorageResult,
+        InvalidArgumentError, LimitExceededError, StorageError, StorageResult,
     },
     pager::Pager,
 };
@@ -72,7 +72,8 @@ impl CatalogManager {
 
         let table_id = self.next_object_id()?;
         let root_page_id = self.pager.create_table_tree()?.root_page_id();
-        let schema = TableSchema { table_id, name: name.to_owned(), root_page_id, row };
+        let schema =
+            TableSchema { table_id, name: name.to_owned(), root_page_id, last_row_id: 0, row };
 
         self.insert_table_catalog_row(&schema.catalog_row())?;
         for (column_id, (ordinal, column)) in
@@ -178,6 +179,27 @@ impl CatalogManager {
         self.pager.index_cursor(schema.root_page_id)
     }
 
+    /// Allocates and persists the next row id for a table.
+    pub fn allocate_table_row_id(&self, table: &TableSchema) -> StorageResult<RowId> {
+        let mut row = self
+            .table_catalog_rows()?
+            .into_iter()
+            .find(|row| row.table_id == table.table_id)
+            .ok_or_else(|| {
+                StorageError::InvalidArgument(InvalidArgumentError::TableNotFound {
+                    name: table.name.clone(),
+                })
+            })?;
+        let next_row_id = row.last_row_id.checked_add(1).ok_or_else(|| {
+            StorageError::LimitExceeded(LimitExceededError::RowIdExhausted {
+                table: table.name.clone(),
+            })
+        })?;
+        row.last_row_id = next_row_id;
+        self.update_table_catalog_row(&row)?;
+        Ok(next_row_id)
+    }
+
     fn initialize_or_validate_system_catalog(&self) -> StorageResult<()> {
         match self.pager.opened_page_count() {
             0 => Err(crate::core::database_header::missing_header()),
@@ -249,6 +271,7 @@ impl CatalogManager {
             table_id: table.table_id,
             name: table.name,
             root_page_id: table.root_page_id,
+            last_row_id: table.last_row_id,
             row: TupleSchema { columns: columns.into_iter().map(column_schema_from_row).collect() },
         })
     }
@@ -262,29 +285,43 @@ impl CatalogManager {
                     })
                 },
             )?;
-        let mut columns: Vec<_> = self
+        let columns: Vec<_> = self
             .column_catalog_rows()?
             .into_iter()
             .filter(|row| {
                 row.object_kind == CatalogObjectKind::Index && row.object_id == index.index_id
             })
             .collect();
-        columns.sort_by_key(|row| row.ordinal);
 
-        Ok(IndexSchema {
-            index_id: index.index_id,
-            name: index.name,
-            table_id: index.table_id,
-            root_page_id: index.root_page_id,
-            unique: index.unique,
-            columns: columns
-                .into_iter()
-                .map(|row| IndexColumnSchema {
-                    source_column_ordinal: row.source_column_ordinal.unwrap_or(row.ordinal),
-                    column: column_schema_from_row(row),
-                })
-                .collect(),
-        })
+        Ok(index_schema_from_rows(index, columns))
+    }
+
+    pub(crate) fn index_schemas_for_table(
+        &self,
+        table: &TableSchema,
+    ) -> StorageResult<Vec<IndexSchema>> {
+        let mut indexes: Vec<_> = self
+            .index_catalog_rows()?
+            .into_iter()
+            .filter(|row| row.table_id == table.table_id)
+            .collect();
+        indexes.sort_by_key(|row| row.index_id);
+
+        let column_rows = self.column_catalog_rows()?;
+        indexes
+            .into_iter()
+            .map(|index| {
+                let columns: Vec<_> = column_rows
+                    .iter()
+                    .filter(|row| {
+                        row.object_kind == CatalogObjectKind::Index
+                            && row.object_id == index.index_id
+                    })
+                    .cloned()
+                    .collect();
+                Ok(index_schema_from_rows(index, columns))
+            })
+            .collect()
     }
 
     fn next_object_id(&self) -> StorageResult<RowId> {
@@ -338,6 +375,12 @@ impl CatalogManager {
 
     fn insert_table_catalog_row(&self, row: &TableCatalogRow) -> StorageResult<()> {
         self.insert_catalog_row(SYS_TABLES_ROOT_PAGE_ID, row.table_id, &row.encode())
+    }
+
+    fn update_table_catalog_row(&self, row: &TableCatalogRow) -> StorageResult<()> {
+        let mut cursor = self.pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID)?;
+        let bytes = row.encode().to_bytes()?;
+        cursor.update(row.table_id, &bytes)
     }
 
     fn insert_index_catalog_row(&self, row: &IndexCatalogRow) -> StorageResult<()> {
@@ -404,6 +447,28 @@ fn column_schema_from_row(row: ColumnCatalogRow) -> ColumnSchema {
     }
 }
 
+fn index_schema_from_rows(
+    index: IndexCatalogRow,
+    mut columns: Vec<ColumnCatalogRow>,
+) -> IndexSchema {
+    columns.sort_by_key(|row| row.ordinal);
+
+    IndexSchema {
+        index_id: index.index_id,
+        name: index.name,
+        table_id: index.table_id,
+        root_page_id: index.root_page_id,
+        unique: index.unique,
+        columns: columns
+            .into_iter()
+            .map(|row| IndexColumnSchema {
+                source_column_ordinal: row.source_column_ordinal.unwrap_or(row.ordinal),
+                column: column_schema_from_row(row),
+            })
+            .collect(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::NamedTempFile;
@@ -432,18 +497,21 @@ mod tests {
             SYS_TABLES_TABLE_ID,
             "sys_tables",
             SYS_TABLES_ROOT_PAGE_ID,
+            3,
         );
         assert_table_catalog_row(
             &mut tables,
             SYS_INDEXES_TABLE_ID,
             "sys_indexes",
             SYS_INDEXES_ROOT_PAGE_ID,
+            0,
         );
         assert_table_catalog_row(
             &mut tables,
             SYS_COLUMNS_TABLE_ID,
             "sys_columns",
             SYS_COLUMNS_ROOT_PAGE_ID,
+            system_column_rows().len() as RowId,
         );
 
         let mut columns = manager.pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
@@ -480,6 +548,7 @@ mod tests {
             SYS_TABLES_TABLE_ID,
             "sys_tables",
             SYS_TABLES_ROOT_PAGE_ID,
+            3,
         );
     }
 
@@ -518,6 +587,7 @@ mod tests {
         assert_eq!(table.table_id, 4);
         assert_eq!(table.name, "users");
         assert_eq!(table.root_page_id, 4);
+        assert_eq!(table.last_row_id, 0);
         assert_eq!(table.row, row_schema);
         assert_eq!(
             manager.table_cursor_by_name("users").unwrap().root_page_id(),
@@ -525,7 +595,7 @@ mod tests {
         );
 
         let mut tables = manager.pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID).unwrap();
-        assert_table_catalog_row(&mut tables, table.table_id, "users", table.root_page_id);
+        assert_table_catalog_row(&mut tables, table.table_id, "users", table.root_page_id, 0);
 
         let first_user_column_id = system_column_rows().len() as RowId + 1;
         let mut columns = manager.pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
@@ -615,17 +685,37 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn allocate_table_row_id_persists_last_row_id() {
+        let file = NamedTempFile::new().unwrap();
+        {
+            let manager = CatalogManager::open(file.path()).unwrap();
+            let table = manager.create_table("users", users_schema()).unwrap();
+
+            assert_eq!(manager.allocate_table_row_id(&table).unwrap(), 1);
+            assert_eq!(manager.allocate_table_row_id(&table).unwrap(), 2);
+            assert_eq!(manager.table_schema_by_name("users").unwrap().last_row_id, 2);
+            manager.flush().unwrap();
+        }
+
+        let manager = CatalogManager::open(file.path()).unwrap();
+        let table = manager.table_schema_by_name("users").unwrap();
+        assert_eq!(table.last_row_id, 2);
+        assert_eq!(manager.allocate_table_row_id(&table).unwrap(), 3);
+    }
+
     fn assert_table_catalog_row(
         tables: &mut TableCursor,
         table_id: RowId,
         name: &str,
         root_page_id: PageId,
+        last_row_id: RowId,
     ) {
         let record = tables.get(table_id).unwrap().expect("system table row should exist");
         let tuple = Tuple::from_bytes(&record.record).unwrap();
         assert_eq!(
             TableCatalogRow::decode(&tuple).unwrap(),
-            TableCatalogRow { table_id, name: name.to_owned(), root_page_id }
+            TableCatalogRow { table_id, name: name.to_owned(), root_page_id, last_row_id }
         );
     }
 

--- a/src/core/cursor.rs
+++ b/src/core/cursor.rs
@@ -1,9 +1,9 @@
 //! Typed table and index cursor wrappers over the raw byte-oriented B+-tree.
 
-use std::fmt;
+use std::fmt::{self, Display};
 
 use crate::core::{
-    RowId,
+    RowId, Tuple,
     btree::{CursorState, OwnedRecord, Record, TreeCursor},
     disk_manager::DiskManager,
     error::StorageResult,
@@ -44,6 +44,17 @@ pub struct TableRecord {
     pub row_id: RowId,
     /// Encoded table record bytes.
     pub record: Box<[u8]>,
+}
+
+impl Display for TableRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: fix unwrap here
+        let tuple = Tuple::from_bytes(&self.record).unwrap();
+        for value in &tuple {
+            let _ = write!(f, "{value}\t");
+        }
+        Ok(())
+    }
 }
 
 /// Owned secondary-index entry returned by [`IndexCursor`] lookups.

--- a/src/core/cursor.rs
+++ b/src/core/cursor.rs
@@ -48,12 +48,15 @@ pub struct TableRecord {
 
 impl Display for TableRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: fix unwrap here
-        let tuple = Tuple::from_bytes(&self.record).unwrap();
-        for value in &tuple {
-            let _ = write!(f, "{value}\t");
+        match Tuple::from_bytes(&self.record) {
+            Ok(tuple) => {
+                for value in &tuple {
+                    write!(f, "{value}\t")?;
+                }
+                Ok(())
+            }
+            Err(_) => write!(f, "<invalid tuple>"),
         }
-        Ok(())
     }
 }
 

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::core::{
-    IndexSchema, TableCursor, TableSchema, TupleSchema, catalog_manager::CatalogManager,
+    IndexSchema, RowId, TableCursor, TableSchema, TupleSchema, catalog_manager::CatalogManager,
     cursor::IndexCursor, error::StorageResult,
 };
 
@@ -52,9 +52,19 @@ impl Database {
         self.catalog.table_schema_by_name(name)
     }
 
+    /// Returns the schemas for secondary indexes defined on `table`.
+    pub fn index_schemas_for_table(&self, table: &TableSchema) -> StorageResult<Vec<IndexSchema>> {
+        self.catalog.index_schemas_for_table(table)
+    }
+
     /// Returns a typed cursor for the table named `name`.
     pub fn table_cursor_by_name(&self, name: &str) -> StorageResult<TableCursor> {
         self.catalog.table_cursor_by_name(name)
+    }
+
+    /// Allocates and persists the next row id for a table.
+    pub fn allocate_table_row_id(&self, table: &TableSchema) -> StorageResult<RowId> {
+        self.catalog.allocate_table_row_id(table)
     }
 
     /// Returns a typed cursor for the index named `name`.

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -141,6 +141,8 @@ pub enum LimitExceededError {
     CellTooLarge { len: usize, max: usize },
     #[error("cache capacity exhausted")]
     CacheCapacityExhausted,
+    #[error("row id space exhausted for table {table}")]
+    RowIdExhausted { table: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/src/core/tuple.rs
+++ b/src/core/tuple.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     io::{self, Read, Write},
     ops::Range,
 };
@@ -27,6 +28,19 @@ pub enum Value {
     Integer(i32),
     Float(f32),
     UnsignedInteger(u64),
+}
+
+impl Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::Null => write!(f, "NULL"),
+            Value::String(s) => write!(f, "{s}"),
+            Value::Boolean(b) => write!(f, "{b}"),
+            Value::Integer(i) => write!(f, "{i}"),
+            Value::Float(fl) => write!(f, "{fl}"),
+            Value::UnsignedInteger(u) => write!(f, "{u}"),
+        }
+    }
 }
 
 /// A borrowed typed value.

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,0 +1,1411 @@
+//! Physical query execution.
+//!
+//! The executor consumes [`PhysicalPlan`] trees produced by the planner and
+//! turns them into either a lazy stream of table records or an immediate
+//! side-effect result such as rows affected or schema changed. Row-producing
+//! operators are deliberately iterator-based: scans, filters, projections,
+//! limits, and offsets do their work as the caller pulls rows from the returned
+//! [`RowStream`].
+//!
+//! This module is also responsible for evaluating planned scalar expressions
+//! against encoded table records, validating inserted rows against catalog
+//! schemas, backfilling newly-created secondary indexes, and keeping existing
+//! secondary indexes up to date when new rows are inserted.
+
+use crate::{
+    core::{
+        DataType, Database, IndexSchema, TableRecord, TableSchema, Tuple, TupleView, Value,
+        error::StorageError,
+    },
+    planner::{BoundColumn, PhysicalPlan, PlannedExpression},
+    sql_parser::parser::op::Op,
+};
+
+/// Errors that can occur while executing a physical query plan.
+///
+/// Executor errors cover storage failures, invalid encoded tuple data, row
+/// shape mismatches, expression type errors, arithmetic failures, and operator
+/// shapes that the current execution engine cannot run yet.
+#[derive(Debug, thiserror::Error)]
+pub enum ExecutorError {
+    /// A lower-level storage or catalog operation failed.
+    #[error("storage error: {0}")]
+    Storage(#[from] StorageError),
+    /// Encoded tuple bytes could not be parsed into typed values.
+    #[error("invalid tuple bytes: {0}")]
+    InvalidTuple(#[source] std::io::Error),
+    /// A planned column ordinal did not exist in the input tuple.
+    #[error("column {column} ordinal {ordinal} is out of bounds for tuple with {len} values")]
+    ColumnOrdinalOutOfBounds {
+        /// Column name used in diagnostics.
+        column: String,
+        /// Requested zero-based tuple position.
+        ordinal: usize,
+        /// Number of values available in the tuple.
+        len: usize,
+    },
+    /// A `WHERE` predicate produced a value other than `TRUE` or `FALSE`.
+    #[error("filter predicate evaluated to non-boolean value: {value:?}")]
+    NonBooleanPredicate {
+        /// Value produced by the predicate expression.
+        value: Value,
+    },
+    /// A unary operator was applied to a value type the executor does not support.
+    #[error("unsupported unary expression: {op} {value:?}")]
+    UnsupportedUnary {
+        /// Operator being evaluated.
+        op: Op,
+        /// Operand value rejected by the operator.
+        value: Value,
+    },
+    /// A binary operator was applied to value types the executor does not support.
+    #[error("unsupported binary expression: {left:?} {op} {right:?}")]
+    UnsupportedBinary {
+        /// Left operand value.
+        left: Value,
+        /// Operator being evaluated.
+        op: Op,
+        /// Right operand value.
+        right: Value,
+    },
+    /// A logical expression received a non-boolean operand.
+    #[error("{op} expected a boolean operand, got {value:?}")]
+    NonBooleanLogicalOperand {
+        /// Logical operator being evaluated.
+        op: Op,
+        /// Operand value rejected by the operator.
+        value: Value,
+    },
+    /// Integer arithmetic overflowed.
+    #[error("integer overflow while evaluating operator {op}")]
+    IntegerOverflow {
+        /// Arithmetic operator whose checked integer operation overflowed.
+        op: Op,
+    },
+    /// A division expression used zero as the divisor.
+    #[error("division by zero")]
+    DivisionByZero,
+    /// A row operator received a non-row-producing child plan.
+    #[error("{operator} expected its input plan to return rows")]
+    ExpectedRows {
+        /// Operator that requested rows from its child.
+        operator: &'static str,
+    },
+    /// The physical operator is planned but not implemented by the executor.
+    #[error("{operator} is not supported yet")]
+    UnsupportedOperator {
+        /// Name of the unsupported physical operator.
+        operator: &'static str,
+    },
+    /// An inserted value row did not match the number of target columns.
+    #[error("insert row has {values} values for {columns} columns")]
+    InsertColumnValueCount {
+        /// Number of target columns in the insert.
+        columns: usize,
+        /// Number of values supplied by the row.
+        values: usize,
+    },
+    /// An inserted row left a non-nullable column as `NULL`.
+    #[error("column {column} does not accept NULL values")]
+    InsertNullConstraint {
+        /// Column that rejected `NULL`.
+        column: String,
+    },
+    /// An inserted value did not match its target column type.
+    #[error("column {column} expects {expected:?}, got {actual:?}")]
+    InsertTypeMismatch {
+        /// Target column name.
+        column: String,
+        /// Column type recorded in the catalog.
+        expected: DataType,
+        /// Value rejected by the column.
+        actual: Value,
+    },
+}
+
+/// Result type returned by executor operations.
+pub type ExecutorResult<T> = Result<T, ExecutorError>;
+
+/// Lazy stream of records produced by a row-returning plan.
+///
+/// Individual rows can fail while the stream is being consumed, for example if
+/// a later scanned page cannot be read or a downstream expression fails for a
+/// specific record.
+pub type RowStream = Box<dyn Iterator<Item = ExecutorResult<TableRecord>>>;
+
+/// Result of executing one physical plan.
+pub enum ExecutionOutput {
+    /// A lazy stream of result rows.
+    Rows {
+        /// Result rows yielded on demand.
+        rows: RowStream,
+    },
+    /// Number of table rows changed by a data-modification statement.
+    RowsAffected(u64),
+    /// A schema-level side effect completed.
+    SchemaAffected,
+}
+
+impl ExecutionOutput {
+    /// Extracts the row stream from this output.
+    ///
+    /// Row operators call this when they expect their child plan to produce
+    /// rows. Non-row outputs become [`ExecutorError::ExpectedRows`] tagged with
+    /// the requesting operator name.
+    pub fn into_rows(self, operator: &'static str) -> ExecutorResult<RowStream> {
+        match self {
+            Self::Rows { rows } => Ok(rows),
+            Self::RowsAffected(_) | Self::SchemaAffected => {
+                Err(ExecutorError::ExpectedRows { operator })
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for ExecutionOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rows { .. } => f.debug_struct("Rows").field("rows", &"<row stream>").finish(),
+            Self::RowsAffected(count) => f.debug_tuple("RowsAffected").field(count).finish(),
+            Self::SchemaAffected => f.write_str("SchemaAffected"),
+        }
+    }
+}
+
+impl std::fmt::Display for ExecutionOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExecutionOutput::Rows { .. } => write!(f, "Query returned rows."),
+            ExecutionOutput::RowsAffected(count) => {
+                write!(f, "{count} rows affected.")
+            }
+            ExecutionOutput::SchemaAffected => write!(f, "Schema affected."),
+        }
+    }
+}
+
+/// Executes physical query plans against a database handle.
+///
+/// The executor borrows a [`Database`] and performs catalog, table, and index
+/// operations through that handle. It owns no transaction state; mutation
+/// ordering is encoded directly in each operator implementation.
+pub struct Executor<'db> {
+    database: &'db Database,
+}
+
+impl<'db> Executor<'db> {
+    /// Creates an executor that runs plans against `database`.
+    pub fn new(database: &'db Database) -> Self {
+        Self { database }
+    }
+
+    /// Executes a physical plan and returns its output.
+    ///
+    /// Row-producing operators return immediately with a lazy [`RowStream`].
+    /// The underlying scan, filter, projection, limit, or offset work is then
+    /// performed as the caller consumes that stream. DDL and insert operators
+    /// perform their side effects before returning.
+    pub fn execute(&mut self, plan: PhysicalPlan) -> ExecutorResult<ExecutionOutput> {
+        match plan {
+            PhysicalPlan::CreateTable { name, schema } => {
+                self.database.create_table(&name, schema)?;
+                Ok(ExecutionOutput::SchemaAffected)
+            }
+            PhysicalPlan::CreateIndex { name, table, columns } => {
+                let column_names: Vec<&str> = columns.iter().map(|col| col.name.as_str()).collect();
+                let index = self.database.create_index(&name, &table.name, &column_names)?;
+                backfill_index(self.database, &table, &index)?;
+                Ok(ExecutionOutput::SchemaAffected)
+            }
+            PhysicalPlan::Values { rows } => execute_values(rows),
+            PhysicalPlan::InsertValues { table, columns, values } => {
+                execute_insert_values(self.database, table, columns, values)
+            }
+            PhysicalPlan::OneRow => Ok(ExecutionOutput::Rows {
+                rows: Box::new(std::iter::once_with(|| empty_record(0))),
+            }),
+            PhysicalPlan::FullTableScan { table } => {
+                let table_cursor = self.database.table_cursor_by_name(&table.name)?;
+                let mut tree_cursor = table_cursor.into_inner();
+                let mut done = false;
+                let rows = std::iter::from_fn(move || {
+                    if done {
+                        return None;
+                    }
+
+                    match tree_cursor.next_owned_record() {
+                        Ok(Some(record)) => {
+                            Some(TableRecord::try_from(record).map_err(ExecutorError::Storage))
+                        }
+                        Ok(None) => {
+                            done = true;
+                            None
+                        }
+                        Err(error) => {
+                            done = true;
+                            Some(Err(error.into()))
+                        }
+                    }
+                });
+                Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
+            }
+            PhysicalPlan::Filter { input, predicate } => {
+                let output_inner = self.execute(*input)?;
+                let rows = output_inner.into_rows("FILTER")?.filter_map(move |row| match row {
+                    Ok(row) => {
+                        let result = EvaluationContext::from_record(&row)
+                            .and_then(|context| evaluate_value(&predicate, &context));
+                        match result {
+                            Ok(Value::Boolean(true)) => Some(Ok(row)),
+                            Ok(Value::Boolean(false)) => None,
+                            Ok(value) => Some(Err(ExecutorError::NonBooleanPredicate { value })),
+                            Err(error) => Some(Err(error)),
+                        }
+                    }
+                    Err(error) => Some(Err(error)),
+                });
+                Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
+            }
+            PhysicalPlan::Sort { input: _, terms: _ } => {
+                // TODO: Change tuple serialization format to allow value comparison from raw byte slices
+                Err(ExecutorError::UnsupportedOperator { operator: "SORT" })
+            }
+            PhysicalPlan::Project { input, expressions } => {
+                let output_inner = self.execute(*input)?;
+                let rows = output_inner
+                    .into_rows("PROJECT")?
+                    .map(move |row| row.and_then(|row| evaluate_expressions(&expressions, &row)));
+                Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
+            }
+
+            PhysicalPlan::Offset { input, offset } => {
+                let output_inner = self.execute(*input)?;
+                // TODO: Make `offset` a usize value.
+                let offset = offset as usize;
+                let rows = offset_rows(output_inner.into_rows("OFFSET")?, offset);
+                Ok(ExecutionOutput::Rows { rows })
+            }
+            PhysicalPlan::Limit { input, limit } => {
+                let output_inner = self.execute(*input)?;
+                // TODO: Make `limit` a usize value.
+                let limit = limit as usize;
+                let rows = Box::new(output_inner.into_rows("LIMIT")?.take(limit));
+                Ok(ExecutionOutput::Rows { rows })
+            }
+        }
+    }
+}
+
+/// Evaluates one planned scalar expression against a record.
+///
+/// The result is represented as a single-column [`TableRecord`] that preserves
+/// the input record's row id. This is primarily useful for tests and callers
+/// that need expression evaluation without building a full projection plan.
+pub fn evaluate_expression(
+    expression: &PlannedExpression,
+    record: &TableRecord,
+) -> ExecutorResult<TableRecord> {
+    evaluate_expressions(std::slice::from_ref(expression), record)
+}
+
+/// Executes a `VALUES` plan as a stream of evaluated literal rows.
+///
+/// Each values row is evaluated against an empty synthetic record. The row's
+/// position in the `VALUES` list becomes the result row id.
+fn execute_values(rows: Vec<Vec<PlannedExpression>>) -> ExecutorResult<ExecutionOutput> {
+    let rows = rows.into_iter().enumerate().map(|(row_id, expressions)| {
+        let input = empty_record(row_id as u64)?;
+        evaluate_expressions(&expressions, &input)
+    });
+    Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
+}
+
+/// Skips rows from a child stream while still surfacing skipped-row errors.
+///
+/// SQL `OFFSET` cannot silently swallow errors from rows it discards: if the
+/// child stream fails before enough rows have been skipped, the offset operator
+/// yields that error and continues counting it as one consumed input row.
+fn offset_rows(mut rows: RowStream, mut remaining: usize) -> RowStream {
+    Box::new(std::iter::from_fn(move || {
+        while remaining > 0 {
+            match rows.next()? {
+                Ok(_) => remaining -= 1,
+                Err(error) => {
+                    remaining -= 1;
+                    return Some(Err(error));
+                }
+            }
+        }
+
+        rows.next()
+    }))
+}
+
+/// Executes an `INSERT ... VALUES` plan.
+///
+/// Each value row is evaluated, expanded into the target table layout, checked
+/// against nullability and type constraints, inserted into the table B+-tree,
+/// and then mirrored into every existing secondary index for that table.
+fn execute_insert_values(
+    database: &Database,
+    table: TableSchema,
+    columns: Vec<BoundColumn>,
+    values: Vec<Vec<PlannedExpression>>,
+) -> ExecutorResult<ExecutionOutput> {
+    let mut cursor = database.table_cursor_by_name(&table.name)?;
+    let indexes = database.index_schemas_for_table(&table)?;
+    let mut affected = 0;
+
+    for expressions in values {
+        if expressions.len() != columns.len() {
+            return Err(ExecutorError::InsertColumnValueCount {
+                columns: columns.len(),
+                values: expressions.len(),
+            });
+        }
+
+        let input = empty_record(0)?;
+        let input_context = EvaluationContext::from_record(&input)?;
+        let mut row_values = vec![Value::Null; table.row.columns.len()];
+        for (column, expression) in columns.iter().zip(expressions.iter()) {
+            let len = row_values.len();
+            let value = evaluate_value(expression, &input_context)?;
+            let slot = row_values.get_mut(column.ordinal).ok_or_else(|| {
+                ExecutorError::ColumnOrdinalOutOfBounds {
+                    column: column.name.clone(),
+                    ordinal: column.ordinal,
+                    len,
+                }
+            })?;
+            *slot = value;
+        }
+        validate_insert_row(&table, &row_values)?;
+
+        let record = record_bytes_from_values(row_values)?;
+        let row_id = database.allocate_table_row_id(&table)?;
+        cursor.insert(row_id, &record)?;
+        let record = TableRecord { row_id, record: record.into_boxed_slice() };
+        insert_index_entries(database, &indexes, &record)?;
+        affected += 1;
+    }
+
+    Ok(ExecutionOutput::RowsAffected(affected))
+}
+
+/// Validates one fully-shaped table row against the table schema.
+///
+/// Missing target columns are represented as [`Value::Null`] before this
+/// function runs, so omitted non-nullable and primary-key columns are rejected
+/// by the same logic as explicit `NULL` values.
+fn validate_insert_row(table: &TableSchema, values: &[Value]) -> ExecutorResult<()> {
+    for (column, value) in table.row.columns.iter().zip(values.iter()) {
+        if matches!(value, Value::Null) {
+            if !column.nullable || column.primary_key {
+                return Err(ExecutorError::InsertNullConstraint { column: column.name.clone() });
+            }
+            continue;
+        }
+
+        if !value_matches_data_type(value, column.data_type) {
+            return Err(ExecutorError::InsertTypeMismatch {
+                column: column.name.clone(),
+                expected: column.data_type,
+                actual: value.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Inserts secondary-index entries for a newly inserted table record.
+///
+/// Index keys are reconstructed from the encoded table record so this code path
+/// uses the same key derivation as index backfill.
+fn insert_index_entries(
+    database: &Database,
+    indexes: &[IndexSchema],
+    record: &TableRecord,
+) -> ExecutorResult<()> {
+    for index in indexes {
+        let key = index_key_from_record(index, record)?;
+        let mut index_cursor = database.index_cursor_by_name(&index.name)?;
+        index_cursor.insert(&key, record.row_id)?;
+    }
+
+    Ok(())
+}
+
+/// Populates a newly-created secondary index from existing table rows.
+fn backfill_index(
+    database: &Database,
+    table: &TableSchema,
+    index: &IndexSchema,
+) -> ExecutorResult<()> {
+    let table_cursor = database.table_cursor_by_name(&table.name)?;
+    let mut table_cursor = table_cursor.into_inner();
+    let mut index_cursor = database.index_cursor_by_name(&index.name)?;
+
+    while let Some(record) = table_cursor.next_owned_record()? {
+        let record = TableRecord::try_from(record).map_err(ExecutorError::Storage)?;
+        let key = index_key_from_record(index, &record)?;
+        index_cursor.insert(&key, record.row_id)?;
+    }
+
+    Ok(())
+}
+
+/// Builds the encoded key tuple for an index entry.
+///
+/// Index column metadata records the ordinal of each source table column. The
+/// key is an encoded tuple containing those source values in index-column order.
+fn index_key_from_record(index: &IndexSchema, record: &TableRecord) -> ExecutorResult<Vec<u8>> {
+    let context = EvaluationContext::from_record(record)?;
+    let values = index
+        .columns
+        .iter()
+        .map(|column| context.value_at(column.source_column_ordinal as usize, &column.column.name))
+        .collect::<ExecutorResult<Vec<_>>>()?;
+    record_bytes_from_values(values)
+}
+
+/// Returns whether a non-null value can be stored in a column of `data_type`.
+fn value_matches_data_type(value: &Value, data_type: DataType) -> bool {
+    matches!(
+        (value, data_type),
+        (Value::String(_), DataType::Text)
+            | (Value::Boolean(_), DataType::Boolean)
+            | (Value::Integer(_), DataType::Integer)
+            | (Value::Float(_), DataType::Float)
+            | (Value::UnsignedInteger(_), DataType::UnsignedInteger)
+    )
+}
+
+/// Evaluates a projection list against one input record.
+fn evaluate_expressions(
+    expressions: &[PlannedExpression],
+    record: &TableRecord,
+) -> ExecutorResult<TableRecord> {
+    let context = EvaluationContext::from_record(record)?;
+    evaluate_expressions_in_context(expressions, &context)
+}
+
+/// Evaluates expressions using an already-parsed tuple context.
+fn evaluate_expressions_in_context(
+    expressions: &[PlannedExpression],
+    context: &EvaluationContext<'_>,
+) -> ExecutorResult<TableRecord> {
+    let values = expressions
+        .iter()
+        .map(|expression| evaluate_value(expression, context))
+        .collect::<ExecutorResult<Vec<_>>>()?;
+    record_from_values(context.row_id, values)
+}
+
+/// Evaluates a scalar expression to one typed value.
+///
+/// Logical `AND` and `OR` are short-circuited here before evaluating the right
+/// operand, so expressions like `FALSE AND (1 / 0)` do not report division by
+/// zero.
+fn evaluate_value(
+    expression: &PlannedExpression,
+    context: &EvaluationContext<'_>,
+) -> ExecutorResult<Value> {
+    match expression {
+        PlannedExpression::Literal(value) => Ok(value.clone()),
+        PlannedExpression::Column(column) => context.evaluate_column(column),
+        PlannedExpression::Unary { op, expr } => {
+            let value = evaluate_value(expr, context)?;
+            evaluate_unary(*op, value)
+        }
+        PlannedExpression::Binary { left, op, right } => {
+            let left = evaluate_value(left, context)?;
+            if matches!(op, Op::And | Op::Or) {
+                return evaluate_logical_binary(left, *op, right, context);
+            }
+            let right = evaluate_value(right, context)?;
+            evaluate_binary(left, *op, right)
+        }
+    }
+}
+
+/// Parsed view of an input record used while evaluating expressions.
+///
+/// The context keeps the original row id so projected records preserve their
+/// source identity, and it keeps a zero-copy tuple view so column references can
+/// read typed values by ordinal.
+struct EvaluationContext<'a> {
+    row_id: u64,
+    tuple: TupleView<'a>,
+}
+
+impl<'a> EvaluationContext<'a> {
+    /// Parses the encoded tuple bytes from `record`.
+    fn from_record(record: &'a TableRecord) -> ExecutorResult<Self> {
+        let tuple = TupleView::parse(&record.record).map_err(ExecutorError::InvalidTuple)?;
+        Ok(Self { row_id: record.row_id, tuple })
+    }
+
+    /// Reads the value for a planner-bound column reference.
+    fn evaluate_column(&self, column: &BoundColumn) -> ExecutorResult<Value> {
+        self.value_at(column.ordinal, &column.name)
+    }
+
+    /// Reads the value at `ordinal`, using `column_name` for diagnostics.
+    fn value_at(&self, ordinal: usize, column_name: &str) -> ExecutorResult<Value> {
+        let len = self.tuple.len();
+        self.tuple.values().nth(ordinal).map(Value::from).ok_or_else(|| {
+            ExecutorError::ColumnOrdinalOutOfBounds { column: column_name.to_owned(), ordinal, len }
+        })
+    }
+}
+
+/// Evaluates a unary operator against one value.
+fn evaluate_unary(op: Op, value: Value) -> ExecutorResult<Value> {
+    match (op, value) {
+        (Op::Not, Value::Boolean(value)) => Ok(Value::Boolean(!value)),
+        (Op::Sub, Value::Integer(value)) => {
+            value.checked_neg().map(Value::Integer).ok_or(ExecutorError::IntegerOverflow { op })
+        }
+        (Op::Sub, Value::Float(value)) => Ok(Value::Float(-value)),
+        (op, value) => Err(ExecutorError::UnsupportedUnary { op, value }),
+    }
+}
+
+/// Evaluates a non-short-circuiting binary operator.
+fn evaluate_binary(left: Value, op: Op, right: Value) -> ExecutorResult<Value> {
+    match op {
+        Op::And | Op::Or => evaluate_eager_boolean_binary(left, op, right),
+        Op::Add | Op::Sub | Op::Mul | Op::Div => evaluate_arithmetic(left, op, right),
+        Op::EqualsEquals | Op::NotEquals => evaluate_equality(left, op, right),
+        Op::LessThan | Op::GreaterThan | Op::LessThanOrEqual | Op::GreaterThanOrEqual => {
+            evaluate_ordering(left, op, right)
+        }
+        Op::Not => Err(ExecutorError::UnsupportedBinary { left, op, right }),
+    }
+}
+
+/// Evaluates short-circuiting boolean `AND` and `OR`.
+fn evaluate_logical_binary(
+    left: Value,
+    op: Op,
+    right: &PlannedExpression,
+    context: &EvaluationContext<'_>,
+) -> ExecutorResult<Value> {
+    match (left, op) {
+        (Value::Boolean(false), Op::And) => Ok(Value::Boolean(false)),
+        (Value::Boolean(true), Op::Or) => Ok(Value::Boolean(true)),
+        (Value::Boolean(_), op @ (Op::And | Op::Or)) => {
+            let right = evaluate_value(right, context)?;
+            match right {
+                Value::Boolean(right) => Ok(Value::Boolean(right)),
+                value => Err(ExecutorError::NonBooleanLogicalOperand { op, value }),
+            }
+        }
+        (value, op @ (Op::And | Op::Or)) => {
+            Err(ExecutorError::NonBooleanLogicalOperand { op, value })
+        }
+        (_, _) => unreachable!("evaluate_logical_binary only accepts logical operators"),
+    }
+}
+
+/// Evaluates boolean operators when both operands have already been evaluated.
+fn evaluate_eager_boolean_binary(left: Value, op: Op, right: Value) -> ExecutorResult<Value> {
+    match (left, op, right) {
+        (Value::Boolean(left), Op::And, Value::Boolean(right)) => Ok(Value::Boolean(left && right)),
+        (Value::Boolean(left), Op::Or, Value::Boolean(right)) => Ok(Value::Boolean(left || right)),
+        (left, op, right) => Err(ExecutorError::UnsupportedBinary { left, op, right }),
+    }
+}
+
+/// Evaluates arithmetic over supported numeric value pairs.
+fn evaluate_arithmetic(left: Value, op: Op, right: Value) -> ExecutorResult<Value> {
+    match (left, op, right) {
+        (Value::Integer(left), Op::Add, Value::Integer(right)) => {
+            left.checked_add(right).map(Value::Integer).ok_or(ExecutorError::IntegerOverflow { op })
+        }
+        (Value::Integer(left), Op::Sub, Value::Integer(right)) => {
+            left.checked_sub(right).map(Value::Integer).ok_or(ExecutorError::IntegerOverflow { op })
+        }
+        (Value::Integer(left), Op::Mul, Value::Integer(right)) => {
+            left.checked_mul(right).map(Value::Integer).ok_or(ExecutorError::IntegerOverflow { op })
+        }
+        (Value::Integer(_), Op::Div, Value::Integer(0)) => Err(ExecutorError::DivisionByZero),
+        (Value::Integer(left), Op::Div, Value::Integer(right)) => {
+            left.checked_div(right).map(Value::Integer).ok_or(ExecutorError::IntegerOverflow { op })
+        }
+        (Value::Float(left), Op::Add, Value::Float(right)) => Ok(Value::Float(left + right)),
+        (Value::Float(left), Op::Sub, Value::Float(right)) => Ok(Value::Float(left - right)),
+        (Value::Float(left), Op::Mul, Value::Float(right)) => Ok(Value::Float(left * right)),
+        (Value::Float(_), Op::Div, Value::Float(0.0)) => Err(ExecutorError::DivisionByZero),
+        (Value::Float(left), Op::Div, Value::Float(right)) => Ok(Value::Float(left / right)),
+        (left, op, right) => Err(ExecutorError::UnsupportedBinary { left, op, right }),
+    }
+}
+
+/// Evaluates equality and inequality for same-type values.
+fn evaluate_equality(left: Value, op: Op, right: Value) -> ExecutorResult<Value> {
+    match (&left, &right) {
+        (Value::Null, Value::Null)
+        | (Value::String(_), Value::String(_))
+        | (Value::Boolean(_), Value::Boolean(_))
+        | (Value::Integer(_), Value::Integer(_))
+        | (Value::Float(_), Value::Float(_))
+        | (Value::UnsignedInteger(_), Value::UnsignedInteger(_)) => {
+            let equal = left == right;
+            Ok(Value::Boolean(if matches!(op, Op::EqualsEquals) { equal } else { !equal }))
+        }
+        _ => Err(ExecutorError::UnsupportedBinary { left, op, right }),
+    }
+}
+
+/// Evaluates ordering comparisons for same-type ordered values.
+fn evaluate_ordering(left: Value, op: Op, right: Value) -> ExecutorResult<Value> {
+    let result = match (&left, &right) {
+        (Value::String(left), Value::String(right)) => compare_ordered(left, op, right),
+        (Value::Boolean(left), Value::Boolean(right)) => compare_ordered(left, op, right),
+        (Value::Integer(left), Value::Integer(right)) => compare_ordered(left, op, right),
+        (Value::Float(left), Value::Float(right)) => compare_ordered(left, op, right),
+        (Value::UnsignedInteger(left), Value::UnsignedInteger(right)) => {
+            compare_ordered(left, op, right)
+        }
+        _ => return Err(ExecutorError::UnsupportedBinary { left, op, right }),
+    };
+    Ok(Value::Boolean(result))
+}
+
+/// Applies an ordering operator to values with a Rust [`PartialOrd`] relation.
+fn compare_ordered<T: PartialOrd>(left: &T, op: Op, right: &T) -> bool {
+    match op {
+        Op::LessThan => left < right,
+        Op::GreaterThan => left > right,
+        Op::LessThanOrEqual => left <= right,
+        Op::GreaterThanOrEqual => left >= right,
+        _ => unreachable!("compare_ordered only accepts ordering operators"),
+    }
+}
+
+/// Builds an encoded empty record with the provided row id.
+fn empty_record(row_id: u64) -> ExecutorResult<TableRecord> {
+    record_from_values(row_id, Vec::new())
+}
+
+/// Builds a table record from owned typed values.
+fn record_from_values(row_id: u64, values: Vec<Value>) -> ExecutorResult<TableRecord> {
+    let record = record_bytes_from_values(values)?;
+    Ok(TableRecord { row_id, record: record.into_boxed_slice() })
+}
+
+/// Serializes typed values using the tuple storage format.
+fn record_bytes_from_values(values: Vec<Value>) -> ExecutorResult<Vec<u8>> {
+    Tuple::new(values).to_bytes().map_err(ExecutorError::InvalidTuple)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::{
+        core::{ColumnSchema, DataType, TupleSchema},
+        planner::{BoundColumn, Planner},
+        sql_parser::parser::Parser,
+    };
+
+    fn record(row_id: u64, values: Vec<Value>) -> TableRecord {
+        record_from_values(row_id, values).unwrap()
+    }
+
+    fn values(record: &TableRecord) -> Vec<Value> {
+        Tuple::from_bytes(&record.record).unwrap().into_values()
+    }
+
+    fn collect_rows(output: ExecutionOutput) -> ExecutorResult<Vec<TableRecord>> {
+        output.into_rows("TEST")?.collect()
+    }
+
+    fn bound(name: &str, ordinal: usize, data_type: DataType) -> BoundColumn {
+        BoundColumn { table: "users".to_owned(), name: name.to_owned(), ordinal, data_type }
+    }
+
+    fn insert_values_plan(
+        database: &Database,
+        columns: Vec<BoundColumn>,
+        rows: Vec<Vec<Value>>,
+    ) -> PhysicalPlan {
+        PhysicalPlan::InsertValues {
+            table: database.table_schema_by_name("users").unwrap(),
+            columns,
+            values: rows
+                .into_iter()
+                .map(|row| row.into_iter().map(PlannedExpression::Literal).collect())
+                .collect(),
+        }
+    }
+
+    fn users_schema() -> TupleSchema {
+        TupleSchema {
+            columns: vec![
+                ColumnSchema {
+                    name: "id".to_owned(),
+                    data_type: DataType::Integer,
+                    nullable: false,
+                    primary_key: true,
+                },
+                ColumnSchema {
+                    name: "name".to_owned(),
+                    data_type: DataType::Text,
+                    nullable: false,
+                    primary_key: false,
+                },
+                ColumnSchema {
+                    name: "active".to_owned(),
+                    data_type: DataType::Boolean,
+                    nullable: false,
+                    primary_key: false,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn single_literal_expression_produces_one_column_record() {
+        let input = record(7, vec![Value::Integer(1)]);
+        let output = evaluate_expression(
+            &PlannedExpression::Literal(Value::String("Ada".to_owned())),
+            &input,
+        )
+        .unwrap();
+
+        assert_eq!(output.row_id, 7);
+        assert_eq!(values(&output), vec![Value::String("Ada".to_owned())]);
+    }
+
+    #[test]
+    fn single_column_expression_reads_bound_ordinal() {
+        let input = record(
+            8,
+            vec![Value::Integer(1), Value::String("Grace".to_owned()), Value::Boolean(true)],
+        );
+        let output = evaluate_expression(
+            &PlannedExpression::Column(bound("name", 1, DataType::Text)),
+            &input,
+        )
+        .unwrap();
+
+        assert_eq!(output.row_id, 8);
+        assert_eq!(values(&output), vec![Value::String("Grace".to_owned())]);
+    }
+
+    #[test]
+    fn project_evaluates_multiple_expressions_in_order() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Project {
+            input: Box::new(PhysicalPlan::Values {
+                rows: vec![vec![
+                    PlannedExpression::Literal(Value::Integer(4)),
+                    PlannedExpression::Literal(Value::Integer(5)),
+                ]],
+            }),
+            expressions: vec![
+                PlannedExpression::Column(bound("right", 1, DataType::Integer)),
+                PlannedExpression::Binary {
+                    left: Box::new(PlannedExpression::Column(bound("left", 0, DataType::Integer))),
+                    op: Op::Add,
+                    right: Box::new(PlannedExpression::Column(bound(
+                        "right",
+                        1,
+                        DataType::Integer,
+                    ))),
+                },
+            ],
+        };
+
+        let rows = collect_rows(executor.execute(plan).unwrap()).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].row_id, 0);
+        assert_eq!(values(&rows[0]), vec![Value::Integer(5), Value::Integer(9)]);
+    }
+
+    #[test]
+    fn filter_keeps_only_rows_with_true_predicate() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Filter {
+            input: Box::new(PhysicalPlan::Values {
+                rows: vec![
+                    vec![
+                        PlannedExpression::Literal(Value::Integer(1)),
+                        PlannedExpression::Literal(Value::Boolean(true)),
+                    ],
+                    vec![
+                        PlannedExpression::Literal(Value::Integer(2)),
+                        PlannedExpression::Literal(Value::Boolean(false)),
+                    ],
+                ],
+            }),
+            predicate: PlannedExpression::Column(bound("active", 1, DataType::Boolean)),
+        };
+
+        let rows = collect_rows(executor.execute(plan).unwrap()).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(values(&rows[0]), vec![Value::Integer(1), Value::Boolean(true)]);
+    }
+
+    #[test]
+    fn filter_rejects_non_boolean_predicate() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Filter {
+            input: Box::new(PhysicalPlan::Values {
+                rows: vec![vec![PlannedExpression::Literal(Value::Integer(1))]],
+            }),
+            predicate: PlannedExpression::Column(bound("id", 0, DataType::Integer)),
+        };
+
+        assert!(matches!(
+            collect_rows(executor.execute(plan).unwrap()),
+            Err(ExecutorError::NonBooleanPredicate { value: Value::Integer(1) })
+        ));
+    }
+
+    #[test]
+    fn limit_does_not_evaluate_rows_beyond_limit() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Limit {
+            input: Box::new(PhysicalPlan::Values {
+                rows: vec![
+                    vec![PlannedExpression::Literal(Value::Integer(1))],
+                    vec![PlannedExpression::Binary {
+                        left: Box::new(PlannedExpression::Literal(Value::Integer(1))),
+                        op: Op::Div,
+                        right: Box::new(PlannedExpression::Literal(Value::Integer(0))),
+                    }],
+                ],
+            }),
+            limit: 1,
+        };
+
+        let rows = collect_rows(executor.execute(plan).unwrap()).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(values(&rows[0]), vec![Value::Integer(1)]);
+    }
+
+    #[test]
+    fn limit_larger_than_child_rows_returns_all_rows() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Limit {
+            input: Box::new(PhysicalPlan::Values {
+                rows: vec![
+                    vec![PlannedExpression::Literal(Value::Integer(1))],
+                    vec![PlannedExpression::Literal(Value::Integer(2))],
+                ],
+            }),
+            limit: u32::MAX,
+        };
+
+        let rows = collect_rows(executor.execute(plan).unwrap()).unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(values(&rows[0]), vec![Value::Integer(1)]);
+        assert_eq!(values(&rows[1]), vec![Value::Integer(2)]);
+    }
+
+    #[test]
+    fn limit_rejects_non_row_child() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Limit {
+            input: Box::new(PhysicalPlan::CreateTable {
+                name: "users".to_owned(),
+                schema: users_schema(),
+            }),
+            limit: 1,
+        };
+
+        assert!(matches!(
+            executor.execute(plan),
+            Err(ExecutorError::ExpectedRows { operator: "LIMIT" })
+        ));
+    }
+
+    #[test]
+    fn offset_reports_errors_from_skipped_rows() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Offset {
+            input: Box::new(PhysicalPlan::Filter {
+                input: Box::new(PhysicalPlan::Values {
+                    rows: vec![
+                        vec![PlannedExpression::Literal(Value::Integer(1))],
+                        vec![PlannedExpression::Literal(Value::Integer(2))],
+                    ],
+                }),
+                predicate: PlannedExpression::Column(bound("id", 0, DataType::Integer)),
+            }),
+            offset: 1,
+        };
+
+        assert!(matches!(
+            collect_rows(executor.execute(plan).unwrap()),
+            Err(ExecutorError::NonBooleanPredicate { value: Value::Integer(1) })
+        ));
+    }
+
+    #[test]
+    fn offset_larger_than_child_rows_returns_no_rows() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Offset {
+            input: Box::new(PhysicalPlan::Values {
+                rows: vec![
+                    vec![PlannedExpression::Literal(Value::Integer(1))],
+                    vec![PlannedExpression::Literal(Value::Integer(2))],
+                ],
+            }),
+            offset: u32::MAX,
+        };
+
+        let rows = collect_rows(executor.execute(plan).unwrap()).unwrap();
+
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn offset_rejects_non_row_child() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Offset {
+            input: Box::new(PhysicalPlan::CreateTable {
+                name: "users".to_owned(),
+                schema: users_schema(),
+            }),
+            offset: 1,
+        };
+
+        assert!(matches!(
+            executor.execute(plan),
+            Err(ExecutorError::ExpectedRows { operator: "OFFSET" })
+        ));
+    }
+
+    #[test]
+    fn filter_propagates_child_row_errors() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Filter {
+            input: Box::new(PhysicalPlan::Filter {
+                input: Box::new(PhysicalPlan::Values {
+                    rows: vec![vec![PlannedExpression::Literal(Value::Integer(1))]],
+                }),
+                predicate: PlannedExpression::Column(bound("id", 0, DataType::Integer)),
+            }),
+            predicate: PlannedExpression::Literal(Value::Boolean(true)),
+        };
+
+        assert!(matches!(
+            collect_rows(executor.execute(plan).unwrap()),
+            Err(ExecutorError::NonBooleanPredicate { value: Value::Integer(1) })
+        ));
+    }
+
+    #[test]
+    fn project_propagates_child_row_errors() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Project {
+            input: Box::new(PhysicalPlan::Filter {
+                input: Box::new(PhysicalPlan::Values {
+                    rows: vec![vec![PlannedExpression::Literal(Value::Integer(1))]],
+                }),
+                predicate: PlannedExpression::Column(bound("id", 0, DataType::Integer)),
+            }),
+            expressions: vec![PlannedExpression::Literal(Value::Integer(2))],
+        };
+
+        assert!(matches!(
+            collect_rows(executor.execute(plan).unwrap()),
+            Err(ExecutorError::NonBooleanPredicate { value: Value::Integer(1) })
+        ));
+    }
+
+    #[test]
+    fn row_operator_rejects_non_row_child() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Project {
+            input: Box::new(PhysicalPlan::CreateTable {
+                name: "users".to_owned(),
+                schema: users_schema(),
+            }),
+            expressions: vec![PlannedExpression::Literal(Value::Integer(1))],
+        };
+
+        assert!(matches!(
+            executor.execute(plan),
+            Err(ExecutorError::ExpectedRows { operator: "PROJECT" })
+        ));
+    }
+
+    #[test]
+    fn sort_returns_unsupported_error_instead_of_panicking() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let mut executor = Executor::new(&database);
+        let plan = PhysicalPlan::Sort {
+            input: Box::new(PhysicalPlan::Values { rows: Vec::new() }),
+            terms: Vec::new(),
+        };
+
+        assert!(matches!(
+            executor.execute(plan),
+            Err(ExecutorError::UnsupportedOperator { operator: "SORT" })
+        ));
+    }
+
+    #[test]
+    fn evaluates_arithmetic_comparison_boolean_and_unary_expressions() {
+        let input = record(9, Vec::new());
+        let expression = PlannedExpression::Binary {
+            left: Box::new(PlannedExpression::Unary {
+                op: Op::Not,
+                expr: Box::new(PlannedExpression::Binary {
+                    left: Box::new(PlannedExpression::Literal(Value::Integer(2))),
+                    op: Op::GreaterThan,
+                    right: Box::new(PlannedExpression::Literal(Value::Integer(3))),
+                }),
+            }),
+            op: Op::And,
+            right: Box::new(PlannedExpression::Binary {
+                left: Box::new(PlannedExpression::Binary {
+                    left: Box::new(PlannedExpression::Literal(Value::Integer(2))),
+                    op: Op::Mul,
+                    right: Box::new(PlannedExpression::Literal(Value::Integer(4))),
+                }),
+                op: Op::EqualsEquals,
+                right: Box::new(PlannedExpression::Literal(Value::Integer(8))),
+            }),
+        };
+
+        let output = evaluate_expression(&expression, &input).unwrap();
+
+        assert_eq!(values(&output), vec![Value::Boolean(true)]);
+    }
+
+    #[test]
+    fn boolean_expressions_short_circuit() {
+        let input = record(9, Vec::new());
+        let divide_by_zero = PlannedExpression::Binary {
+            left: Box::new(PlannedExpression::Literal(Value::Integer(1))),
+            op: Op::Div,
+            right: Box::new(PlannedExpression::Literal(Value::Integer(0))),
+        };
+        let false_and_error = PlannedExpression::Binary {
+            left: Box::new(PlannedExpression::Literal(Value::Boolean(false))),
+            op: Op::And,
+            right: Box::new(divide_by_zero.clone()),
+        };
+        let true_or_error = PlannedExpression::Binary {
+            left: Box::new(PlannedExpression::Literal(Value::Boolean(true))),
+            op: Op::Or,
+            right: Box::new(divide_by_zero),
+        };
+
+        let false_and_output = evaluate_expression(&false_and_error, &input).unwrap();
+        let true_or_output = evaluate_expression(&true_or_error, &input).unwrap();
+
+        assert_eq!(values(&false_and_output), vec![Value::Boolean(false)]);
+        assert_eq!(values(&true_or_output), vec![Value::Boolean(true)]);
+    }
+
+    #[test]
+    fn invalid_type_combinations_return_executor_errors() {
+        let input = record(10, Vec::new());
+        let expression = PlannedExpression::Binary {
+            left: Box::new(PlannedExpression::Literal(Value::Integer(1))),
+            op: Op::Add,
+            right: Box::new(PlannedExpression::Literal(Value::Float(1.0))),
+        };
+
+        assert!(matches!(
+            evaluate_expression(&expression, &input),
+            Err(ExecutorError::UnsupportedBinary {
+                left: Value::Integer(1),
+                op: Op::Add,
+                right: Value::Float(1.0),
+            })
+        ));
+    }
+
+    #[test]
+    fn select_with_projection_and_filter_executes_end_to_end() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        users
+            .insert(
+                1,
+                &Tuple::new(vec![
+                    Value::Integer(1),
+                    Value::String("Ada".to_owned()),
+                    Value::Boolean(true),
+                ])
+                .to_bytes()
+                .unwrap(),
+            )
+            .unwrap();
+        users
+            .insert(
+                2,
+                &Tuple::new(vec![
+                    Value::Integer(2),
+                    Value::String("Grace".to_owned()),
+                    Value::Boolean(false),
+                ])
+                .to_bytes()
+                .unwrap(),
+            )
+            .unwrap();
+
+        let statement = Parser::new("SELECT name FROM users WHERE id == 1;").stmt().unwrap();
+        let plan = Planner::new(&database).plan_statement(&statement).unwrap();
+        let mut executor = Executor::new(&database);
+
+        let rows = collect_rows(executor.execute(plan.physical).unwrap()).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].row_id, 1);
+        assert_eq!(values(&rows[0]), vec![Value::String("Ada".to_owned())]);
+    }
+
+    #[test]
+    fn insert_values_allocates_row_ids_and_persists_rows() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+
+        let statement = Parser::new(
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE), (2, 'Grace', FALSE);",
+        )
+        .stmt()
+        .unwrap();
+        let plan = Planner::new(&database).plan_statement(&statement).unwrap();
+        let mut executor = Executor::new(&database);
+
+        let output = executor.execute(plan.physical).unwrap();
+
+        assert!(matches!(output, ExecutionOutput::RowsAffected(2)));
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 2);
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        let first = users.get(1).unwrap().expect("first inserted row should exist");
+        let second = users.get(2).unwrap().expect("second inserted row should exist");
+        assert_eq!(
+            values(&first),
+            vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true),]
+        );
+        assert_eq!(
+            values(&second),
+            vec![Value::Integer(2), Value::String("Grace".to_owned()), Value::Boolean(false),]
+        );
+    }
+
+    #[test]
+    fn insert_values_rejects_omitted_non_nullable_columns() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+
+        let plan = insert_values_plan(
+            &database,
+            vec![bound("id", 0, DataType::Integer), bound("name", 1, DataType::Text)],
+            vec![vec![Value::Integer(1), Value::String("Ada".to_owned())]],
+        );
+        let mut executor = Executor::new(&database);
+
+        assert!(matches!(
+            executor.execute(plan),
+            Err(ExecutorError::InsertNullConstraint { column }) if column == "active"
+        ));
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
+    }
+
+    #[test]
+    fn insert_values_rejects_values_with_wrong_type() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+
+        let statement =
+            Parser::new("INSERT INTO users (id, name, active) VALUES ('one', 'Ada', TRUE);")
+                .stmt()
+                .unwrap();
+        let plan = Planner::new(&database).plan_statement(&statement).unwrap();
+        let mut executor = Executor::new(&database);
+
+        assert!(matches!(
+            executor.execute(plan.physical),
+            Err(ExecutorError::InsertTypeMismatch {
+                column,
+                expected: DataType::Integer,
+                actual: Value::String(value),
+            }) if column == "id" && value == "one"
+        ));
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
+    }
+
+    #[test]
+    fn insert_values_rejects_null_for_non_nullable_columns() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+
+        let plan = insert_values_plan(
+            &database,
+            vec![
+                bound("id", 0, DataType::Integer),
+                bound("name", 1, DataType::Text),
+                bound("active", 2, DataType::Boolean),
+            ],
+            vec![vec![Value::Integer(1), Value::Null, Value::Boolean(true)]],
+        );
+        let mut executor = Executor::new(&database);
+
+        assert!(matches!(
+            executor.execute(plan),
+            Err(ExecutorError::InsertNullConstraint { column }) if column == "name"
+        ));
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
+    }
+
+    #[test]
+    fn failed_insert_does_not_advance_last_row_id() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+        let mut executor = Executor::new(&database);
+
+        let valid = insert_values_plan(
+            &database,
+            vec![
+                bound("id", 0, DataType::Integer),
+                bound("name", 1, DataType::Text),
+                bound("active", 2, DataType::Boolean),
+            ],
+            vec![vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true)]],
+        );
+        executor.execute(valid).unwrap();
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
+
+        let invalid = insert_values_plan(
+            &database,
+            vec![
+                bound("id", 0, DataType::Integer),
+                bound("name", 1, DataType::Text),
+                bound("active", 2, DataType::Boolean),
+            ],
+            vec![vec![
+                Value::Integer(2),
+                Value::String("Grace".to_owned()),
+                Value::String("yes".to_owned()),
+            ]],
+        );
+
+        assert!(matches!(
+            executor.execute(invalid),
+            Err(ExecutorError::InsertTypeMismatch {
+                column,
+                expected: DataType::Boolean,
+                actual: Value::String(value),
+            }) if column == "active" && value == "yes"
+        ));
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        assert!(users.get(2).unwrap().is_none());
+    }
+
+    #[test]
+    fn create_index_backfills_existing_table_rows() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+        let insert = Parser::new(
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE), (2, 'Grace', FALSE);",
+        )
+        .stmt()
+        .unwrap();
+        let insert_plan = Planner::new(&database).plan_statement(&insert).unwrap();
+        let mut executor = Executor::new(&database);
+        executor.execute(insert_plan.physical).unwrap();
+
+        let create_index =
+            Parser::new("CREATE INDEX idx_users_name ON users (name);").stmt().unwrap();
+        let create_index_plan = Planner::new(&database).plan_statement(&create_index).unwrap();
+        executor.execute(create_index_plan.physical).unwrap();
+
+        let mut index = database.index_cursor_by_name("idx_users_name").unwrap();
+        let key = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
+        let entry = index.get(&key).unwrap().expect("index entry should be backfilled");
+
+        assert_eq!(entry.row_id, 1);
+    }
+
+    #[test]
+    fn insert_values_updates_existing_secondary_indexes() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+        let create_index =
+            Parser::new("CREATE INDEX idx_users_name ON users (name);").stmt().unwrap();
+        let create_index_plan = Planner::new(&database).plan_statement(&create_index).unwrap();
+        let mut executor = Executor::new(&database);
+        executor.execute(create_index_plan.physical).unwrap();
+
+        let insert = Parser::new("INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE);")
+            .stmt()
+            .unwrap();
+        let insert_plan = Planner::new(&database).plan_statement(&insert).unwrap();
+        executor.execute(insert_plan.physical).unwrap();
+
+        let mut index = database.index_cursor_by_name("idx_users_name").unwrap();
+        let key = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
+        let entry = index.get(&key).unwrap().expect("index entry should track inserted row");
+
+        assert_eq!(entry.row_id, 1);
+    }
+
+    #[test]
+    fn select_without_from_executes_through_one_row_and_project() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        let statement = Parser::new("SELECT 1 + 2;").stmt().unwrap();
+        let plan = Planner::new(&database).plan_statement(&statement).unwrap();
+        let mut executor = Executor::new(&database);
+
+        let rows = collect_rows(executor.execute(plan.physical).unwrap()).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].row_id, 0);
+        assert_eq!(values(&rows[0]), vec![Value::Integer(3)]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod core;
+pub mod executor;
 pub mod planner;
 pub mod sql_parser;

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -1,3 +1,15 @@
+//! SQL query planning.
+//!
+//! The planner lowers parsed SQL statements into a [`Plan`] that contains both
+//! a catalog-bound [`LogicalPlan`] and the executable [`PhysicalPlan`]. Planning
+//! resolves table and column names against the database catalog, expands
+//! wildcard projections, validates statement shapes, and records enough schema
+//! metadata for execution to read or write typed tuples.
+//!
+//! This planner is intentionally conservative. It preserves the parsed query
+//! shape for most relational operators and currently chooses only simple
+//! physical operators such as full table scans and values-backed inserts.
+
 use std::collections::HashSet;
 
 use thiserror::Error;
@@ -23,139 +35,248 @@ use crate::{
     },
 };
 
+/// Result type returned by query planning operations.
 pub type PlannerResult<T> = Result<T, PlannerError>;
 
+/// Complete planning result for one SQL statement.
+///
+/// The logical plan is useful for validation, tests, and future optimization
+/// passes. The physical plan is the tree consumed by the executor.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Plan {
+    /// Catalog-bound statement representation before physical operator
+    /// selection.
     pub logical: LogicalPlan,
+    /// Executable operator tree selected from the logical plan.
     pub physical: PhysicalPlan,
 }
 
+/// Catalog-bound relational representation of a parsed SQL statement.
+///
+/// Logical plans describe what the statement means after name binding and basic
+/// validation, but before choosing concrete access methods. Children are stored
+/// in `Box`es so the plan can form recursive operator trees.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogicalPlan {
+    /// Create a table with the provided tuple schema.
     CreateTable { name: String, schema: TupleSchema },
+    /// Create a secondary index over bound columns from an existing table.
     CreateIndex { name: String, table: TableSchema, columns: Vec<BoundColumn> },
+    /// Literal rows, usually produced by an `INSERT ... VALUES` statement.
     Values { rows: Vec<Vec<PlannedExpression>> },
+    /// Insert rows from an input plan into bound table columns.
     Insert { table: TableSchema, columns: Vec<BoundColumn>, input: Box<LogicalPlan> },
+    /// Synthetic single-row input used for projection-only selects without a
+    /// `FROM` clause.
     OneRow,
+    /// Read every row from a catalog table.
     TableScan { table: TableSchema },
+    /// Keep only rows for which the predicate evaluates truthfully.
     Filter { input: Box<LogicalPlan>, predicate: PlannedExpression },
+    /// Order input rows by one or more columns.
     Sort { input: Box<LogicalPlan>, terms: Vec<SortTerm> },
+    /// Produce output expressions from each input row.
     Project { input: Box<LogicalPlan>, expressions: Vec<PlannedExpression> },
+    /// Skip the first `offset` input rows.
     Offset { input: Box<LogicalPlan>, offset: u32 },
+    /// Emit at most `limit` input rows.
     Limit { input: Box<LogicalPlan>, limit: u32 },
 }
 
+/// Executable operator tree selected by the planner.
+///
+/// Physical plans mirror the current executor's available operators. Today this
+/// mostly maps logical operators directly, with a few concrete choices such as
+/// [`PhysicalPlan::FullTableScan`] for table access and
+/// [`PhysicalPlan::InsertValues`] for `INSERT ... VALUES`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PhysicalPlan {
+    /// Execute a catalog table creation.
     CreateTable {
+        /// Table name to create.
         name: String,
+        /// Row schema for the new table.
         schema: TupleSchema,
     },
+    /// Execute a catalog secondary-index creation.
     CreateIndex {
+        /// Index name to create.
         name: String,
+        /// Table whose rows the index covers.
         table: TableSchema,
+        /// Bound table columns that form the index key.
         columns: Vec<BoundColumn>,
     },
+    /// Produce literal rows.
     Values {
+        /// Planned expressions for each literal row.
         rows: Vec<Vec<PlannedExpression>>,
     },
+    /// Insert literal values into bound table columns.
     InsertValues {
+        /// Target table.
         table: TableSchema,
+        /// Target columns in value order.
         columns: Vec<BoundColumn>,
+        /// Literal value rows to insert.
         values: Vec<Vec<PlannedExpression>>,
     },
+    /// Produce exactly one empty row.
     OneRow,
+    /// Scan all rows from a table.
     FullTableScan {
+        /// Table to scan.
         table: TableSchema,
     },
+    /// Filter rows from an input physical operator.
     Filter {
+        /// Input operator.
         input: Box<PhysicalPlan>,
+        /// Predicate evaluated for each input row.
         predicate: PlannedExpression,
     },
+    /// Sort rows from an input physical operator.
     Sort {
+        /// Input operator.
         input: Box<PhysicalPlan>,
+        /// Sort keys in priority order.
         terms: Vec<SortTerm>,
     },
+    /// Evaluate expressions for each input row.
     Project {
+        /// Input operator.
         input: Box<PhysicalPlan>,
+        /// Output expressions in result-column order.
         expressions: Vec<PlannedExpression>,
     },
+    /// Skip input rows before producing output.
     Offset {
+        /// Input operator.
         input: Box<PhysicalPlan>,
+        /// Number of rows to skip.
         offset: u32,
     },
+    /// Stop after producing a bounded number of rows.
     Limit {
+        /// Input operator.
         input: Box<PhysicalPlan>,
+        /// Maximum number of rows to emit.
         limit: u32,
     },
 }
 
+/// Expression after literal conversion and column binding.
+///
+/// Bound column expressions carry catalog metadata and row ordinals, so the
+/// executor can evaluate them without doing name resolution again.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PlannedExpression {
+    /// Constant storage value.
     Literal(Value),
+    /// Reference to a bound table column.
     Column(BoundColumn),
+    /// Unary operator applied to a planned expression.
     Unary { op: Op, expr: Box<PlannedExpression> },
+    /// Binary operator applied to two planned expressions.
     Binary { left: Box<PlannedExpression>, op: Op, right: Box<PlannedExpression> },
 }
 
+/// Catalog column reference resolved during planning.
+///
+/// `ordinal` is the zero-based position of the column in the table row schema.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BoundColumn {
+    /// Name of the table that owns this column.
     pub table: String,
+    /// Column name.
     pub name: String,
+    /// Zero-based column position in the table row.
     pub ordinal: usize,
+    /// Storage type recorded for the column.
     pub data_type: DataType,
 }
 
+/// One bound column and optional direction from an `ORDER BY` clause.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SortTerm {
-    pub expression: PlannedExpression,
+    /// Column used as the sort key.
+    pub column: BoundColumn,
+    /// Direction specified by SQL, or `None` when the query omitted one.
     pub direction: Option<Ordering>,
 }
 
+/// Normalized sort direction.
+///
+/// This enum is available for consumers that need an executor-level direction
+/// independent of the parser's `ORDER BY` syntax.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortDirection {
+    /// Sort smaller values before larger values.
     Ascending,
+    /// Sort larger values before smaller values.
     Descending,
 }
 
+/// Errors that can occur while converting parsed SQL into a plan.
 #[derive(Debug, Error)]
 pub enum PlannerError {
+    /// A statement referenced a table that does not exist in the catalog.
     #[error("table not found: {name}")]
     TableNotFound { name: String },
+    /// A statement referenced a column that is not present in the bound table.
     #[error("column {column} not found")]
     ColumnNotFound { column: String },
+    /// An `INSERT` column list named the same column more than once.
     #[error("duplicate insert column: {column}")]
     DuplicateInsertColumn { column: String },
+    /// A `CREATE INDEX` column list named the same column more than once.
     #[error("duplicate index column: {column}")]
     DuplicateIndexColumn { column: String },
+    /// A values row does not provide exactly one value for each target column.
     #[error("insert row has {values} values for {columns} columns")]
     InsertColumnValueCount { columns: usize, values: usize },
+    /// The parser accepted a statement kind the planner cannot lower.
     #[error("unsupported statement: {statement}")]
     UnsupportedStatement { statement: String },
+    /// The planner cannot lower this expression in the current context.
     #[error("unsupported expression: {expression}")]
     UnsupportedExpression { expression: String },
+    /// Aggregate functions are parsed but not yet planned.
     #[error("unsupported aggregate function: {function}")]
     UnsupportedAggregate { function: String },
+    /// A wildcard appeared outside the projection list.
     #[error("wildcard is only supported in SELECT projection")]
     UnsupportedWildcardPosition,
+    /// A wildcard projection was used without a table to expand against.
     #[error("wildcard projection requires a FROM table")]
     WildcardRequiresTable,
+    /// Physical planning found an insert input shape it cannot execute.
     #[error("invalid insert input: expected VALUES")]
     InvalidInsertInput,
+    /// Storage or catalog access failed while planning.
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
 }
 
+/// Planner bound to a database catalog.
+///
+/// A planner borrows a [`Database`] so it can resolve table schemas and bind
+/// column references. It does not mutate the catalog; DDL statements are only
+/// represented as plan nodes until executed.
 pub struct Planner<'db> {
     database: &'db Database,
 }
 
 impl<'db> Planner<'db> {
+    /// Creates a planner that resolves names through `database`.
     pub fn new(database: &'db Database) -> Self {
         Self { database }
     }
 
+    /// Plans one parsed SQL statement.
+    ///
+    /// This first builds a [`LogicalPlan`] with catalog-bound names, then
+    /// converts it into a [`PhysicalPlan`] that can be passed to the executor.
     pub fn plan_statement(&self, statement: &Statement<'_>) -> PlannerResult<Plan> {
         let logical = self.logical_plan_statement(statement)?;
         let physical = self.physical_plan(&logical)?;
@@ -247,7 +368,7 @@ impl<'db> Planner<'db> {
                         column: term.column.to_owned(),
                     })?;
                     Ok(SortTerm {
-                        expression: PlannedExpression::Column(bind_column(table, term.column)?),
+                        column: bind_column(table, term.column)?,
                         direction: term.order.clone(),
                     })
                 })
@@ -648,10 +769,7 @@ mod tests {
         };
         assert_eq!(
             terms,
-            &[SortTerm {
-                expression: PlannedExpression::Column(bound("users", "id", 0, DataType::Integer)),
-                direction: None,
-            }]
+            &[SortTerm { column: bound("users", "id", 0, DataType::Integer), direction: None }]
         );
         assert!(
             matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")


### PR DESCRIPTION
**Summary**
- Add a physical executor for query plans, including `VALUES`, `FILTER`, `PROJECT`, `OFFSET`, `LIMIT`, inserts, and index backfill/update paths.
- Extend catalog metadata with persistent per-table `last_row_id` tracking and row-id allocation.
- Update planner output and supporting types to bind sort terms and expose execution-ready metadata.
- Add display helpers for stored values and table records to support debugging and inspection.

**Testing**
- Added and updated unit coverage for catalog bootstrap, row-id persistence, planner binding, expression evaluation, inserts, and secondary index maintenance.
- Ran the full Rust test suite locally; all tests passed.