### PR TITLE
Add BEGIN, COMMIT, and ROLLBACK transaction support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4,13 +4,7 @@ use std::{
     process,
 };
 
-use databas::{
-    core::Database,
-    error::DatabaseError,
-    executor::{ExecutionOutput, Executor},
-    planner::Planner,
-    sql_parser::parser::Parser,
-};
+use databas::{core::Database, error::DatabaseError, executor::ExecutionOutput, session::Session};
 
 pub fn run() -> Result<(), DatabaseError<'static>> {
     let mut args = env::args();
@@ -69,8 +63,7 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, ()> {
 }
 
 fn run_repl(db: Database) -> Result<(), DatabaseError<'static>> {
-    let planner = Planner::new(&db);
-    let mut executor = Executor::new(&db);
+    let mut session = Session::new(&db);
 
     println!("Databas");
 
@@ -92,7 +85,7 @@ fn run_repl(db: Database) -> Result<(), DatabaseError<'static>> {
             break;
         }
         let timer = std::time::Instant::now();
-        let exec_res = execute_query(buf, &planner, &mut executor);
+        let exec_res = session.execute_sql(buf);
         match exec_res {
             Ok(output) => {
                 let mut stdout = stdout();
@@ -114,10 +107,9 @@ fn run_repl(db: Database) -> Result<(), DatabaseError<'static>> {
 
 fn run_command(db: Database, command: String) -> Result<(), DatabaseError<'static>> {
     let command = command_with_trailing_semicolon(command);
-    let planner = Planner::new(&db);
-    let mut executor = Executor::new(&db);
+    let mut session = Session::new(&db);
 
-    match execute_query(&command, &planner, &mut executor) {
+    match session.execute_sql(&command) {
         Ok(output) => {
             let mut stdout = stdout();
             if let Err(err) = write_execution_output(output, &mut stdout) {
@@ -145,17 +137,6 @@ fn command_with_trailing_semicolon(mut command: String) -> String {
         command.push(';');
     }
     command
-}
-
-fn execute_query<'a>(
-    query: &'a str,
-    planner: &Planner<'_>,
-    executor: &mut Executor<'_>,
-) -> Result<ExecutionOutput, DatabaseError<'a>> {
-    let query = Parser::new(query).stmt()?;
-    let plan = planner.plan_statement(&query)?;
-    let output = executor.execute(plan.physical)?;
-    Ok(output)
 }
 
 fn write_execution_output(

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::core::{
     IndexSchema, RowId, TableCursor, TableSchema, TupleSchema, catalog_manager::CatalogManager,
     cursor::IndexCursor, error::StorageResult, log_manager::TxnId, pager::Pager,
-    transaction_runtime::TransactionRuntime,
+    transaction_manager::TransactionSavepoint, transaction_runtime::TransactionRuntime,
 };
 
 /// Public database handle for one database file.
@@ -55,8 +55,37 @@ impl Database {
         self.transactions.commit_transaction(txn_id)
     }
 
+    pub(crate) fn statement_savepoint(&self, txn_id: TxnId) -> StorageResult<TransactionSavepoint> {
+        self.transactions.statement_savepoint(txn_id)
+    }
+
+    pub(crate) fn rollback_to_savepoint(
+        &self,
+        savepoint: TransactionSavepoint,
+    ) -> StorageResult<()> {
+        self.transactions.rollback_to_savepoint(savepoint)
+    }
+
     pub(crate) fn rollback_transaction(&self, txn_id: TxnId) -> StorageResult<()> {
         self.transactions.rollback_transaction(txn_id)
+    }
+
+    pub(crate) fn active_transaction_id(&self) -> Option<TxnId> {
+        self.transactions.active_transaction_id()
+    }
+
+    pub(crate) fn transaction_is_poisoned(&self, txn_id: TxnId) -> StorageResult<bool> {
+        self.transactions.transaction_is_poisoned(txn_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_next_lsn_exhausted_for_test(&self) {
+        self.transactions.force_next_lsn_exhausted_for_test();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_wal_flush_for_test(&self) {
+        self.transactions.fail_next_wal_flush_for_test();
     }
 
     /// Creates a table and records its schema in the system catalog.

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -180,6 +180,10 @@ pub enum InvariantViolation {
     NoActiveTransaction,
     #[error("active transaction mismatch: expected {expected}, got {actual}")]
     TransactionMismatch { expected: TxnId, actual: TxnId },
+    #[error(
+        "invalid transaction savepoint for transaction {txn_id}: undo length {undo_len} exceeds active undo length {active_undo_len}"
+    )]
+    InvalidTransactionSavepoint { txn_id: TxnId, undo_len: usize, active_undo_len: usize },
     #[error("transaction id space exhausted")]
     TransactionIdExhausted,
     #[error("transaction {txn_id} failed before commit")]

--- a/src/core/storage_runtime.rs
+++ b/src/core/storage_runtime.rs
@@ -6,7 +6,7 @@ use crate::core::{
     error::{DiskManagerError, StorageResult},
     log_manager::{LogManager, LogManagerError, LogManagerFlushError, LogRecord, Lsn, TxnId},
     recovery::recover_from_wal,
-    transaction_manager::{LoggedPageUpdate, PageUndo, TransactionManager},
+    transaction_manager::{LoggedPageUpdate, PageUndo, TransactionManager, TransactionSavepoint},
 };
 
 /// Shared concrete storage runtime for database pages and the write-ahead log.
@@ -87,6 +87,11 @@ impl StorageRuntime {
         self.log.borrow_mut().force_next_lsn_exhausted_for_test();
     }
 
+    #[cfg(test)]
+    pub(crate) fn fail_next_wal_flush_for_test(&self) {
+        self.log.borrow_mut().fail_next_flush_for_test();
+    }
+
     pub(crate) fn begin_transaction(&self) -> StorageResult<TxnId> {
         self.transactions.borrow_mut().begin(&mut self.log.borrow_mut())
     }
@@ -113,8 +118,27 @@ impl StorageRuntime {
         self.transactions.borrow_mut().record_failure();
     }
 
+    pub(crate) fn active_transaction_id(&self) -> Option<TxnId> {
+        self.transactions.borrow().active_transaction_id()
+    }
+
+    pub(crate) fn transaction_is_poisoned(&self, txn_id: TxnId) -> StorageResult<bool> {
+        self.transactions.borrow().transaction_is_poisoned(txn_id)
+    }
+
     pub(crate) fn commit_transaction(&self, txn_id: TxnId) -> StorageResult<()> {
         self.transactions.borrow_mut().commit(&mut self.log.borrow_mut(), txn_id)
+    }
+
+    pub(crate) fn statement_savepoint(&self, txn_id: TxnId) -> StorageResult<TransactionSavepoint> {
+        self.transactions.borrow().statement_savepoint(txn_id)
+    }
+
+    pub(crate) fn rollback_to_savepoint(
+        &self,
+        savepoint: TransactionSavepoint,
+    ) -> StorageResult<Vec<PageUndo>> {
+        self.transactions.borrow_mut().rollback_to_savepoint(&mut self.log.borrow_mut(), savepoint)
     }
 
     pub(crate) fn take_rollback_pages(&self, txn_id: TxnId) -> StorageResult<Vec<PageUndo>> {

--- a/src/core/transaction_manager.rs
+++ b/src/core/transaction_manager.rs
@@ -24,8 +24,17 @@ pub(crate) struct PageUndo {
     pub(crate) page_id: PageId,
     /// Full page image captured before the logged update.
     pub(crate) before: [u8; PAGE_SIZE],
+    /// Full page image installed by the logged update.
+    pub(crate) after: [u8; PAGE_SIZE],
     /// LSN assigned to the update that this image undoes.
     pub(crate) lsn: Lsn,
+}
+
+/// In-memory checkpoint for rolling back one statement inside a transaction.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TransactionSavepoint {
+    txn_id: TxnId,
+    undo_len: usize,
 }
 
 /// WAL metadata returned after a transactional page update is logged.
@@ -165,7 +174,7 @@ impl TransactionManager {
         };
         debug_assert_eq!(appended_lsn, lsn);
         active.last_lsn = lsn;
-        active.undo_pages.push(PageUndo { page_id, before: *before, lsn });
+        active.undo_pages.push(PageUndo { page_id, before: *before, after: redo, lsn });
         Ok(Some(LoggedPageUpdate { lsn, redo }))
     }
 
@@ -177,6 +186,21 @@ impl TransactionManager {
         if let Some(active) = self.active.as_mut() {
             active.poisoned = true;
         }
+    }
+
+    /// Returns the active transaction id, if a transaction is open.
+    pub(crate) fn active_transaction_id(&self) -> Option<TxnId> {
+        self.active.as_ref().map(|active| active.txn_id)
+    }
+
+    /// Returns whether the active transaction has observed an unrecoverable error.
+    pub(crate) fn transaction_is_poisoned(&self, txn_id: TxnId) -> StorageResult<bool> {
+        let active = self.active.as_ref().ok_or_else(no_active_transaction)?;
+        if active.txn_id != txn_id {
+            return Err(transaction_mismatch(active.txn_id, txn_id));
+        }
+
+        Ok(active.poisoned)
     }
 
     /// Commits the active transaction and flushes its commit record to durable storage.
@@ -198,6 +222,79 @@ impl TransactionManager {
         self.active = None;
         log.flush_through(lsn)?;
         Ok(())
+    }
+
+    /// Creates a checkpoint at the current end of the active transaction's undo log.
+    pub(crate) fn statement_savepoint(&self, txn_id: TxnId) -> StorageResult<TransactionSavepoint> {
+        let active = self.active.as_ref().ok_or_else(no_active_transaction)?;
+        if active.txn_id != txn_id {
+            return Err(transaction_mismatch(active.txn_id, txn_id));
+        }
+
+        Ok(TransactionSavepoint { txn_id, undo_len: active.undo_pages.len() })
+    }
+
+    /// Logs compensation records and returns page images that restore a savepoint.
+    ///
+    /// The active transaction remains open. Compensation records are ordinary
+    /// page updates in the same transaction, so if the transaction later commits
+    /// crash recovery replays both the failed statement's physical updates and
+    /// these compensating updates in LSN order.
+    pub(crate) fn rollback_to_savepoint(
+        &mut self,
+        log: &mut LogManager,
+        savepoint: TransactionSavepoint,
+    ) -> StorageResult<Vec<PageUndo>> {
+        let active = self.active.as_mut().ok_or_else(no_active_transaction)?;
+        if active.txn_id != savepoint.txn_id {
+            return Err(transaction_mismatch(active.txn_id, savepoint.txn_id));
+        }
+        if savepoint.undo_len > active.undo_pages.len() {
+            return Err(invariant(InvariantViolation::InvalidTransactionSavepoint {
+                txn_id: savepoint.txn_id,
+                undo_len: savepoint.undo_len,
+                active_undo_len: active.undo_pages.len(),
+            }));
+        }
+
+        let rollback_pages = active.undo_pages[savepoint.undo_len..].to_vec();
+        let mut restore_pages = Vec::with_capacity(rollback_pages.len());
+        for undo in rollback_pages.into_iter().rev() {
+            let lsn = match log.next_lsn() {
+                Ok(lsn) => lsn,
+                Err(err) => {
+                    active.poisoned = true;
+                    return Err(err.into());
+                }
+            };
+            let mut redo = undo.before;
+            stamp_page_lsn(&mut redo, lsn);
+            let appended_lsn = match log.append_record(
+                active.txn_id,
+                LogRecordKind::PageUpdate {
+                    page_id: undo.page_id,
+                    redo_data: &redo,
+                    undo_data: &undo.after,
+                },
+            ) {
+                Ok(lsn) => lsn,
+                Err(err) => {
+                    active.poisoned = true;
+                    return Err(err.into());
+                }
+            };
+            debug_assert_eq!(appended_lsn, lsn);
+            active.last_lsn = lsn;
+            restore_pages.push(PageUndo {
+                page_id: undo.page_id,
+                before: redo,
+                after: undo.after,
+                lsn,
+            });
+        }
+
+        active.undo_pages.truncate(savepoint.undo_len);
+        Ok(restore_pages)
     }
 
     /// Removes the active transaction and returns its undo images for rollback.
@@ -320,6 +417,28 @@ mod tests {
                 (1, OwnedLogRecordKind::Commit),
             ]
         );
+    }
+
+    #[test]
+    fn rollback_to_invalid_savepoint_returns_error_without_panicking() {
+        let file = NamedTempFile::new().unwrap();
+        let mut log = LogManager::new(file.path()).unwrap();
+        let mut transactions = TransactionManager::new(0);
+
+        let txn_id = transactions.begin(&mut log).unwrap();
+        let savepoint = TransactionSavepoint { txn_id, undo_len: 1 };
+        let result = transactions.rollback_to_savepoint(&mut log, savepoint);
+
+        assert!(matches!(
+            result,
+            Err(StorageError::Internal(InternalError::InvariantViolation(
+                InvariantViolation::InvalidTransactionSavepoint {
+                    txn_id: actual_txn_id,
+                    undo_len: 1,
+                    active_undo_len: 0,
+                }
+            ))) if actual_txn_id == txn_id
+        ));
     }
 
     #[test]

--- a/src/core/transaction_runtime.rs
+++ b/src/core/transaction_runtime.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::core::{
     error::StorageResult, log_manager::TxnId, page_cache::PageCache,
-    storage_runtime::StorageRuntime,
+    storage_runtime::StorageRuntime, transaction_manager::TransactionSavepoint,
 };
 
 /// Transaction-facing runtime for a database file.
@@ -29,11 +29,45 @@ impl TransactionRuntime {
         self.runtime.commit_transaction(txn_id)
     }
 
+    pub(crate) fn active_transaction_id(&self) -> Option<TxnId> {
+        self.runtime.active_transaction_id()
+    }
+
+    pub(crate) fn transaction_is_poisoned(&self, txn_id: TxnId) -> StorageResult<bool> {
+        self.runtime.transaction_is_poisoned(txn_id)
+    }
+
+    pub(crate) fn statement_savepoint(&self, txn_id: TxnId) -> StorageResult<TransactionSavepoint> {
+        self.runtime.statement_savepoint(txn_id)
+    }
+
+    pub(crate) fn rollback_to_savepoint(
+        &self,
+        savepoint: TransactionSavepoint,
+    ) -> StorageResult<()> {
+        let undo_pages = self.runtime.rollback_to_savepoint(savepoint)?;
+        if let Err(err) = self.page_cache.restore_rollback_pages(undo_pages) {
+            self.runtime.record_transaction_failure();
+            return Err(err.into());
+        }
+        Ok(())
+    }
+
     pub(crate) fn rollback_transaction(&self, txn_id: TxnId) -> StorageResult<()> {
         let undo_pages = self.runtime.take_rollback_pages(txn_id)?;
         self.page_cache.restore_rollback_pages(undo_pages)?;
         self.page_cache.flush_all()?;
         self.runtime.sync_database_file()?;
         self.runtime.finish_rollback(txn_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_next_lsn_exhausted_for_test(&self) {
+        self.runtime.force_next_lsn_exhausted_for_test();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_wal_flush_for_test(&self) {
+        self.runtime.fail_next_wal_flush_for_test();
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::{
     core::error::StorageError, executor::ExecutorError, planner::PlannerError,
-    sql_parser::error::SQLError,
+    session::SessionError, sql_parser::error::SQLError,
 };
 
 #[derive(Debug, Error)]
@@ -17,6 +17,8 @@ pub enum DatabaseError<'a> {
     Planner(#[from] PlannerError),
     #[error(transparent)]
     Executor(#[from] ExecutorError),
+    #[error(transparent)]
+    Session(#[from] SessionError),
     #[error(transparent)]
     Io(#[from] io::Error),
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -15,7 +15,7 @@
 use crate::{
     core::{
         DataType, Database, IndexSchema, TableRecord, TableSchema, Tuple, TupleView, Value,
-        error::{InternalError, InvariantViolation, StorageError},
+        error::StorageError,
     },
     planner::{BoundColumn, PhysicalPlan, PlannedExpression},
     sql_parser::parser::op::Op,
@@ -162,6 +162,8 @@ pub enum ExecutionOutput {
     RowsAffected(u64),
     /// A schema-level side effect completed.
     SchemaAffected,
+    /// A non-planned command completed.
+    CommandOk,
 }
 
 impl ExecutionOutput {
@@ -174,7 +176,7 @@ impl ExecutionOutput {
         match self {
             Self::Explain(_) => Err(ExecutorError::ExpectedRows { operator }),
             Self::Rows { rows } => Ok(rows),
-            Self::RowsAffected(_) | Self::SchemaAffected => {
+            Self::RowsAffected(_) | Self::SchemaAffected | Self::CommandOk => {
                 Err(ExecutorError::ExpectedRows { operator })
             }
         }
@@ -188,6 +190,7 @@ impl std::fmt::Debug for ExecutionOutput {
             Self::Rows { .. } => f.debug_struct("Rows").field("rows", &"<row stream>").finish(),
             Self::RowsAffected(count) => f.debug_tuple("RowsAffected").field(count).finish(),
             Self::SchemaAffected => f.write_str("SchemaAffected"),
+            Self::CommandOk => f.write_str("CommandOk"),
         }
     }
 }
@@ -201,6 +204,7 @@ impl std::fmt::Display for ExecutionOutput {
                 write!(f, "{count} rows affected.")
             }
             ExecutionOutput::SchemaAffected => write!(f, "Schema affected."),
+            ExecutionOutput::CommandOk => write!(f, "Command executed."),
         }
     }
 }
@@ -230,25 +234,19 @@ impl<'db> Executor<'db> {
         match plan {
             PhysicalPlan::Explain { input } => Ok(ExecutionOutput::Explain(input.to_string())),
             PhysicalPlan::CreateTable { name, schema } => {
-                self.execute_mutating_statement(|database| {
-                    database.create_table(&name, schema)?;
-                    Ok(ExecutionOutput::SchemaAffected)
-                })
+                self.database.create_table(&name, schema)?;
+                Ok(ExecutionOutput::SchemaAffected)
             }
             PhysicalPlan::CreateIndex { name, table, columns } => {
-                self.execute_mutating_statement(|database| {
-                    let column_names: Vec<&str> =
-                        columns.iter().map(|col| col.name.as_str()).collect();
-                    let index = database.create_index(&name, &table.name, &column_names)?;
-                    backfill_index(database, &table, &index)?;
-                    Ok(ExecutionOutput::SchemaAffected)
-                })
+                let column_names: Vec<&str> = columns.iter().map(|col| col.name.as_str()).collect();
+                let index = self.database.create_index(&name, &table.name, &column_names)?;
+                backfill_index(self.database, &table, &index)?;
+                Ok(ExecutionOutput::SchemaAffected)
             }
             PhysicalPlan::Values { rows } => execute_values(rows),
-            PhysicalPlan::InsertValues { table, columns, values } => self
-                .execute_mutating_statement(|database| {
-                    execute_insert_values(database, table, columns, values)
-                }),
+            PhysicalPlan::InsertValues { table, columns, values } => {
+                execute_insert_values(self.database, table, columns, values)
+            }
             PhysicalPlan::OneRow => Ok(ExecutionOutput::Rows {
                 rows: Box::new(std::iter::once_with(|| empty_record(0))),
             }),
@@ -322,41 +320,6 @@ impl<'db> Executor<'db> {
             }
         }
     }
-
-    fn execute_mutating_statement(
-        &self,
-        execute: impl FnOnce(&Database) -> ExecutorResult<ExecutionOutput>,
-    ) -> ExecutorResult<ExecutionOutput> {
-        let txn_id = self.database.begin_transaction()?;
-        match execute(self.database) {
-            Ok(output) => match self.database.commit_transaction(txn_id) {
-                Ok(()) => Ok(output),
-                Err(commit_error) => {
-                    if let Err(rollback_error) = self.database.rollback_transaction(txn_id)
-                        && !is_no_active_transaction(&rollback_error)
-                    {
-                        return Err(rollback_error.into());
-                    }
-                    Err(commit_error.into())
-                }
-            },
-            Err(error) => {
-                if let Err(rollback_error) = self.database.rollback_transaction(txn_id) {
-                    return Err(rollback_error.into());
-                }
-                Err(error)
-            }
-        }
-    }
-}
-
-fn is_no_active_transaction(error: &StorageError) -> bool {
-    matches!(
-        error,
-        StorageError::Internal(InternalError::InvariantViolation(
-            InvariantViolation::NoActiveTransaction
-        ))
-    )
 }
 
 /// Evaluates one planned scalar expression against a record.
@@ -793,8 +756,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::{ColumnSchema, DataType, PAGE_SIZE, TupleSchema},
+        core::{
+            ColumnSchema, DataType, PAGE_SIZE, TupleSchema,
+            error::{InternalError, InvariantViolation, StorageError},
+        },
+        error::DatabaseError,
         planner::{BoundColumn, Planner},
+        session::Session,
         sql_parser::parser::Parser,
     };
 
@@ -810,10 +778,27 @@ mod tests {
         output.into_rows("TEST")?.collect()
     }
 
-    fn execute_sql(database: &Database, sql: &str) -> ExecutorResult<ExecutionOutput> {
-        let statement = Parser::new(sql).stmt().unwrap();
-        let plan = Planner::new(database).plan_statement(&statement).unwrap();
-        Executor::new(database).execute(plan.physical)
+    fn execute_sql<'a>(
+        database: &Database,
+        sql: &'a str,
+    ) -> Result<ExecutionOutput, DatabaseError<'a>> {
+        Session::new(database).execute_sql(sql)
+    }
+
+    fn execute_sql_with_session<'a>(
+        session: &mut Session<'_>,
+        sql: &'a str,
+    ) -> Result<ExecutionOutput, DatabaseError<'a>> {
+        session.execute_sql(sql)
+    }
+
+    fn execute_script(database: &Database, sql: &str) {
+        let items = Parser::new(sql).collect::<Result<Vec<_>, _>>().unwrap();
+        let mut session = Session::new(database);
+
+        for item in items {
+            session.execute_item(item).unwrap();
+        }
     }
 
     fn bound(name: &str, ordinal: usize, data_type: DataType) -> BoundColumn {
@@ -1473,38 +1458,119 @@ mod tests {
         let dir = tempdir().unwrap();
         let database = Database::create(dir.path().join("test.db")).unwrap();
         database.create_table("users", users_schema()).unwrap();
-        let mut executor = Executor::new(&database);
 
-        let invalid = insert_values_plan(
+        let result = execute_sql(
             &database,
-            vec![
-                bound("id", 0, DataType::Integer),
-                bound("name", 1, DataType::Text),
-                bound("active", 2, DataType::Boolean),
-            ],
-            vec![
-                vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true)],
-                vec![
-                    Value::Integer(2),
-                    Value::String("Grace".to_owned()),
-                    Value::String("yes".to_owned()),
-                ],
-            ],
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE), (2, 'Grace', 'yes');",
         );
 
         assert!(matches!(
-            executor.execute(invalid),
-            Err(ExecutorError::InsertTypeMismatch {
+            result,
+            Err(DatabaseError::Executor(ExecutorError::InsertTypeMismatch {
                 column,
                 expected: DataType::Boolean,
                 actual: Value::String(value),
-            }) if column == "active" && value == "yes"
+            })) if column == "active" && value == "yes"
         ));
 
         assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
         let mut users = database.table_cursor_by_name("users").unwrap();
         assert!(users.get(1).unwrap().is_none());
         assert!(users.get(2).unwrap().is_none());
+    }
+
+    #[test]
+    fn failed_multi_row_insert_in_explicit_transaction_rolls_back_statement_before_commit() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let database = Database::create(&path).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        database.flush().unwrap();
+
+        let mut session = Session::new(&database);
+        execute_sql_with_session(&mut session, "BEGIN;").unwrap();
+        let result = execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE), (2, 'Grace', 'yes');",
+        );
+
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Executor(ExecutorError::InsertTypeMismatch {
+                column,
+                expected: DataType::Boolean,
+                actual: Value::String(value),
+            })) if column == "active" && value == "yes"
+        ));
+        execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (2, 'Linus', TRUE);",
+        )
+        .unwrap();
+        execute_sql_with_session(&mut session, "COMMIT;").unwrap();
+        drop(session);
+        std::mem::forget(database);
+
+        let reopened = Database::open(&path).unwrap();
+        let mut users = reopened.table_cursor_by_name("users").unwrap();
+        let mut index = reopened.index_cursor_by_name("idx_users_name").unwrap();
+        let ada = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
+        let linus = Tuple::new(vec![Value::String("Linus".to_owned())]).to_bytes().unwrap();
+        let row = users.get(1).unwrap().expect("successful statement should commit");
+
+        assert_eq!(reopened.table_schema_by_name("users").unwrap().last_row_id, 1);
+        assert_eq!(
+            values(&row),
+            vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Boolean(true)]
+        );
+        assert!(users.get(2).unwrap().is_none());
+        assert!(index.get(&ada).unwrap().is_none());
+        assert_eq!(index.get(&linus).unwrap().unwrap().row_id, 1);
+    }
+
+    #[test]
+    fn savepoint_rollback_error_takes_precedence_over_executor_error() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+        let mut session = Session::new(&database);
+
+        execute_sql_with_session(&mut session, "BEGIN;").unwrap();
+        session.fail_next_savepoint_rollback_for_test();
+        let result = execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE), (2, 'Grace', 'yes');",
+        );
+
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Storage(crate::core::error::StorageError::Internal(
+                InternalError::InvariantViolation(InvariantViolation::WalLog { message })
+            ))) if message == "WAL LSN exhausted"
+        ));
+    }
+
+    #[test]
+    fn wal_logging_failure_during_explicit_statement_is_reported_immediately() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+        let mut session = Session::new(&database);
+
+        execute_sql_with_session(&mut session, "BEGIN;").unwrap();
+        database.force_next_lsn_exhausted_for_test();
+        let result = execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE);",
+        );
+
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Storage(StorageError::Internal(InternalError::InvariantViolation(
+                InvariantViolation::TransactionPoisoned { txn_id: 1 }
+            ))))
+        ));
     }
 
     #[test]
