### PR TITLE
Optimize B-tree insert and rebalance paths

### DIFF
--- a/src/core/btree.rs
+++ b/src/core/btree.rs
@@ -4,7 +4,7 @@
 //! only with raw byte keys and raw byte values stored in `RawLeaf` pages
 //! and separator byte keys stored in `RawInterior` pages.
 
-use std::{cell::Cell, cmp::Ordering, rc::Rc};
+use std::{borrow::Cow, cell::Cell, cmp::Ordering, rc::Rc};
 
 use crate::core::{
     PAGE_SIZE, PageId,
@@ -98,9 +98,9 @@ struct PendingSplit {
 
 /// Temporary description of one leaf cell while rebuilding split pages.
 #[derive(Debug, Clone)]
-struct LeafSplitCell {
-    key: Vec<u8>,
-    value: Vec<u8>,
+struct LeafSplitCell<'a> {
+    key: Cow<'a, [u8]>,
+    value: Cow<'a, [u8]>,
 }
 
 /// Child pointer plus the maximum key reachable through that child.
@@ -110,7 +110,15 @@ struct ChildEntry {
     max_key: Option<Vec<u8>>,
 }
 
-impl LeafSplitCell {
+impl<'a> LeafSplitCell<'a> {
+    fn borrowed(key: &'a [u8], value: &'a [u8]) -> Self {
+        Self { key: Cow::Borrowed(key), value: Cow::Borrowed(value) }
+    }
+
+    fn owned(key: Vec<u8>, value: Vec<u8>) -> Self {
+        Self { key: Cow::Owned(key), value: Cow::Owned(value) }
+    }
+
     /// Returns the key length this cell will occupy after the split.
     fn key_len(&self) -> usize {
         self.key.len()
@@ -128,12 +136,12 @@ impl LeafSplitCell {
 
     /// Returns the key bytes from either the page snapshot or owned storage.
     fn key(&self) -> &[u8] {
-        &self.key
+        self.key.as_ref()
     }
 
     /// Returns the value bytes from either the page snapshot or owned storage.
     fn value(&self) -> &[u8] {
-        &self.value
+        self.value.as_ref()
     }
 }
 

--- a/src/core/btree/mutation.rs
+++ b/src/core/btree/mutation.rs
@@ -183,7 +183,7 @@ impl TreeCursor {
         drop(leaf_guard);
         drop(leaf_pin_guard);
         self.propagate_split(&tree_path, pending)?;
-        self.refresh_subtree_separators()
+        self.refresh_path_separators(&tree_path)
     }
 
     /// Replaces the value stored for an existing `key`.
@@ -219,7 +219,7 @@ impl TreeCursor {
         drop(leaf_guard);
         drop(leaf_pin_guard);
         self.propagate_split(&tree_path, pending)?;
-        self.refresh_subtree_separators()
+        self.refresh_path_separators(&tree_path)
     }
 
     /// Deletes the record identified by `key`.

--- a/src/core/btree/mutation.rs
+++ b/src/core/btree/mutation.rs
@@ -156,21 +156,25 @@ impl TreeCursor {
         };
         let leaf_pin_guard = self.page_cache.fetch_page(leaf_page_id)?;
         let mut leaf_guard = leaf_pin_guard.write()?;
-        let has_capacity = {
+        let (has_capacity, old_slot_count) = {
             let page = leaf_guard.open::<Leaf>()?;
             let needed = self.leaf_cell_local_size(key, value)? + page::format::SLOT_ENTRY_SIZE;
-            page.total_reclaimable_space()? >= needed
+            (page.total_reclaimable_space()? >= needed, page.slot_count())
         };
 
         if has_capacity {
+            let inserted_new_leaf_max;
             {
                 let mut page = leaf_guard.open_mut::<Leaf>()?;
                 let slot_index = self.insert_leaf_payload_at(&mut page, slot_index, key, value)?;
                 self.set_positioned_state(leaf_page_id, slot_index);
+                inserted_new_leaf_max = slot_index == old_slot_count;
             }
             drop(leaf_guard);
             drop(leaf_pin_guard);
-            self.refresh_subtree_separators()?;
+            if inserted_new_leaf_max {
+                self.refresh_insert_path_after_leaf_max_change(&tree_path, key)?;
+            }
             return Ok(());
         }
 

--- a/src/core/btree/payload.rs
+++ b/src/core/btree/payload.rs
@@ -120,7 +120,7 @@ fn append_overflow_chain_exact(
     Ok(())
 }
 
-fn append_overflow_prefix(
+pub(super) fn append_overflow_prefix(
     page_cache: &PageCache,
     first_overflow_page_id: PageId,
     payload: &mut Vec<u8>,
@@ -196,31 +196,6 @@ pub(super) fn materialize_payload(
     Ok(payload)
 }
 
-pub(super) fn materialize_key(
-    page_cache: &PageCache,
-    page_id: PageId,
-    inline_payload: &[u8],
-    first_overflow_page_id: Option<PageId>,
-    key_len: usize,
-) -> StorageResult<Vec<u8>> {
-    let inline_key_len = key_len.min(inline_payload.len());
-    let mut key = Vec::with_capacity(key_len);
-    key.extend_from_slice(&inline_payload[..inline_key_len]);
-
-    if key.len() == key_len {
-        return Ok(key);
-    }
-
-    let first_overflow_page_id = first_overflow_page_id
-        .ok_or_else(|| cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds))?;
-    append_overflow_prefix(page_cache, first_overflow_page_id, &mut key, key_len)?;
-
-    if key.len() != key_len {
-        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
-    }
-    Ok(key)
-}
-
 pub(super) fn materialize_leaf_cell(
     page_cache: &PageCache,
     page_id: PageId,
@@ -242,31 +217,6 @@ pub(super) fn materialize_leaf_cell(
 
     let value = payload.split_off(key_len);
     Ok((payload.into_boxed_slice(), value.into_boxed_slice()))
-}
-
-pub(super) fn read_interior_cell(
-    page_cache: &PageCache,
-    page_id: PageId,
-    slot_index: u16,
-) -> StorageResult<(PageId, Vec<u8>)> {
-    let pin = page_cache.fetch_page(page_id)?;
-    let (left_child, key) = {
-        let page = pin.read()?;
-        let interior = page.open::<Interior>()?;
-        let (left_child, key_len, first_overflow_page_id, inline_range) =
-            interior.cell_payload_parts(slot_index)?;
-        let key = materialize_payload(
-            page_cache,
-            page_id,
-            &page.page()[inline_range],
-            first_overflow_page_id,
-            key_len,
-        )?;
-        (left_child, key)
-    };
-    drop(pin);
-
-    Ok((left_child, key))
 }
 
 pub(super) fn compare_key_prefix(

--- a/src/core/btree/payload.rs
+++ b/src/core/btree/payload.rs
@@ -120,6 +120,50 @@ fn append_overflow_chain_exact(
     Ok(())
 }
 
+fn append_overflow_prefix(
+    page_cache: &PageCache,
+    first_overflow_page_id: PageId,
+    payload: &mut Vec<u8>,
+    total_payload_len: usize,
+) -> StorageResult<()> {
+    let initial_len = payload.len();
+    let expected_overflow_len = total_payload_len - initial_len;
+    let mut page_id = Some(first_overflow_page_id);
+
+    while payload.len() < total_payload_len {
+        let Some(current_page_id) = page_id else {
+            return Err(overflow_corruption(
+                None,
+                CorruptionKind::OverflowChainTooShort {
+                    expected: expected_overflow_len,
+                    actual: payload.len() - initial_len,
+                },
+            ));
+        };
+
+        if current_page_id == NO_OVERFLOW_PAGE_ID {
+            return Err(overflow_corruption(
+                Some(current_page_id),
+                CorruptionKind::OverflowChainTooShort {
+                    expected: expected_overflow_len,
+                    actual: payload.len() - initial_len,
+                },
+            ));
+        }
+
+        let pin = page_cache.fetch_page(current_page_id)?;
+        let page = pin.read()?;
+        let remaining = total_payload_len - payload.len();
+        let take = remaining.min(overflow::OVERFLOW_PAYLOAD_SIZE);
+        payload.extend_from_slice(
+            &page.page()[OVERFLOW_NEXT_PAGE_ID_SIZE..OVERFLOW_NEXT_PAGE_ID_SIZE + take],
+        );
+        page_id = read_overflow_next_page_id(page.page());
+    }
+
+    Ok(())
+}
+
 pub(super) fn materialize_payload(
     page_cache: &PageCache,
     page_id: PageId,
@@ -152,6 +196,31 @@ pub(super) fn materialize_payload(
     Ok(payload)
 }
 
+pub(super) fn materialize_key(
+    page_cache: &PageCache,
+    page_id: PageId,
+    inline_payload: &[u8],
+    first_overflow_page_id: Option<PageId>,
+    key_len: usize,
+) -> StorageResult<Vec<u8>> {
+    let inline_key_len = key_len.min(inline_payload.len());
+    let mut key = Vec::with_capacity(key_len);
+    key.extend_from_slice(&inline_payload[..inline_key_len]);
+
+    if key.len() == key_len {
+        return Ok(key);
+    }
+
+    let first_overflow_page_id = first_overflow_page_id
+        .ok_or_else(|| cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds))?;
+    append_overflow_prefix(page_cache, first_overflow_page_id, &mut key, key_len)?;
+
+    if key.len() != key_len {
+        return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+    }
+    Ok(key)
+}
+
 pub(super) fn materialize_leaf_cell(
     page_cache: &PageCache,
     page_id: PageId,
@@ -173,34 +242,6 @@ pub(super) fn materialize_leaf_cell(
 
     let value = payload.split_off(key_len);
     Ok((payload.into_boxed_slice(), value.into_boxed_slice()))
-}
-
-pub(super) fn read_leaf_cell(
-    page_cache: &PageCache,
-    page_id: PageId,
-    slot_index: u16,
-) -> StorageResult<(Vec<u8>, Vec<u8>)> {
-    let pin = page_cache.fetch_page(page_id)?;
-    let payload = {
-        let page = pin.read()?;
-        let leaf = page.open::<Leaf>()?;
-        let (key_len, value_len, first_overflow_page_id, inline_range) =
-            leaf.cell_payload_parts(slot_index)?;
-        let mut payload = materialize_payload(
-            page_cache,
-            page_id,
-            &page.page()[inline_range],
-            first_overflow_page_id,
-            key_len + value_len,
-        )?;
-        if payload.len() < key_len {
-            return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
-        }
-        let value = payload.split_off(key_len);
-        (payload, value)
-    };
-    drop(pin);
-    Ok(payload)
 }
 
 pub(super) fn read_interior_cell(

--- a/src/core/btree/rebalance.rs
+++ b/src/core/btree/rebalance.rs
@@ -673,29 +673,32 @@ impl TreeCursor {
         let child_index = self.child_index_in_parent(parent_page_id, leaf_page_id)?;
         let parent_children = self.read_interior_child_page_ids(parent_page_id)?;
 
-        if child_index > 0 {
+        let mut left_snapshot = [0; PAGE_SIZE];
+        let mut left_leaf_snapshot = [0; PAGE_SIZE];
+        let left_cells = if child_index > 0 {
             let left_page_id = parent_children[child_index - 1];
-            let mut left_snapshot = [0; PAGE_SIZE];
-            let mut leaf_snapshot = [0; PAGE_SIZE];
             let cells = self.snapshot_leaf_pair_cells_sorted(
                 left_page_id,
                 &mut left_snapshot,
                 leaf_page_id,
-                &mut leaf_snapshot,
+                &mut left_leaf_snapshot,
             )?;
             if let Some(split_index) = Self::choose_leaf_rebalance_split(&cells) {
                 self.redistribute_leaf_pair(left_page_id, leaf_page_id, &cells, split_index)?;
                 return Ok(false);
             }
-        }
+            Some(cells)
+        } else {
+            None
+        };
 
-        if child_index + 1 < parent_children.len() {
+        let mut right_leaf_snapshot = [0; PAGE_SIZE];
+        let mut right_snapshot = [0; PAGE_SIZE];
+        let right_cells = if child_index + 1 < parent_children.len() {
             let right_page_id = parent_children[child_index + 1];
-            let mut leaf_snapshot = [0; PAGE_SIZE];
-            let mut right_snapshot = [0; PAGE_SIZE];
             let cells = self.snapshot_leaf_pair_cells_sorted(
                 leaf_page_id,
-                &mut leaf_snapshot,
+                &mut right_leaf_snapshot,
                 right_page_id,
                 &mut right_snapshot,
             )?;
@@ -703,48 +706,35 @@ impl TreeCursor {
                 self.redistribute_leaf_pair(leaf_page_id, right_page_id, &cells, split_index)?;
                 return Ok(false);
             }
-        }
+            Some(cells)
+        } else {
+            None
+        };
 
-        if child_index > 0 {
+        if let Some(cells) = left_cells.as_ref() {
             let left_page_id = parent_children[child_index - 1];
-            let mut left_snapshot = [0; PAGE_SIZE];
-            let mut leaf_snapshot = [0; PAGE_SIZE];
-            let cells = self.snapshot_leaf_pair_cells_sorted(
-                left_page_id,
-                &mut left_snapshot,
-                leaf_page_id,
-                &mut leaf_snapshot,
-            )?;
-            if Self::leaf_cells_fit(&cells) {
-                self.merge_leaf_pages(left_page_id, leaf_page_id, &cells)?;
+            if Self::leaf_cells_fit(cells) {
+                self.merge_leaf_pages(left_page_id, leaf_page_id, cells)?;
                 self.remove_child_from_parent(parent_page_id, leaf_page_id)?;
                 self.set_page_state(left_page_id);
                 return Ok(true);
             }
-            if let Some(split_index) = Self::choose_leaf_fitting_split(&cells) {
-                self.redistribute_leaf_pair(left_page_id, leaf_page_id, &cells, split_index)?;
+            if let Some(split_index) = Self::choose_leaf_fitting_split(cells) {
+                self.redistribute_leaf_pair(left_page_id, leaf_page_id, cells, split_index)?;
                 return Ok(false);
             }
         }
 
-        if child_index + 1 < parent_children.len() {
+        if let Some(cells) = right_cells.as_ref() {
             let right_page_id = parent_children[child_index + 1];
-            let mut leaf_snapshot = [0; PAGE_SIZE];
-            let mut right_snapshot = [0; PAGE_SIZE];
-            let cells = self.snapshot_leaf_pair_cells_sorted(
-                leaf_page_id,
-                &mut leaf_snapshot,
-                right_page_id,
-                &mut right_snapshot,
-            )?;
-            if Self::leaf_cells_fit(&cells) {
-                self.merge_leaf_pages(leaf_page_id, right_page_id, &cells)?;
+            if Self::leaf_cells_fit(cells) {
+                self.merge_leaf_pages(leaf_page_id, right_page_id, cells)?;
                 self.remove_child_from_parent(parent_page_id, right_page_id)?;
                 self.set_page_state(leaf_page_id);
                 return Ok(true);
             }
-            if let Some(split_index) = Self::choose_leaf_fitting_split(&cells) {
-                self.redistribute_leaf_pair(leaf_page_id, right_page_id, &cells, split_index)?;
+            if let Some(split_index) = Self::choose_leaf_fitting_split(cells) {
+                self.redistribute_leaf_pair(leaf_page_id, right_page_id, cells, split_index)?;
                 return Ok(false);
             }
         }
@@ -837,7 +827,7 @@ impl TreeCursor {
         let child_index = self.child_index_in_parent(parent_page_id, interior_page_id)?;
         let parent_children = self.read_interior_child_page_ids(parent_page_id)?;
 
-        if child_index > 0 {
+        let left_children = if child_index > 0 {
             let left_page_id = parent_children[child_index - 1];
             let mut children = self.read_interior_child_entries(left_page_id)?;
             children.extend(self.read_interior_child_entries(interior_page_id)?);
@@ -850,9 +840,12 @@ impl TreeCursor {
                 )?;
                 return Ok(false);
             }
-        }
+            Some(children)
+        } else {
+            None
+        };
 
-        if child_index + 1 < parent_children.len() {
+        let right_children = if child_index + 1 < parent_children.len() {
             let right_page_id = parent_children[child_index + 1];
             let mut children = self.read_interior_child_entries(interior_page_id)?;
             children.extend(self.read_interior_child_entries(right_page_id)?);
@@ -865,42 +858,41 @@ impl TreeCursor {
                 )?;
                 return Ok(false);
             }
-        }
+            Some(children)
+        } else {
+            None
+        };
 
-        if child_index > 0 {
+        if let Some(children) = left_children.as_ref() {
             let left_page_id = parent_children[child_index - 1];
-            let mut children = self.read_interior_child_entries(left_page_id)?;
-            children.extend(self.read_interior_child_entries(interior_page_id)?);
-            if Self::interior_children_fit(&children) {
-                self.merge_interior_pages(left_page_id, interior_page_id, &children)?;
+            if Self::interior_children_fit(children) {
+                self.merge_interior_pages(left_page_id, interior_page_id, children)?;
                 self.remove_child_from_parent(parent_page_id, interior_page_id)?;
                 return Ok(true);
             }
-            if let Some(split_index) = Self::choose_interior_fitting_split(&children) {
+            if let Some(split_index) = Self::choose_interior_fitting_split(children) {
                 self.redistribute_interior_pair(
                     left_page_id,
                     interior_page_id,
-                    &children,
+                    children,
                     split_index,
                 )?;
                 return Ok(false);
             }
         }
 
-        if child_index + 1 < parent_children.len() {
+        if let Some(children) = right_children.as_ref() {
             let right_page_id = parent_children[child_index + 1];
-            let mut children = self.read_interior_child_entries(interior_page_id)?;
-            children.extend(self.read_interior_child_entries(right_page_id)?);
-            if Self::interior_children_fit(&children) {
-                self.merge_interior_pages(interior_page_id, right_page_id, &children)?;
+            if Self::interior_children_fit(children) {
+                self.merge_interior_pages(interior_page_id, right_page_id, children)?;
                 self.remove_child_from_parent(parent_page_id, right_page_id)?;
                 return Ok(true);
             }
-            if let Some(split_index) = Self::choose_interior_fitting_split(&children) {
+            if let Some(split_index) = Self::choose_interior_fitting_split(children) {
                 self.redistribute_interior_pair(
                     interior_page_id,
                     right_page_id,
-                    &children,
+                    children,
                     split_index,
                 )?;
                 return Ok(false);

--- a/src/core/btree/rebalance.rs
+++ b/src/core/btree/rebalance.rs
@@ -1,4 +1,4 @@
-use super::payload::{materialize_key, read_interior_cell};
+use super::payload::{append_overflow_prefix, cell_corruption};
 use super::root::read_page_kind;
 use super::*;
 
@@ -27,28 +27,94 @@ impl TreeCursor {
 
     /// Returns the largest key in a leaf page, or `None` when the page is empty.
     pub(super) fn read_leaf_max_key(&self, page_id: PageId) -> StorageResult<Option<Vec<u8>>> {
-        let slot_count = self.raw_leaf_slot_count(page_id)?;
-        if slot_count == 0 {
-            return Ok(None);
-        }
-
         let pin = self.page_cache.fetch_page(page_id)?;
         let key = {
             let page = pin.read()?;
             let leaf = page.open::<Leaf>()?;
+            let slot_count = leaf.slot_count();
+            if slot_count == 0 {
+                return Ok(None);
+            }
+
             let (key_len, _, first_overflow_page_id, inline_range) =
                 leaf.cell_payload_parts(slot_count - 1)?;
-            materialize_key(
-                &self.page_cache,
-                page_id,
-                &page.page()[inline_range],
-                first_overflow_page_id,
-                key_len,
-            )?
+            let inline_payload = &page.page()[inline_range];
+            let inline_key_len = key_len.min(inline_payload.len());
+            let mut key = Vec::with_capacity(key_len);
+            key.extend_from_slice(&inline_payload[..inline_key_len]);
+            if key.len() < key_len {
+                let first_overflow_page_id = first_overflow_page_id.ok_or_else(|| {
+                    cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds)
+                })?;
+                append_overflow_prefix(
+                    &self.page_cache,
+                    first_overflow_page_id,
+                    &mut key,
+                    key_len,
+                )?;
+                if key.len() != key_len {
+                    return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+                }
+            }
+            key
         };
         drop(pin);
 
         Ok(Some(key))
+    }
+
+    /// Executes `f` with the largest key reachable from the subtree rooted at `page_id`.
+    ///
+    /// Inline leaf keys are borrowed from the page for the duration of `f`; keys
+    /// that cross into overflow are materialized before the callback.
+    pub(super) fn with_subtree_max_key<R>(
+        &self,
+        page_id: PageId,
+        f: impl FnOnce(Option<&[u8]>) -> StorageResult<R>,
+    ) -> StorageResult<R> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let page = pin.read()?;
+        match read_page_kind(page.page(), page_id)? {
+            PageKind::RawLeaf => {
+                let leaf = page.open::<Leaf>()?;
+                let slot_count = leaf.slot_count();
+                if slot_count == 0 {
+                    return f(None);
+                }
+
+                let (key_len, _, first_overflow_page_id, inline_range) =
+                    leaf.cell_payload_parts(slot_count - 1)?;
+                let inline_payload = &page.page()[inline_range];
+                let inline_key_len = key_len.min(inline_payload.len());
+                if inline_key_len == key_len {
+                    return f(Some(&inline_payload[..inline_key_len]));
+                }
+
+                let mut key = Vec::with_capacity(key_len);
+                key.extend_from_slice(&inline_payload[..inline_key_len]);
+                let first_overflow_page_id = first_overflow_page_id.ok_or_else(|| {
+                    cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds)
+                })?;
+                append_overflow_prefix(
+                    &self.page_cache,
+                    first_overflow_page_id,
+                    &mut key,
+                    key_len,
+                )?;
+                if key.len() != key_len {
+                    return Err(cell_corruption(page_id, CorruptionKind::CellLengthOutOfBounds));
+                }
+
+                f(Some(&key))
+            }
+            PageKind::RawInterior => {
+                let interior = page.open::<Interior>()?;
+                let next = interior.rightmost_child();
+                drop(page);
+                drop(pin);
+                self.with_subtree_max_key(next, f)
+            }
+        }
     }
 
     /// Reads child page ids from an interior page in logical left-to-right order.
@@ -248,28 +314,21 @@ impl TreeCursor {
     }
 
     /// Returns whether an interior page already matches refreshed child maxima.
-    pub(super) fn interior_page_matches_children(
+    pub(super) fn interior_page_matches_child_max_keys(
         &self,
         page_id: PageId,
-        children: &[ChildEntry],
     ) -> StorageResult<bool> {
-        let current_children = self.read_interior_child_page_ids(page_id)?;
-        if current_children.len() != children.len()
-            || current_children
-                .iter()
-                .zip(children)
-                .any(|(&current, desired)| current != desired.page_id)
+        let child_page_ids = self.read_interior_child_page_ids(page_id)?;
+        for (slot_index, &child_page_id) in
+            child_page_ids[..child_page_ids.len() - 1].iter().enumerate()
         {
-            return Ok(false);
-        }
-
-        for (slot_index, child) in children[..children.len() - 1].iter().enumerate() {
-            let expected_key = child
-                .max_key
-                .as_deref()
-                .ok_or_else(|| Self::missing_child_max_key_error(page_id))?;
-            let (_, actual_key) = read_interior_cell(&self.page_cache, page_id, slot_index as u16)?;
-            if actual_key != expected_key {
+            let matches = self.with_subtree_max_key(child_page_id, |expected_key| {
+                let expected_key =
+                    expected_key.ok_or_else(|| Self::missing_child_max_key_error(page_id))?;
+                self.compare_interior_key(page_id, slot_index as u16, expected_key)
+                    .map(|ordering| ordering == Ordering::Equal)
+            })?;
+            if !matches {
                 return Ok(false);
             }
         }
@@ -279,10 +338,11 @@ impl TreeCursor {
 
     /// Refreshes one interior page only when one of its separators changed.
     pub(super) fn refresh_interior_page_separators(&self, page_id: PageId) -> StorageResult<()> {
-        let children = self.read_interior_child_entries(page_id)?;
-        if self.interior_page_matches_children(page_id, &children)? {
+        if self.interior_page_matches_child_max_keys(page_id)? {
             return Ok(());
         }
+
+        let children = self.read_interior_child_entries(page_id)?;
 
         let (prev_page_id, next_page_id) = self.read_interior_page_links(page_id)?;
         self.rewrite_interior_page(page_id, &children, prev_page_id, next_page_id)
@@ -911,11 +971,11 @@ impl TreeCursor {
             }
         }
 
-        let children = self.read_interior_child_entries(page_id)?;
-        if self.interior_page_matches_children(page_id, &children)? {
+        if self.interior_page_matches_child_max_keys(page_id)? {
             return Ok(None);
         }
 
+        let children = self.read_interior_child_entries(page_id)?;
         if Self::interior_children_fit(&children) {
             let (prev_page_id, next_page_id) = self.read_interior_page_links(page_id)?;
             self.rewrite_interior_page(page_id, &children, prev_page_id, next_page_id)?;

--- a/src/core/btree/rebalance.rs
+++ b/src/core/btree/rebalance.rs
@@ -1,4 +1,4 @@
-use super::payload::{append_overflow_prefix, cell_corruption};
+use super::payload::{append_overflow_prefix, cell_corruption, materialize_payload};
 use super::root::read_page_kind;
 use super::*;
 
@@ -210,6 +210,76 @@ impl TreeCursor {
             });
         }
         Ok(children)
+    }
+
+    /// Collects ordered child entries using separator keys already stored in one interior page.
+    pub(super) fn read_interior_child_entries_from_page(
+        &self,
+        page_id: PageId,
+    ) -> StorageResult<Vec<ChildEntry>> {
+        let snapshot = {
+            let pin = self.page_cache.fetch_page(page_id)?;
+            let page = pin.read()?;
+            *page.page()
+        };
+        let interior = RawInterior::<Read<'_>>::open(&snapshot)?;
+        let mut children = Vec::with_capacity(interior.slot_count() as usize + 1);
+        for slot_index in 0..interior.slot_count() {
+            let (left_child, key_len, first_overflow_page_id, inline_range) =
+                interior.cell_payload_parts(slot_index)?;
+            let key = materialize_payload(
+                &self.page_cache,
+                page_id,
+                &snapshot[inline_range],
+                first_overflow_page_id,
+                key_len,
+            )?;
+            children.push(ChildEntry { page_id: left_child, max_key: Some(key) });
+        }
+        children.push(ChildEntry { page_id: interior.rightmost_child(), max_key: None });
+        Ok(children)
+    }
+
+    /// Rewrites one stored separator while preserving the rest of the interior page.
+    pub(super) fn replace_interior_separator(
+        &self,
+        page_id: PageId,
+        slot_index: u16,
+        key: &[u8],
+    ) -> StorageResult<()> {
+        let mut children = self.read_interior_child_entries_from_page(page_id)?;
+        let child_index = slot_index as usize;
+        if child_index + 1 >= children.len() {
+            return Err(StorageError::Corruption(CorruptionError {
+                component: CorruptionComponent::InteriorPage,
+                page_id: Some(page_id),
+                kind: CorruptionKind::CellLengthOutOfBounds,
+            }));
+        }
+        let child = &mut children[child_index];
+        child.max_key = Some(key.to_vec());
+
+        let (prev_page_id, next_page_id) = self.read_interior_page_links(page_id)?;
+        self.rewrite_interior_page(page_id, &children, prev_page_id, next_page_id)
+    }
+
+    /// Updates ancestors after a leaf max key changed without changing tree shape.
+    pub(super) fn refresh_insert_path_after_leaf_max_change(
+        &self,
+        tree_path: &[PathFrame],
+        max_key: &[u8],
+    ) -> StorageResult<()> {
+        for frame in tree_path.iter().rev() {
+            match frame.child_ref {
+                ChildSlotRef::Slot(slot_index) => {
+                    self.replace_interior_separator(frame.page_id, slot_index, max_key)?;
+                    return Ok(());
+                }
+                ChildSlotRef::Rightmost => {}
+            }
+        }
+
+        Ok(())
     }
 
     /// Locates a child page within its parent's ordered child list.

--- a/src/core/btree/rebalance.rs
+++ b/src/core/btree/rebalance.rs
@@ -436,11 +436,8 @@ impl TreeCursor {
 
     /// Returns whether a leaf rebuilt from `cells` would be underoccupied.
     pub(super) fn leaf_cells_underoccupied(cells: &[LeafSplitCell<'_>]) -> bool {
-        let occupied_variable_bytes = cells.len() * page::format::SLOT_ENTRY_SIZE
-            + cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
-        let usable_variable_bytes =
-            page::format::USABLE_SPACE_END - PageKind::RawLeaf.header_size();
-        occupied_variable_bytes * 2 < usable_variable_bytes
+        let cell_bytes = cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
+        Self::leaf_cell_bytes_underoccupied(cells.len(), cell_bytes)
     }
 
     /// Chooses a split index that keeps both leaf siblings fit and occupied.
@@ -451,15 +448,15 @@ impl TreeCursor {
 
         for split_index in 1..cells.len() {
             left_cell_len += cells[split_index - 1].encoded_size();
-            if !Self::leaf_cells_fit(&cells[..split_index])
-                || !Self::leaf_cells_fit(&cells[split_index..])
-                || Self::leaf_cells_underoccupied(&cells[..split_index])
-                || Self::leaf_cells_underoccupied(&cells[split_index..])
+            let right_cell_len = total_cell_len - left_cell_len;
+            if !Self::leaf_cell_bytes_fit(split_index, left_cell_len)
+                || !Self::leaf_cell_bytes_fit(cells.len() - split_index, right_cell_len)
+                || Self::leaf_cell_bytes_underoccupied(split_index, left_cell_len)
+                || Self::leaf_cell_bytes_underoccupied(cells.len() - split_index, right_cell_len)
             {
                 continue;
             }
 
-            let right_cell_len = total_cell_len - left_cell_len;
             let imbalance = left_cell_len.abs_diff(right_cell_len);
             if best.is_none_or(|(best_imbalance, _)| imbalance < best_imbalance) {
                 best = Some((imbalance, split_index));
@@ -477,13 +474,13 @@ impl TreeCursor {
 
         for split_index in 1..cells.len() {
             left_cell_len += cells[split_index - 1].encoded_size();
-            if !Self::leaf_cells_fit(&cells[..split_index])
-                || !Self::leaf_cells_fit(&cells[split_index..])
+            let right_cell_len = total_cell_len - left_cell_len;
+            if !Self::leaf_cell_bytes_fit(split_index, left_cell_len)
+                || !Self::leaf_cell_bytes_fit(cells.len() - split_index, right_cell_len)
             {
                 continue;
             }
 
-            let right_cell_len = total_cell_len - left_cell_len;
             let imbalance = left_cell_len.abs_diff(right_cell_len);
             if best.is_none_or(|(best_imbalance, _)| imbalance < best_imbalance) {
                 best = Some((imbalance, split_index));

--- a/src/core/btree/rebalance.rs
+++ b/src/core/btree/rebalance.rs
@@ -1,4 +1,4 @@
-use super::payload::{read_interior_cell, read_leaf_cell};
+use super::payload::{materialize_key, read_interior_cell};
 use super::root::read_page_kind;
 use super::*;
 
@@ -25,17 +25,6 @@ impl TreeCursor {
         Ok((interior.prev_page_id(), interior.next_page_id()))
     }
 
-    /// Materializes all leaf cells in slot order for rebalance planning.
-    pub(super) fn read_leaf_cells(&self, page_id: PageId) -> StorageResult<Vec<LeafSplitCell>> {
-        let slot_count = self.raw_leaf_slot_count(page_id)?;
-        let mut cells = Vec::with_capacity(slot_count as usize);
-        for slot_index in 0..slot_count {
-            let (key, value) = read_leaf_cell(&self.page_cache, page_id, slot_index)?;
-            cells.push(LeafSplitCell { key, value });
-        }
-        Ok(cells)
-    }
-
     /// Returns the largest key in a leaf page, or `None` when the page is empty.
     pub(super) fn read_leaf_max_key(&self, page_id: PageId) -> StorageResult<Option<Vec<u8>>> {
         let slot_count = self.raw_leaf_slot_count(page_id)?;
@@ -43,7 +32,23 @@ impl TreeCursor {
             return Ok(None);
         }
 
-        read_leaf_cell(&self.page_cache, page_id, slot_count - 1).map(|(key, _)| Some(key))
+        let pin = self.page_cache.fetch_page(page_id)?;
+        let key = {
+            let page = pin.read()?;
+            let leaf = page.open::<Leaf>()?;
+            let (key_len, _, first_overflow_page_id, inline_range) =
+                leaf.cell_payload_parts(slot_count - 1)?;
+            materialize_key(
+                &self.page_cache,
+                page_id,
+                &page.page()[inline_range],
+                first_overflow_page_id,
+                key_len,
+            )?
+        };
+        drop(pin);
+
+        Ok(Some(key))
     }
 
     /// Reads child page ids from an interior page in logical left-to-right order.
@@ -170,7 +175,7 @@ impl TreeCursor {
     pub(super) fn rewrite_leaf_page(
         &self,
         page_id: PageId,
-        cells: &[LeafSplitCell],
+        cells: &[LeafSplitCell<'_>],
         prev_page_id: Option<PageId>,
         next_page_id: Option<PageId>,
     ) -> StorageResult<()> {
@@ -300,7 +305,7 @@ impl TreeCursor {
     }
 
     /// Returns whether a leaf rebuilt from `cells` would be underoccupied.
-    pub(super) fn leaf_cells_underoccupied(cells: &[LeafSplitCell]) -> bool {
+    pub(super) fn leaf_cells_underoccupied(cells: &[LeafSplitCell<'_>]) -> bool {
         let occupied_variable_bytes = cells.len() * page::format::SLOT_ENTRY_SIZE
             + cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
         let usable_variable_bytes =
@@ -309,7 +314,7 @@ impl TreeCursor {
     }
 
     /// Chooses a split index that keeps both leaf siblings fit and occupied.
-    pub(super) fn choose_leaf_rebalance_split(cells: &[LeafSplitCell]) -> Option<usize> {
+    pub(super) fn choose_leaf_rebalance_split(cells: &[LeafSplitCell<'_>]) -> Option<usize> {
         let total_cell_len = cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
         let mut left_cell_len = 0;
         let mut best = None;
@@ -335,7 +340,7 @@ impl TreeCursor {
     }
 
     /// Chooses a split index that keeps both leaf siblings within page capacity.
-    pub(super) fn choose_leaf_fitting_split(cells: &[LeafSplitCell]) -> Option<usize> {
+    pub(super) fn choose_leaf_fitting_split(cells: &[LeafSplitCell<'_>]) -> Option<usize> {
         let total_cell_len = cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
         let mut left_cell_len = 0;
         let mut best = None;
@@ -483,7 +488,7 @@ impl TreeCursor {
         &self,
         left_page_id: PageId,
         right_page_id: PageId,
-        cells: &[LeafSplitCell],
+        cells: &[LeafSplitCell<'_>],
         split_index: usize,
     ) -> StorageResult<()> {
         let (left_prev_page_id, _) = self.read_leaf_page_links(left_page_id)?;
@@ -507,7 +512,7 @@ impl TreeCursor {
         &self,
         survivor_page_id: PageId,
         removed_page_id: PageId,
-        cells: &[LeafSplitCell],
+        cells: &[LeafSplitCell<'_>],
     ) -> StorageResult<()> {
         let (survivor_prev_page_id, _) = self.read_leaf_page_links(survivor_page_id)?;
         let (_, removed_next_page_id) = self.read_leaf_page_links(removed_page_id)?;
@@ -523,7 +528,7 @@ impl TreeCursor {
         Ok(())
     }
 
-    pub(super) fn sort_leaf_cells(cells: &mut [LeafSplitCell]) {
+    pub(super) fn sort_leaf_cells(cells: &mut [LeafSplitCell<'_>]) {
         cells.sort_by(|left, right| left.key().cmp(right.key()));
     }
 
@@ -540,9 +545,14 @@ impl TreeCursor {
 
         if child_index > 0 {
             let left_page_id = parent_children[child_index - 1];
-            let mut cells = self.read_leaf_cells(left_page_id)?;
-            cells.extend(self.read_leaf_cells(leaf_page_id)?);
-            Self::sort_leaf_cells(&mut cells);
+            let mut left_snapshot = [0; PAGE_SIZE];
+            let mut leaf_snapshot = [0; PAGE_SIZE];
+            let cells = self.snapshot_leaf_pair_cells_sorted(
+                left_page_id,
+                &mut left_snapshot,
+                leaf_page_id,
+                &mut leaf_snapshot,
+            )?;
             if let Some(split_index) = Self::choose_leaf_rebalance_split(&cells) {
                 self.redistribute_leaf_pair(left_page_id, leaf_page_id, &cells, split_index)?;
                 return Ok(false);
@@ -551,9 +561,14 @@ impl TreeCursor {
 
         if child_index + 1 < parent_children.len() {
             let right_page_id = parent_children[child_index + 1];
-            let mut cells = self.read_leaf_cells(leaf_page_id)?;
-            cells.extend(self.read_leaf_cells(right_page_id)?);
-            Self::sort_leaf_cells(&mut cells);
+            let mut leaf_snapshot = [0; PAGE_SIZE];
+            let mut right_snapshot = [0; PAGE_SIZE];
+            let cells = self.snapshot_leaf_pair_cells_sorted(
+                leaf_page_id,
+                &mut leaf_snapshot,
+                right_page_id,
+                &mut right_snapshot,
+            )?;
             if let Some(split_index) = Self::choose_leaf_rebalance_split(&cells) {
                 self.redistribute_leaf_pair(leaf_page_id, right_page_id, &cells, split_index)?;
                 return Ok(false);
@@ -562,9 +577,14 @@ impl TreeCursor {
 
         if child_index > 0 {
             let left_page_id = parent_children[child_index - 1];
-            let mut cells = self.read_leaf_cells(left_page_id)?;
-            cells.extend(self.read_leaf_cells(leaf_page_id)?);
-            Self::sort_leaf_cells(&mut cells);
+            let mut left_snapshot = [0; PAGE_SIZE];
+            let mut leaf_snapshot = [0; PAGE_SIZE];
+            let cells = self.snapshot_leaf_pair_cells_sorted(
+                left_page_id,
+                &mut left_snapshot,
+                leaf_page_id,
+                &mut leaf_snapshot,
+            )?;
             if Self::leaf_cells_fit(&cells) {
                 self.merge_leaf_pages(left_page_id, leaf_page_id, &cells)?;
                 self.remove_child_from_parent(parent_page_id, leaf_page_id)?;
@@ -579,9 +599,14 @@ impl TreeCursor {
 
         if child_index + 1 < parent_children.len() {
             let right_page_id = parent_children[child_index + 1];
-            let mut cells = self.read_leaf_cells(leaf_page_id)?;
-            cells.extend(self.read_leaf_cells(right_page_id)?);
-            Self::sort_leaf_cells(&mut cells);
+            let mut leaf_snapshot = [0; PAGE_SIZE];
+            let mut right_snapshot = [0; PAGE_SIZE];
+            let cells = self.snapshot_leaf_pair_cells_sorted(
+                leaf_page_id,
+                &mut leaf_snapshot,
+                right_page_id,
+                &mut right_snapshot,
+            )?;
             if Self::leaf_cells_fit(&cells) {
                 self.merge_leaf_pages(leaf_page_id, right_page_id, &cells)?;
                 self.remove_child_from_parent(parent_page_id, right_page_id)?;

--- a/src/core/btree/split.rs
+++ b/src/core/btree/split.rs
@@ -85,10 +85,22 @@ impl TreeCursor {
 
     /// Returns whether the provided leaf cells fit into one leaf page.
     pub(super) fn leaf_cells_fit(cells: &[LeafSplitCell<'_>]) -> bool {
+        let cell_bytes = cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
+        Self::leaf_cell_bytes_fit(cells.len(), cell_bytes)
+    }
+
+    pub(super) fn leaf_cell_bytes_fit(cell_count: usize, cell_bytes: usize) -> bool {
         let used_bytes = PageKind::RawLeaf.header_size()
-            + cells.len() * page::format::SLOT_ENTRY_SIZE
-            + cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
+            + cell_count * page::format::SLOT_ENTRY_SIZE
+            + cell_bytes;
         used_bytes <= page::format::USABLE_SPACE_END
+    }
+
+    pub(super) fn leaf_cell_bytes_underoccupied(cell_count: usize, cell_bytes: usize) -> bool {
+        let occupied_variable_bytes = cell_count * page::format::SLOT_ENTRY_SIZE + cell_bytes;
+        let usable_variable_bytes =
+            page::format::USABLE_SPACE_END - PageKind::RawLeaf.header_size();
+        occupied_variable_bytes * 2 < usable_variable_bytes
     }
 
     /// Chooses the leaf split point with the smallest byte imbalance.
@@ -101,13 +113,13 @@ impl TreeCursor {
 
         for split_index in 1..cells.len() {
             left_cell_len += cells[split_index - 1].encoded_size();
-            if !Self::leaf_cells_fit(&cells[..split_index])
-                || !Self::leaf_cells_fit(&cells[split_index..])
+            let right_cell_len = total_cell_len - left_cell_len;
+            if !Self::leaf_cell_bytes_fit(split_index, left_cell_len)
+                || !Self::leaf_cell_bytes_fit(cells.len() - split_index, right_cell_len)
             {
                 continue;
             }
 
-            let right_cell_len = total_cell_len - left_cell_len;
             let imbalance = left_cell_len.abs_diff(right_cell_len);
             let is_better = match best {
                 Some((best_imbalance, best_left_cell_len, _)) => {

--- a/src/core/btree/split.rs
+++ b/src/core/btree/split.rs
@@ -352,7 +352,7 @@ impl TreeCursor {
         let PendingSplit { separator, left_page_id, right_page_id: incoming_right_page_id } =
             pending;
         let (prev_page_id, next_page_id) = self.read_interior_page_links(parent_frame.page_id)?;
-        let mut children = self.read_interior_child_entries(parent_frame.page_id)?;
+        let mut children = self.read_interior_child_entries_from_page(parent_frame.page_id)?;
         let child_index = match parent_frame.child_ref {
             ChildSlotRef::Slot(slot_index) => slot_index as usize,
             ChildSlotRef::Rightmost => children.len() - 1,

--- a/src/core/btree/split.rs
+++ b/src/core/btree/split.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::payload::{cell_corruption, materialize_payload};
 use super::root::read_page_kind;
 use super::*;
@@ -82,7 +84,7 @@ impl TreeCursor {
     }
 
     /// Returns whether the provided leaf cells fit into one leaf page.
-    pub(super) fn leaf_cells_fit(cells: &[LeafSplitCell]) -> bool {
+    pub(super) fn leaf_cells_fit(cells: &[LeafSplitCell<'_>]) -> bool {
         let used_bytes = PageKind::RawLeaf.header_size()
             + cells.len() * page::format::SLOT_ENTRY_SIZE
             + cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
@@ -90,7 +92,7 @@ impl TreeCursor {
     }
 
     /// Chooses the leaf split point with the smallest byte imbalance.
-    pub(super) fn choose_leaf_split_index(cells: &[LeafSplitCell]) -> StorageResult<usize> {
+    pub(super) fn choose_leaf_split_index(cells: &[LeafSplitCell<'_>]) -> StorageResult<usize> {
         debug_assert!(cells.len() >= 2, "leaf splits need at least two cells");
 
         let total_cell_len = cells.iter().map(LeafSplitCell::encoded_size).sum::<usize>();
@@ -130,31 +132,105 @@ impl TreeCursor {
         }
     }
 
-    /// Materializes all leaf cells from a stable page snapshot.
-    pub(super) fn read_leaf_cells_from_snapshot(
+    /// Reads all leaf cells from a stable page snapshot.
+    pub(super) fn read_leaf_cells_from_snapshot<'a>(
         &self,
         leaf_page_id: PageId,
-        leaf_snapshot_bytes: &[u8; PAGE_SIZE],
+        leaf_snapshot_bytes: &'a [u8; PAGE_SIZE],
         leaf_snapshot: &RawLeaf<Read<'_>>,
-    ) -> StorageResult<Vec<LeafSplitCell>> {
+    ) -> StorageResult<Vec<LeafSplitCell<'a>>> {
         let mut cells = Vec::with_capacity(leaf_snapshot.slot_count() as usize);
         for slot_index in 0..leaf_snapshot.slot_count() {
             let (key_len, value_len, first_overflow_page_id, inline_range) =
                 leaf_snapshot.cell_payload_parts(slot_index)?;
-            let mut payload = materialize_payload(
-                &self.page_cache,
-                leaf_page_id,
-                &leaf_snapshot_bytes[inline_range],
-                first_overflow_page_id,
-                key_len + value_len,
-            )?;
-            if payload.len() < key_len {
-                return Err(cell_corruption(leaf_page_id, CorruptionKind::CellLengthOutOfBounds));
-            }
-            let value = payload.split_off(key_len);
-            cells.push(LeafSplitCell { key: payload, value });
+            let inline_payload = &leaf_snapshot_bytes[inline_range];
+            let cell = match first_overflow_page_id {
+                None => {
+                    if inline_payload.len() != key_len + value_len {
+                        return Err(cell_corruption(
+                            leaf_page_id,
+                            CorruptionKind::CellLengthOutOfBounds,
+                        ));
+                    }
+                    let (key, value) = inline_payload.split_at(key_len);
+                    LeafSplitCell::borrowed(key, value)
+                }
+                Some(_) => {
+                    let mut payload = materialize_payload(
+                        &self.page_cache,
+                        leaf_page_id,
+                        inline_payload,
+                        first_overflow_page_id,
+                        key_len + value_len,
+                    )?;
+                    if payload.len() < key_len {
+                        return Err(cell_corruption(
+                            leaf_page_id,
+                            CorruptionKind::CellLengthOutOfBounds,
+                        ));
+                    }
+                    let value = payload.split_off(key_len);
+                    LeafSplitCell::owned(payload, value)
+                }
+            };
+            cells.push(cell);
         }
         Ok(cells)
+    }
+
+    pub(super) fn snapshot_leaf_cells<'a>(
+        &self,
+        page_id: PageId,
+        snapshot_bytes: &'a mut [u8; PAGE_SIZE],
+    ) -> StorageResult<Vec<LeafSplitCell<'a>>> {
+        let pin = self.page_cache.fetch_page(page_id)?;
+        {
+            let page = pin.read()?;
+            *snapshot_bytes = *page.page();
+        }
+        drop(pin);
+
+        let snapshot = RawLeaf::<Read<'_>>::open(snapshot_bytes)?;
+        self.read_leaf_cells_from_snapshot(page_id, snapshot_bytes, &snapshot)
+    }
+
+    pub(super) fn snapshot_leaf_pair_cells<'a>(
+        &self,
+        first_page_id: PageId,
+        first_snapshot_bytes: &'a mut [u8; PAGE_SIZE],
+        second_page_id: PageId,
+        second_snapshot_bytes: &'a mut [u8; PAGE_SIZE],
+    ) -> StorageResult<Vec<LeafSplitCell<'a>>> {
+        let mut cells = self.snapshot_leaf_cells(first_page_id, first_snapshot_bytes)?;
+        cells.extend(self.snapshot_leaf_cells(second_page_id, second_snapshot_bytes)?);
+        Ok(cells)
+    }
+
+    pub(super) fn snapshot_leaf_pair_cells_sorted<'a>(
+        &self,
+        first_page_id: PageId,
+        first_snapshot_bytes: &'a mut [u8; PAGE_SIZE],
+        second_page_id: PageId,
+        second_snapshot_bytes: &'a mut [u8; PAGE_SIZE],
+    ) -> StorageResult<Vec<LeafSplitCell<'a>>> {
+        let mut cells = self.snapshot_leaf_pair_cells(
+            first_page_id,
+            first_snapshot_bytes,
+            second_page_id,
+            second_snapshot_bytes,
+        )?;
+        Self::sort_leaf_cells(&mut cells);
+        Ok(cells)
+    }
+
+    #[cfg(test)]
+    pub(super) fn leaf_cell_storage_is_borrowed_for_test(cell: &LeafSplitCell<'_>) -> (bool, bool) {
+        (matches!(cell.key, Cow::Borrowed(_)), matches!(cell.value, Cow::Borrowed(_)))
+    }
+
+    #[cfg(test)]
+    pub(super) fn leaf_cell_storage_is_owned_for_test(cell: &LeafSplitCell<'_>) -> (bool, bool) {
+        (matches!(cell.key, Cow::Owned(_)), matches!(cell.value, Cow::Owned(_)))
     }
 
     /// Rebuilds a split leaf pair from ordered materialized cells.
@@ -164,7 +240,7 @@ impl TreeCursor {
         leaf_guard: &mut PageWriteGuard<'_>,
         prev_page_id: Option<PageId>,
         next_page_id: Option<PageId>,
-        cells: &[LeafSplitCell],
+        cells: &[LeafSplitCell<'_>],
         target_key: &[u8],
     ) -> StorageResult<PendingSplit> {
         let split_index = Self::choose_leaf_split_index(cells)?;
@@ -231,7 +307,7 @@ impl TreeCursor {
             Ok(_) => return Err(PageError::DuplicateKey.into()),
             Err(insert_index) => insert_index,
         };
-        cells.insert(idx, LeafSplitCell { key: key.to_vec(), value: value.to_vec() });
+        cells.insert(idx, LeafSplitCell::owned(key.to_vec(), value.to_vec()));
 
         self.split_leaf_cells(leaf_page_id, leaf_guard, prev_page_id, next_page_id, &cells, key)
     }
@@ -254,8 +330,8 @@ impl TreeCursor {
         let target = cells
             .get_mut(slot_index as usize)
             .ok_or_else(|| cell_corruption(leaf_page_id, CorruptionKind::CellLengthOutOfBounds))?;
-        target.value = value.to_vec();
-        let target_key = target.key.clone();
+        target.value = Cow::Owned(value.to_vec());
+        let target_key = target.key().to_vec();
 
         self.split_leaf_cells(
             leaf_page_id,

--- a/src/core/btree/tests.rs
+++ b/src/core/btree/tests.rs
@@ -473,6 +473,53 @@ fn unchanged_path_separator_refresh_does_not_grow_file() {
 }
 
 #[test]
+fn snapshot_leaf_cells_borrow_inline_payload() {
+    let mut cursor = temp_tree_cursor(8);
+
+    cursor.insert(b"alpha", b"value").unwrap();
+
+    let page_id = cursor.leaf_page_for_key(b"alpha").unwrap();
+    let mut snapshot_bytes = [0; PAGE_SIZE];
+    let cells = cursor.snapshot_leaf_cells(page_id, &mut snapshot_bytes).unwrap();
+
+    assert_eq!(cells.len(), 1);
+    assert_eq!(cells[0].key(), b"alpha");
+    assert_eq!(cells[0].value(), b"value");
+    assert_eq!(TreeCursor::leaf_cell_storage_is_borrowed_for_test(&cells[0]), (true, true));
+}
+
+#[test]
+fn snapshot_leaf_cells_own_overflow_payload() {
+    let mut cursor = temp_tree_cursor(8);
+    let value = vec![42; PAGE_SIZE];
+
+    cursor.insert(b"alpha", &value).unwrap();
+
+    let page_id = cursor.leaf_page_for_key(b"alpha").unwrap();
+    let mut snapshot_bytes = [0; PAGE_SIZE];
+    let cells = cursor.snapshot_leaf_cells(page_id, &mut snapshot_bytes).unwrap();
+
+    assert_eq!(cells.len(), 1);
+    assert_eq!(cells[0].key(), b"alpha");
+    assert_eq!(cells[0].value(), value.as_slice());
+    assert_eq!(TreeCursor::leaf_cell_storage_is_owned_for_test(&cells[0]), (true, true));
+}
+
+#[test]
+fn read_leaf_max_key_copies_only_inline_key() {
+    let mut cursor = temp_tree_cursor(8);
+    let value = vec![7; MAX_INLINE_OVERFLOW_PAYLOAD_BYTES - b"bravo".len()];
+
+    cursor.insert(b"alpha", b"small").unwrap();
+    cursor.insert(b"bravo", &value).unwrap();
+
+    let page_id = cursor.leaf_page_for_key(b"bravo").unwrap();
+    let max_key = cursor.read_leaf_max_key(page_id).unwrap();
+
+    assert_eq!(max_key.as_deref(), Some(b"bravo".as_slice()));
+}
+
+#[test]
 fn inline_record_is_page_resident() {
     let mut cursor = temp_tree_cursor(4);
 


### PR DESCRIPTION
## Summary

This PR optimizes the B+-tree insert and rebalance hot paths that showed up in insert-heavy profiler traces. The changes reduce avoidable heap allocation, avoid whole-subtree separator refreshes after inserts, and remove repeated scans/reconstruction in split and rebalance helpers.

The public cursor/table/index APIs are unchanged. The work is scoped to internal B+-tree payload extraction, separator maintenance, split handling, rebalance gathering, and focused tests for the new allocation behavior.

## Performance Optimizations

### 1. Borrow inline leaf cells during structural rewrites

`LeafSplitCell` now stores keys and values as `Cow<'a, [u8]>`. When a leaf cell is fully inline in the page snapshot, split and rebalance code borrows the key/value slices directly from that snapshot instead of allocating and copying them into owned buffers.

Overflow cells still materialize into owned buffers because their bytes live across overflow pages and must survive page rewrites. This keeps overflow behavior explicit while removing the common-case allocation cost for inline cells during leaf split/rebalance extraction.

### 2. Read only max-key bytes for separator refresh

The old structural max-key path used full leaf-cell materialization even when separator maintenance only needed the key. `read_leaf_max_key` now copies only the key bytes from the leaf max cell. If the key is inline, it copies just that inline key range; if the key crosses into overflow, it reads only the overflow prefix needed to complete the key and does not materialize the value.

The separator validation path also uses a borrowed callback-style max-key reader for inline max keys, so unchanged separator checks can compare against page-resident key bytes without allocating a temporary key buffer.

### 3. Skip full-tree separator refresh for ordinary inserts

Previously, every successful no-split insert called `refresh_subtree_separators()`, recursively walking the reachable B+-tree even when the insert landed in the middle of a leaf and could not change any ancestor separator.

The insert path now tracks whether the inserted slot became the leaf's new maximum. Middle-of-leaf inserts skip separator work entirely. If the leaf maximum changed, the code walks the recorded descent path upward and rewrites only the first stored ancestor separator that can observe the new maximum. Rightmost-child edges keep bubbling because they have no stored separator at that level.

### 4. Refresh only the affected insertion path after splits

Split propagation already inserts the promoted separator into the direct parent and bubbles a `PendingSplit` upward when needed. After that, the old path still ran a whole-subtree separator refresh.

After insert/update splits, the code now refreshes only the recorded descent path. This keeps the existing ancestor repair behavior for pages affected by the split while avoiding recursive visits to unrelated subtrees.

### 5. Reuse stored separators during interior splits

Interior page splitting used to call `read_interior_child_entries()`, which recomputed each child maximum by descending through every child subtree. For an interior split caused by a propagated child split, most of that information is already present in the page's stored separators, and the pending split supplies the one new separator.

The split path now builds its temporary child list from the existing interior page image, splices in the pending left/right children, and preserves the rightmost child without forcing a materialized max key. This removes repeated `subtree_max_key` work from interior split handling.

### 6. Reuse sibling-pair snapshots during delete rebalance

Leaf and interior rebalance previously gathered the same sibling pair once for redistribution and then again for merge or fitting-redistribution fallback. That duplicated leaf snapshots, borrowed-cell extraction, and interior child-entry reconstruction.

Rebalance now gathers each candidate sibling pair once, tries the preferred redistribution, and reuses the gathered cells or child entries for fallback decisions. The existing left-before-right behavior and merge/redistribution policy are preserved.

### 7. Use rolling byte totals for leaf split selection

Leaf split and leaf rebalance split-point selection previously tested each candidate split by calling helpers that re-summed both slice halves. That made split selection effectively quadratic in the number of cells considered.

The split selectors now keep rolling left/right encoded-byte totals while scanning candidates. Fit and underoccupancy checks use those totals directly, preserving the chosen split policy while making candidate evaluation linear.

## Validation

- `cargo test -p databas`

## Notes

This PR intentionally leaves broader B+-tree algorithm changes out of scope. In particular, it does not change public APIs, record-read behavior, or the overall delete rebalance policy. The focus is removing avoidable allocation, materialization, and traversal from the existing implementation.