@@ -1555,6 +1621,215 @@ mod tests {
         let entry = index.get(&key).unwrap().expect("index entry should track inserted row");
 
         assert_eq!(entry.row_id, 1);
+    }
+
+    #[test]
+    fn explicit_transaction_commit_persists_schema_rows_and_indexes_after_reopen() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let database = Database::create(&path).unwrap();
+        database.flush().unwrap();
+
+        execute_script(
+            &database,
+            "\
+BEGIN;
+CREATE TABLE users (id INT PRIMARY KEY, name TEXT, active INT);
+INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1), (2, 'Grace', 0);
+CREATE INDEX idx_users_name ON users (name);
+COMMIT;
+",
+        );
+        std::mem::forget(database);
+
+        let reopened = Database::open(&path).unwrap();
+        let schema = reopened.table_schema_by_name("users").unwrap();
+
+        assert_eq!(schema.name, "users");
+        assert_eq!(schema.row.columns.len(), 3);
+        assert_eq!(schema.last_row_id, 2);
+        assert_name_index_entry(&reopened, "Ada", 1);
+        assert_name_index_entry(&reopened, "Grace", 2);
+    }
+
+    #[test]
+    fn explicit_transaction_rollback_discards_dml_and_ddl_but_preserves_prior_commits() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+
+        execute_sql(&database, "CREATE TABLE users (id INT PRIMARY KEY, name TEXT, active INT);")
+            .unwrap();
+        execute_sql(&database, "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);")
+            .unwrap();
+
+        execute_script(
+            &database,
+            "\
+BEGIN;
+INSERT INTO users (id, name, active) VALUES (2, 'Grace', 0);
+CREATE TABLE rolled_back (id INT PRIMARY KEY);
+CREATE INDEX idx_users_name ON users (name);
+ROLLBACK;
+",
+        );
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
+        assert!(users.get(1).unwrap().is_some());
+        assert!(users.get(2).unwrap().is_none());
+        assert!(database.table_schema_by_name("rolled_back").is_err());
+        assert!(database.index_cursor_by_name("idx_users_name").is_err());
+    }
+
+    #[test]
+    fn implicit_transactions_still_commit_before_and_after_explicit_rollback() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+
+        execute_sql(&database, "CREATE TABLE users (id INT PRIMARY KEY, name TEXT, active INT);")
+            .unwrap();
+        execute_sql(&database, "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);")
+            .unwrap();
+
+        execute_script(
+            &database,
+            "\
+BEGIN;
+INSERT INTO users (id, name, active) VALUES (2, 'Grace', 0);
+ROLLBACK;
+",
+        );
+        execute_sql(&database, "INSERT INTO users (id, name, active) VALUES (2, 'Linus', 1);")
+            .unwrap();
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        let first = users.get(1).unwrap().expect("pre-transaction row should remain committed");
+        let second = users.get(2).unwrap().expect("post-rollback implicit insert should commit");
+
+        assert_eq!(
+            values(&first),
+            vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Integer(1)]
+        );
+        assert_eq!(
+            values(&second),
+            vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Integer(1)]
+        );
+    }
+
+    #[test]
+    fn commit_without_active_transaction_errors_and_later_implicit_statement_commits() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        execute_sql(&database, "CREATE TABLE users (id INT PRIMARY KEY, name TEXT, active INT);")
+            .unwrap();
+        let mut session = Session::new(&database);
+
+        assert!(execute_sql_with_session(&mut session, "COMMIT;").is_err());
+        execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);",
+        )
+        .unwrap();
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        assert!(users.get(1).unwrap().is_some());
+    }
+
+    #[test]
+    fn failed_commit_clears_session_when_storage_transaction_was_cleared() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        execute_sql(&database, "CREATE TABLE users (id INT PRIMARY KEY, name TEXT, active INT);")
+            .unwrap();
+        let mut session = Session::new(&database);
+
+        execute_sql_with_session(&mut session, "BEGIN;").unwrap();
+        execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);",
+        )
+        .unwrap();
+        database.fail_next_wal_flush_for_test();
+
+        assert!(execute_sql_with_session(&mut session, "COMMIT;").is_err());
+        execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (2, 'Linus', 1);",
+        )
+        .unwrap();
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        assert!(users.get(2).unwrap().is_some());
+    }
+
+    #[test]
+    fn rollback_without_active_transaction_errors_and_later_implicit_statement_commits() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        execute_sql(&database, "CREATE TABLE users (id INT PRIMARY KEY, name TEXT, active INT);")
+            .unwrap();
+        let mut session = Session::new(&database);
+
+        assert!(execute_sql_with_session(&mut session, "ROLLBACK;").is_err());
+        execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);",
+        )
+        .unwrap();
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        assert!(users.get(1).unwrap().is_some());
+    }
+
+    #[test]
+    fn nested_begin_errors_without_ending_outer_transaction() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        execute_sql(&database, "CREATE TABLE users (id INT PRIMARY KEY, name TEXT, active INT);")
+            .unwrap();
+        let mut session = Session::new(&database);
+
+        execute_sql_with_session(&mut session, "BEGIN;").unwrap();
+        execute_sql_with_session(
+            &mut session,
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);",
+        )
+        .unwrap();
+        assert!(execute_sql_with_session(&mut session, "BEGIN;").is_err());
+        execute_sql_with_session(&mut session, "ROLLBACK;").unwrap();
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        assert!(users.get(1).unwrap().is_none());
+    }
+
+    #[test]
+    fn dropping_session_with_active_transaction_rolls_back_and_releases_database_handle() {
+        let dir = tempdir().unwrap();
+        let database = Database::create(dir.path().join("test.db")).unwrap();
+        database.create_table("users", users_schema()).unwrap();
+
+        {
+            let mut session = Session::new(&database);
+            execute_sql_with_session(&mut session, "BEGIN;").unwrap();
+            execute_sql_with_session(
+                &mut session,
+                "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE);",
+            )
+            .unwrap();
+        }
+
+        execute_sql(&database, "INSERT INTO users (id, name, active) VALUES (2, 'Linus', TRUE);")
+            .unwrap();
+
+        let mut users = database.table_cursor_by_name("users").unwrap();
+        let row = users.get(1).unwrap().expect("new statement should commit after session drop");
+
+        assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
+        assert_eq!(
+            values(&row),
+            vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Boolean(true)]
+        );
+        assert!(users.get(2).unwrap().is_none());
     }
 
     #[test]
@@ -1652,30 +1927,18 @@ mod tests {
         database.create_index("idx_users_name", "users", &["name"]).unwrap();
         database.flush().unwrap();
 
-        let invalid = insert_values_plan(
+        let result = execute_sql(
             &database,
-            vec![
-                bound("id", 0, DataType::Integer),
-                bound("name", 1, DataType::Text),
-                bound("active", 2, DataType::Boolean),
-            ],
-            vec![
-                vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true)],
-                vec![
-                    Value::Integer(2),
-                    Value::String("Grace".to_owned()),
-                    Value::String("yes".to_owned()),
-                ],
-            ],
+            "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE), (2, 'Grace', 'yes');",
         );
 
         assert!(matches!(
-            Executor::new(&database).execute(invalid),
-            Err(ExecutorError::InsertTypeMismatch {
+            result,
+            Err(DatabaseError::Executor(ExecutorError::InsertTypeMismatch {
                 column,
                 expected: DataType::Boolean,
                 actual: Value::String(value),
-            }) if column == "active" && value == "yes"
+            })) if column == "active" && value == "yes"
         ));
         std::mem::forget(database);
 
@@ -1747,14 +2010,8 @@ mod tests {
         let database = Database::create(&path).unwrap();
         database.create_table("users", users_schema()).unwrap();
         database.flush().unwrap();
-        let insert = Parser::new("INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE);")
-            .stmt()
+        execute_sql(&database, "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE);")
             .unwrap();
-        let insert_plan = Planner::new(&database).plan_statement(&insert).unwrap();
-        {
-            let mut executor = Executor::new(&database);
-            executor.execute(insert_plan.physical).unwrap();
-        }
         std::mem::forget(database);
 
         let reopened = Database::open(&path).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod core;
 pub mod error;
 pub mod executor;
 pub mod planner;
+pub mod session;
 pub mod sql_parser;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,251 @@
+//! SQL session execution and transaction policy.
+//!
+//! A session is the top-level SQL execution context for one database handle. It
+//! dispatches parsed SQL items, keeps explicit transaction state, and preserves
+//! the implicit transaction behavior for standalone mutating statements.
+
+use thiserror::Error;
+
+use crate::{
+    core::{
+        Database,
+        error::{InternalError, InvariantViolation, StorageError},
+        transaction_manager::TransactionSavepoint,
+    },
+    error::DatabaseError,
+    executor::{ExecutionOutput, Executor},
+    planner::{PhysicalPlan, Planner},
+    sql_parser::parser::{Command, Parser, SqlItem, stmt::Statement},
+};
+
+/// Errors raised by session-level transaction control.
+#[derive(Debug, Error)]
+pub enum SessionError {
+    /// `BEGIN` was executed while the session already had an explicit
+    /// transaction open.
+    #[error("transaction {txn_id} is already active")]
+    TransactionAlreadyActive { txn_id: u64 },
+    /// `COMMIT` or `ROLLBACK` was executed without an explicit transaction.
+    #[error("no active transaction")]
+    NoActiveTransaction,
+}
+
+/// SQL execution context for a single database handle.
+pub struct Session<'db> {
+    database: &'db Database,
+    active_txn: Option<u64>,
+    #[cfg(test)]
+    fail_next_savepoint_rollback: bool,
+}
+
+impl<'db> Session<'db> {
+    /// Creates a new session over `database`.
+    pub fn new(database: &'db Database) -> Self {
+        Self {
+            database,
+            active_txn: None,
+            #[cfg(test)]
+            fail_next_savepoint_rollback: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_savepoint_rollback_for_test(&mut self) {
+        self.fail_next_savepoint_rollback = true;
+    }
+
+    /// Parses and executes one top-level SQL item.
+    pub fn execute_sql<'sql>(
+        &mut self,
+        sql: &'sql str,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        let item = Parser::new(sql).item()?;
+        self.execute_item(item)
+    }
+
+    /// Executes one parsed SQL item.
+    pub fn execute_item<'sql>(
+        &mut self,
+        item: SqlItem<'sql>,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        match item {
+            SqlItem::Statement(statement) => self.execute_statement(statement),
+            SqlItem::Command(command) => self.execute_command(command),
+        }
+    }
+
+    fn execute_statement<'sql>(
+        &mut self,
+        statement: Statement<'sql>,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        let mutating = statement_is_mutating(&statement);
+        let plan = Planner::new(self.database).plan_statement(&statement)?;
+
+        if !mutating {
+            return self.execute_plan(plan.physical);
+        }
+
+        if let Some(txn_id) = self.active_txn {
+            self.execute_explicit_transaction_statement(txn_id, plan.physical)
+        } else {
+            self.execute_implicit_transaction(plan.physical)
+        }
+    }
+
+    fn execute_command<'sql>(
+        &mut self,
+        command: Command,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        match command {
+            Command::Begin => self.begin_transaction(),
+            Command::Commit => self.commit_transaction(),
+            Command::Rollback => self.rollback_transaction(),
+        }
+    }
+
+    fn begin_transaction<'sql>(&mut self) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        if let Some(txn_id) = self.active_txn {
+            return Err(SessionError::TransactionAlreadyActive { txn_id }.into());
+        }
+
+        let txn_id = self.database.begin_transaction()?;
+        self.active_txn = Some(txn_id);
+        Ok(ExecutionOutput::CommandOk)
+    }
+
+    fn commit_transaction<'sql>(&mut self) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        let txn_id = self.active_txn.ok_or(SessionError::NoActiveTransaction)?;
+        match self.database.commit_transaction(txn_id) {
+            Ok(()) => {
+                self.active_txn = None;
+                Ok(ExecutionOutput::CommandOk)
+            }
+            Err(error) => {
+                self.sync_active_transaction(txn_id);
+                Err(error.into())
+            }
+        }
+    }
+
+    fn rollback_transaction<'sql>(&mut self) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        let txn_id = self.active_txn.ok_or(SessionError::NoActiveTransaction)?;
+        match self.database.rollback_transaction(txn_id) {
+            Ok(()) => {
+                self.active_txn = None;
+                Ok(ExecutionOutput::CommandOk)
+            }
+            Err(error) => {
+                self.sync_active_transaction(txn_id);
+                Err(error.into())
+            }
+        }
+    }
+
+    fn execute_plan<'sql>(
+        &self,
+        plan: PhysicalPlan,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        Ok(Executor::new(self.database).execute(plan)?)
+    }
+
+    fn execute_explicit_transaction_statement<'sql>(
+        &mut self,
+        txn_id: u64,
+        plan: PhysicalPlan,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        let savepoint = self.database.statement_savepoint(txn_id)?;
+        match Executor::new(self.database).execute(plan) {
+            Ok(output) => {
+                if self.database.transaction_is_poisoned(txn_id)? {
+                    return self.rollback_failed_explicit_transaction_statement(
+                        savepoint,
+                        transaction_poisoned(txn_id).into(),
+                    );
+                }
+                Ok(output)
+            }
+            Err(error) => {
+                #[cfg(test)]
+                if self.fail_next_savepoint_rollback {
+                    self.fail_next_savepoint_rollback = false;
+                    self.database.force_next_lsn_exhausted_for_test();
+                }
+
+                self.rollback_failed_explicit_transaction_statement(savepoint, error.into())
+            }
+        }
+    }
+
+    fn rollback_failed_explicit_transaction_statement<'sql>(
+        &self,
+        savepoint: TransactionSavepoint,
+        error: DatabaseError<'sql>,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        match self.database.rollback_to_savepoint(savepoint) {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(rollback_error.into()),
+        }
+    }
+
+    fn execute_implicit_transaction<'sql>(
+        &self,
+        plan: PhysicalPlan,
+    ) -> Result<ExecutionOutput, DatabaseError<'sql>> {
+        let txn_id = self.database.begin_transaction()?;
+        match Executor::new(self.database).execute(plan) {
+            Ok(output) => match self.database.commit_transaction(txn_id) {
+                Ok(()) => Ok(output),
+                Err(commit_error) => {
+                    if let Err(rollback_error) = self.database.rollback_transaction(txn_id)
+                        && !is_no_active_transaction(&rollback_error)
+                    {
+                        return Err(rollback_error.into());
+                    }
+                    Err(commit_error.into())
+                }
+            },
+            Err(error) => {
+                if let Err(rollback_error) = self.database.rollback_transaction(txn_id) {
+                    return Err(rollback_error.into());
+                }
+                Err(error.into())
+            }
+        }
+    }
+
+    fn sync_active_transaction(&mut self, txn_id: u64) {
+        if self.database.active_transaction_id() != Some(txn_id) {
+            self.active_txn = None;
+        }
+    }
+}
+
+impl Drop for Session<'_> {
+    fn drop(&mut self) {
+        if let Some(txn_id) = self.active_txn.take() {
+            let _ = self.database.rollback_transaction(txn_id);
+        }
+    }
+}
+
+fn statement_is_mutating(statement: &Statement<'_>) -> bool {
+    match statement {
+        Statement::CreateTable(_) | Statement::CreateIndex(_) | Statement::Insert(_) => true,
+        Statement::Select(_) | Statement::Explain(_) => false,
+    }
+}
+
+fn is_no_active_transaction(error: &StorageError) -> bool {
+    matches!(
+        error,
+        StorageError::Internal(InternalError::InvariantViolation(
+            InvariantViolation::NoActiveTransaction
+        ))
+    )
+}
+
+fn transaction_poisoned(txn_id: u64) -> StorageError {
+    StorageError::Internal(InternalError::InvariantViolation(
+        InvariantViolation::TransactionPoisoned { txn_id },
+    ))
+}

--- a/src/sql_parser/lexer/token_kind.rs
+++ b/src/sql_parser/lexer/token_kind.rs
@@ -60,6 +60,9 @@ pub enum Keyword {
     Primary,
     Key,
     Nullable,
+    Begin,
+    Commit,
+    Rollback,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -111,6 +114,9 @@ impl Display for Keyword {
             Keyword::Primary => write!(f, "PRIMARY"),
             Keyword::Key => write!(f, "KEY"),
             Keyword::Nullable => write!(f, "NULLABLE"),
+            Keyword::Begin => write!(f, "BEGIN"),
+            Keyword::Commit => write!(f, "COMMIT"),
+            Keyword::Rollback => write!(f, "ROLLBACK"),
         }
     }
 }
@@ -182,6 +188,9 @@ impl<'a> From<&'a str> for TokenKind<'a> {
             "PRIMARY" => TokenKind::Keyword(Keyword::Primary),
             "KEY" => TokenKind::Keyword(Keyword::Key),
             "NULLABLE" => TokenKind::Keyword(Keyword::Nullable),
+            "BEGIN" => TokenKind::Keyword(Keyword::Begin),
+            "COMMIT" => TokenKind::Keyword(Keyword::Commit),
+            "ROLLBACK" => TokenKind::Keyword(Keyword::Rollback),
 
             _ => TokenKind::Identifier(value),
         }

--- a/src/sql_parser/parser/mod.rs
+++ b/src/sql_parser/parser/mod.rs
@@ -2,6 +2,8 @@ pub mod expr;
 pub mod op;
 pub mod stmt;
 
+use std::fmt::Display;
+
 use expr::{AggregateFunction, AggregateFunctionKind, Expression, Literal};
 use op::Op;
 use stmt::Statement;
@@ -17,11 +19,43 @@ pub struct Parser<'a> {
     lexer: Lexer<'a>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Command {
+    Begin,
+    Commit,
+    Rollback,
+}
+
+impl Display for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Command::Begin => write!(f, "BEGIN;"),
+            Command::Commit => write!(f, "COMMIT;"),
+            Command::Rollback => write!(f, "ROLLBACK;"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SqlItem<'a> {
+    Statement(Statement<'a>),
+    Command(Command),
+}
+
+impl Display for SqlItem<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SqlItem::Statement(statement) => statement.fmt(f),
+            SqlItem::Command(command) => command.fmt(f),
+        }
+    }
+}
+
 impl<'a> Iterator for Parser<'a> {
-    type Item = Result<Statement<'a>, SQLError<'a>>;
+    type Item = Result<SqlItem<'a>, SQLError<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.stmt() {
+        match self.item() {
             Err(SQLError { kind: SQLErrorKind::UnexpectedEnd, .. }) => None,
             other => Some(other),
         }
@@ -110,11 +144,37 @@ impl<'a> Parser<'a> {
             })?
     }
 
+    pub fn item(&mut self) -> Result<SqlItem<'a>, SQLError<'a>> {
+        let token = self
+            .lexer
+            .next()
+            .ok_or(SQLError { kind: SQLErrorKind::UnexpectedEnd, pos: self.lexer.position })??;
+        match token.kind {
+            TokenKind::Keyword(Keyword::Begin) => {
+                Ok(SqlItem::Command(self.parse_command(Command::Begin)?))
+            }
+            TokenKind::Keyword(Keyword::Commit) => {
+                Ok(SqlItem::Command(self.parse_command(Command::Commit)?))
+            }
+            TokenKind::Keyword(Keyword::Rollback) => {
+                Ok(SqlItem::Command(self.parse_command(Command::Rollback)?))
+            }
+            _ => self.parse_statement_from_token(token).map(SqlItem::Statement),
+        }
+    }
+
     pub fn stmt(&mut self) -> Result<Statement<'a>, SQLError<'a>> {
         let token = self
             .lexer
             .next()
             .ok_or(SQLError { kind: SQLErrorKind::UnexpectedEnd, pos: self.lexer.position })??;
+        self.parse_statement_from_token(token)
+    }
+
+    fn parse_statement_from_token(
+        &mut self,
+        token: Token<'a>,
+    ) -> Result<Statement<'a>, SQLError<'a>> {
         match token.kind {
             TokenKind::Keyword(Keyword::Explain) => Ok(Statement::Explain(Box::new(self.stmt()?))),
             TokenKind::Keyword(Keyword::Select) => {
@@ -126,6 +186,11 @@ impl<'a> Parser<'a> {
             TokenKind::Keyword(Keyword::Create) => self.parse_create_query(),
             other => Err(SQLError::new(SQLErrorKind::Other(other), token.offset)),
         }
+    }
+
+    fn parse_command(&mut self, command: Command) -> Result<Command, SQLError<'a>> {
+        self.lexer.expect_token(TokenKind::Semicolon)?;
+        Ok(command)
     }
 
     fn parse_create_query(&mut self) -> Result<Statement<'a>, SQLError<'a>> {

--- a/src/sql_parser/parser/stmt/create_index.rs
+++ b/src/sql_parser/parser/stmt/create_index.rs
@@ -38,7 +38,7 @@ impl<'a> Parser<'a> {
 mod tests {
     use super::*;
     use crate::sql_parser::parser::{
-        Parser,
+        Parser, SqlItem,
         stmt::{Statement, lists::IdentifierList},
     };
 
@@ -53,7 +53,7 @@ mod tests {
             columns: IdentifierList(vec!["name"]),
         };
 
-        assert_eq!(Some(Ok(Statement::CreateIndex(expected))), parser.next());
+        assert_eq!(Some(Ok(SqlItem::Statement(Statement::CreateIndex(expected)))), parser.next());
     }
 
     #[test]
@@ -67,7 +67,7 @@ mod tests {
             columns: IdentifierList(vec!["customer_id", "created_at"]),
         };
 
-        assert_eq!(Some(Ok(Statement::CreateIndex(expected))), parser.next());
+        assert_eq!(Some(Ok(SqlItem::Statement(Statement::CreateIndex(expected)))), parser.next());
     }
 
     #[test]

--- a/src/sql_parser/parser/stmt/insert.rs
+++ b/src/sql_parser/parser/stmt/insert.rs
@@ -59,7 +59,7 @@ impl<'a> Parser<'a> {
 mod tests {
     use super::*;
     use crate::sql_parser::parser::{
-        Parser,
+        Parser, SqlItem,
         expr::{Expression, Literal},
         stmt::{
             Statement,
@@ -88,6 +88,6 @@ mod tests {
                 ]),
             ]),
         };
-        assert_eq!(Some(Ok(Statement::Insert(expected))), got);
+        assert_eq!(Some(Ok(SqlItem::Statement(Statement::Insert(expected)))), got);
     }
 }

--- a/tests/sql_parser_roundtrip.rs
+++ b/tests/sql_parser_roundtrip.rs
@@ -1,4 +1,4 @@
-use databas::sql_parser::parser::{Parser, stmt::Statement};
+use databas::sql_parser::parser::{Parser, SqlItem, stmt::Statement};
 use hegel::TestCase;
 use hegel::generators as gs;
 
@@ -88,27 +88,40 @@ fn assert_round_trips(sql: &str) {
     assert_eq!(parsed, reparsed, "SQL did not round-trip: {sql}\ndisplayed as: {displayed}");
 }
 
-fn parse_statements(sql: &str) -> Vec<Statement<'_>> {
+fn parse_item(sql: &str) -> SqlItem<'_> {
+    Parser::new(sql).item().unwrap_or_else(|err| panic!("failed to parse `{sql}`: {err:?}"))
+}
+
+fn assert_item_round_trips(sql: &str) {
+    let parsed = parse_item(sql);
+    let displayed = parsed.to_string();
+    let reparsed = parse_item(&displayed);
+
+    assert_eq!(parsed, reparsed, "SQL item did not round-trip: {sql}\ndisplayed as: {displayed}");
+}
+
+fn parse_items(sql: &str) -> Vec<SqlItem<'_>> {
     Parser::new(sql)
         .collect::<Result<Vec<_>, _>>()
         .unwrap_or_else(|err| panic!("failed to parse `{sql}`: {err:?}"))
 }
 
-fn assert_statements_round_trip(sql: &str) {
-    let parsed = parse_statements(sql);
+fn assert_items_round_trip(sql: &str) {
+    let parsed = parse_items(sql);
     let displayed = parsed.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n");
-    let reparsed = parse_statements(&displayed);
+    let reparsed = parse_items(&displayed);
 
     assert_eq!(parsed, reparsed, "SQL did not round-trip: {sql}\ndisplayed as: {displayed}");
 }
 
 fn draw_statement(tc: &TestCase) -> String {
-    match draw_index(tc, 5) {
+    match draw_index(tc, 6) {
         0 => draw_insert(tc),
         1 => draw_select(tc),
         2 => draw_create_table(tc),
         3 => draw_create_index(tc),
         4 => draw_explain_select(tc),
+        5 => draw_transaction_control(tc),
         _ => unreachable!(),
     }
 }
@@ -205,6 +218,15 @@ fn draw_create_index(tc: &TestCase) -> String {
     format!("CREATE INDEX {index} ON {table} ({});", columns.join(", "))
 }
 
+fn draw_transaction_control(tc: &TestCase) -> String {
+    match draw_index(tc, 3) {
+        0 => "BEGIN;".to_owned(),
+        1 => "COMMIT;".to_owned(),
+        2 => "ROLLBACK;".to_owned(),
+        _ => unreachable!(),
+    }
+}
+
 #[hegel::test(test_cases = 250)]
 fn insert_queries_round_trip_through_display(tc: TestCase) {
     let sql = draw_insert(&tc);
@@ -250,12 +272,33 @@ fn create_index_queries_round_trip_through_display(tc: TestCase) {
     assert_round_trips(&sql);
 }
 
+#[test]
+fn transaction_control_queries_round_trip_through_display() {
+    assert_item_round_trips("BEGIN;");
+    assert_item_round_trips("COMMIT;");
+    assert_item_round_trips("ROLLBACK;");
+}
+
+#[test]
+fn transaction_control_queries_round_trip_in_mixed_script() {
+    assert_items_round_trip(
+        "\
+BEGIN;
+CREATE TABLE users (id INT PRIMARY KEY, name TEXT);
+INSERT INTO users (id, name) VALUES (1, 'Ada');
+COMMIT;
+BEGIN;
+ROLLBACK;
+",
+    );
+}
+
 #[hegel::test(test_cases = 250)]
 fn multiple_queries_round_trip_through_display(tc: TestCase) {
     let sql =
         (0..draw_non_empty_len(&tc, 8)).map(|_| draw_statement(&tc)).collect::<Vec<_>>().join("\n");
     tc.note(&sql);
-    assert_statements_round_trip(&sql);
+    assert_items_round_trip(&sql);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add transaction lifecycle support across the client, session, executor, and runtime layers
- Extend parser and lexer handling for `BEGIN`, `COMMIT`, and `ROLLBACK` statements
- Update database and error handling to propagate transaction state correctly
- Add round-trip parser coverage for the new SQL statements

## Testing
- Added and updated SQL parser round-trip tests
- Not run (not requested)