### PR TITLE
Batch WAL writes across transaction and storage runtime

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -206,8 +206,6 @@ pub(crate) type DiskManagerResult<T> = Result<T, DiskManagerError>;
 pub(crate) enum PageCacheError {
     #[error("disk manager error: {0}")]
     Disk(#[from] DiskManagerError),
-    #[error("WAL flush error: {0}")]
-    WalFlush(#[from] LogManagerFlushError),
     #[error("transaction error: {0}")]
     Transaction(Box<StorageError>),
     #[error("no evictable frame available")]
@@ -266,17 +264,6 @@ impl From<PageCacheError> for StorageError {
     fn from(err: PageCacheError) -> Self {
         match err {
             PageCacheError::Disk(err) => err.into(),
-            PageCacheError::WalFlush(err) => match err {
-                LogManagerFlushError::Io(err) => Self::Io(err),
-                LogManagerFlushError::LsnNotAppended { requested_lsn, highest_appended_lsn } => {
-                    Self::Internal(InternalError::InvariantViolation(
-                        InvariantViolation::WalFlushLsnNotAppended {
-                            requested_lsn,
-                            highest_appended_lsn,
-                        },
-                    ))
-                }
-            },
             PageCacheError::Transaction(err) => *err,
             PageCacheError::NoEvictableFrame => {
                 Self::LimitExceeded(LimitExceededError::CacheCapacityExhausted)

--- a/src/core/log_manager/frame.rs
+++ b/src/core/log_manager/frame.rs
@@ -380,7 +380,7 @@ pub(crate) fn read_log_record_kinds_for_test(
     wal_file.read_to_end(&mut buf).unwrap();
 
     let mut records = Vec::new();
-    let mut offset = 0;
+    let mut offset = super::WAL_FILE_HEADER_LEN;
     while offset < buf.len() {
         let frame_len = transaction_frame_len(&buf[offset..]).unwrap();
         let transaction = deserialize_transaction(&buf[offset..offset + frame_len]).unwrap();

--- a/src/core/log_manager/mod.rs
+++ b/src/core/log_manager/mod.rs
@@ -5,20 +5,24 @@
 //! frames:
 //!
 //! ```text
-//! header magic | format version | transaction id | record count | payload length
-//! payload records...
-//! footer magic | transaction id | payload CRC32
+//! WAL file header | transaction frame...
+//!
+//! transaction frame:
+//!   header magic | format version | transaction id | record count | payload length
+//!   payload records...
+//!   footer magic | transaction id | payload CRC32
 //! ```
 //!
-//! LSNs are not stored explicitly in the frame. They are assigned logically by
-//! record position across complete frames, starting at 1. Appending advances
-//! the highest appended LSN, while [`LogManager::flush_through`] is responsible
-//! for making appended bytes durable before pages protected by those LSNs are
-//! written to the database file.
+//! LSNs are not stored explicitly in transaction frames. The WAL file header
+//! stores the durable high-water LSN before the current WAL segment, and records
+//! in complete frames are assigned logical LSNs after that value. Appending
+//! advances the highest appended LSN, while [`LogManager::flush_through`] is
+//! responsible for making appended bytes durable before pages protected by
+//! those LSNs are written to the database file.
 
 use std::{
     fs::{File, OpenOptions},
-    io::{BufReader, BufWriter, Read, Seek, Write},
+    io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
 };
 
@@ -46,6 +50,9 @@ pub(crate) const ZERO_LSN: Lsn = 0;
 
 const WAL_READ_BUFFER_LEN: usize = 64 * 1024;
 const WAL_WRITE_BUFFER_LEN: usize = 64 * 1024;
+const WAL_FILE_HEADER_MAGIC: [u8; 8] = *b"DBWALHDR";
+const WAL_FILE_HEADER_VERSION: u16 = 1;
+const WAL_FILE_HEADER_LEN: usize = 24;
 
 /// Errors raised while opening, writing, or decoding WAL frames.
 #[derive(Debug, Error)]
@@ -180,6 +187,8 @@ pub(crate) struct RecoveryLogScan {
     pub(crate) truncated_tail: bool,
     /// Largest transaction id observed in complete frames.
     pub(crate) max_txn_id: TxnId,
+    /// Highest LSN assigned before this WAL segment plus all complete records.
+    pub(crate) last_assigned_lsn: Lsn,
 }
 
 #[cfg(test)]
@@ -198,6 +207,56 @@ pub(crate) struct LogTransaction<'a> {
     pub(crate) txn_id: TxnId,
     /// Records decoded from the frame payload.
     pub(crate) records: Vec<LogRecord<'a>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WalFileHeader {
+    last_assigned_lsn: Lsn,
+}
+
+fn ensure_wal_file_header(wal_file: &mut File) -> Result<WalFileHeader, LogManagerError> {
+    if wal_file.metadata()?.len() == 0 {
+        write_wal_file_header(wal_file, ZERO_LSN)?;
+        wal_file.sync_all()?;
+        return Ok(WalFileHeader { last_assigned_lsn: ZERO_LSN });
+    }
+    read_wal_file_header(wal_file)
+}
+
+fn read_wal_file_header(wal_file: &mut File) -> Result<WalFileHeader, LogManagerError> {
+    let mut header = [0; WAL_FILE_HEADER_LEN];
+    wal_file.seek(SeekFrom::Start(0))?;
+    wal_file.read_exact(&mut header)?;
+
+    let magic: [u8; 8] = header[0..8].try_into().expect("slice length is fixed");
+    if magic != WAL_FILE_HEADER_MAGIC {
+        return Err(LogManagerError::InvalidHeaderMagic { actual: magic });
+    }
+
+    let version = u16::from_le_bytes(header[8..10].try_into().expect("slice length is fixed"));
+    if version != WAL_FILE_HEADER_VERSION {
+        return Err(LogManagerError::UnsupportedVersion {
+            expected: WAL_FILE_HEADER_VERSION,
+            actual: version,
+        });
+    }
+
+    let last_assigned_lsn =
+        u64::from_le_bytes(header[16..24].try_into().expect("slice length is fixed"));
+    Ok(WalFileHeader { last_assigned_lsn })
+}
+
+fn write_wal_file_header(
+    wal_file: &mut File,
+    last_assigned_lsn: Lsn,
+) -> Result<(), LogManagerError> {
+    let mut header = [0; WAL_FILE_HEADER_LEN];
+    header[0..8].copy_from_slice(&WAL_FILE_HEADER_MAGIC);
+    header[8..10].copy_from_slice(&WAL_FILE_HEADER_VERSION.to_le_bytes());
+    header[16..24].copy_from_slice(&last_assigned_lsn.to_le_bytes());
+    wal_file.seek(SeekFrom::Start(0))?;
+    wal_file.write_all(&header)?;
+    Ok(())
 }
 
 /// Append-only manager for the database write-ahead log.
@@ -230,13 +289,18 @@ impl LogManager {
         let mut wal_file = OpenOptions::new()
             .create(true)
             .read(true)
-            .append(true)
+            .write(true)
             .truncate(false)
             .open(wal_file_path)?;
+        let wal_header = ensure_wal_file_header(&mut wal_file).map_err(wal_open_error)?;
 
-        let mut highest_appended_lsn = None;
+        let mut highest_appended_lsn = if wal_header.last_assigned_lsn == ZERO_LSN {
+            None
+        } else {
+            Some(wal_header.last_assigned_lsn)
+        };
         let mut highest_txn_id = 0;
-        wal_file.seek(std::io::SeekFrom::Start(0))?;
+        wal_file.seek(SeekFrom::Start(WAL_FILE_HEADER_LEN as u64))?;
         {
             let mut wal_reader = BufReader::with_capacity(WAL_READ_BUFFER_LEN, &mut wal_file);
             while let Some(frame) =
@@ -253,7 +317,7 @@ impl LogManager {
                 }
             }
         }
-        wal_file.seek(std::io::SeekFrom::End(0))?;
+        wal_file.seek(SeekFrom::End(0))?;
 
         let wal_writer = BufWriter::with_capacity(WAL_WRITE_BUFFER_LEN, wal_file);
 
@@ -408,12 +472,14 @@ pub(crate) fn read_recovery_log(
         .write(true)
         .truncate(false)
         .open(wal_file_path)?;
+    let wal_header = ensure_wal_file_header(&mut wal_file)?;
     let mut buf = Vec::new();
+    wal_file.seek(SeekFrom::Start(0))?;
     wal_file.read_to_end(&mut buf)?;
 
-    let mut records = Vec::new();
-    let mut offset = 0;
-    let mut next_lsn = ZERO_LSN;
+    let mut frame_ranges = Vec::new();
+    let mut offset = WAL_FILE_HEADER_LEN;
+    let mut complete_record_count = 0u64;
     let mut max_txn_id = 0;
     let mut truncated_tail = false;
 
@@ -441,14 +507,12 @@ pub(crate) fn read_recovery_log(
 
         let transaction = deserialize_transaction(&buf[offset..frame_end])?;
         max_txn_id = max_txn_id.max(transaction.txn_id);
-        for record in transaction.records {
-            next_lsn = next_lsn.checked_add(1).ok_or(LogManagerError::LsnExhausted)?;
-            records.push(RecoveryLogRecord {
-                lsn: next_lsn,
-                txn_id: record.txn_id,
-                kind: RecoveryLogRecordKind::from_log_record_kind(record.kind)?,
-            });
-        }
+        complete_record_count = complete_record_count
+            .checked_add(
+                u64::try_from(transaction.records.len()).expect("usize record count fits in u64"),
+            )
+            .ok_or(LogManagerError::LsnExhausted)?;
+        frame_ranges.push((offset, frame_end));
         offset = frame_end;
     }
 
@@ -457,14 +521,41 @@ pub(crate) fn read_recovery_log(
         wal_file.sync_all()?;
     }
 
-    Ok(RecoveryLogScan { records, truncated_tail, max_txn_id })
+    let last_assigned_lsn = wal_header
+        .last_assigned_lsn
+        .checked_add(complete_record_count)
+        .ok_or(LogManagerError::LsnExhausted)?;
+    let mut next_lsn = wal_header.last_assigned_lsn;
+    let mut records = Vec::new();
+    for (frame_start, frame_end) in frame_ranges {
+        let transaction = deserialize_transaction(&buf[frame_start..frame_end])?;
+        for record in transaction.records {
+            next_lsn = next_lsn.checked_add(1).ok_or(LogManagerError::LsnExhausted)?;
+            records.push(RecoveryLogRecord {
+                lsn: next_lsn,
+                txn_id: record.txn_id,
+                kind: RecoveryLogRecordKind::from_log_record_kind(record.kind)?,
+            });
+        }
+    }
+
+    Ok(RecoveryLogScan { records, truncated_tail, max_txn_id, last_assigned_lsn })
 }
 
 /// Removes all WAL contents after recovery has made the database file consistent.
-pub(crate) fn truncate_wal(db_file_path: impl AsRef<Path>) -> Result<(), LogManagerError> {
+pub(crate) fn truncate_wal(
+    db_file_path: impl AsRef<Path>,
+    last_assigned_lsn: Lsn,
+) -> Result<(), LogManagerError> {
     let wal_file_path = db_file_path.as_ref().with_added_extension("wal");
-    let wal_file =
-        OpenOptions::new().create(true).write(true).truncate(true).open(wal_file_path)?;
+    let mut wal_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(wal_file_path)?;
+    write_wal_file_header(&mut wal_file, last_assigned_lsn)?;
+    wal_file.set_len(WAL_FILE_HEADER_LEN as u64)?;
     wal_file.sync_all()?;
     Ok(())
 }
@@ -724,7 +815,7 @@ mod tests {
         let mut wal_file = File::open(file.path().with_added_extension("wal")).unwrap();
         let mut buf = Vec::new();
         wal_file.read_to_end(&mut buf).unwrap();
-        let transaction = deserialize_transaction(&buf).unwrap();
+        let transaction = deserialize_transaction(&buf[WAL_FILE_HEADER_LEN..]).unwrap();
 
         assert_eq!(transaction.txn_id, 11);
         assert_eq!(transaction.records.len(), 2);
@@ -821,7 +912,8 @@ mod tests {
         );
         let wal_file_path = file.path().with_added_extension("wal");
         {
-            let mut wal_file = File::create(&wal_file_path).unwrap();
+            let _manager = LogManager::new(file.path()).unwrap();
+            let mut wal_file = OpenOptions::new().append(true).open(&wal_file_path).unwrap();
             wal_file.write_all(&valid_frame).unwrap();
             wal_file.write_all(b"DBWAL").unwrap();
         }
@@ -831,7 +923,10 @@ mod tests {
         assert!(scan.truncated_tail);
         assert_eq!(scan.max_txn_id, 11);
         assert_eq!(scan.records.len(), 2);
-        assert_eq!(std::fs::metadata(wal_file_path).unwrap().len(), valid_frame.len() as u64);
+        assert_eq!(
+            std::fs::metadata(wal_file_path).unwrap().len(),
+            (WAL_FILE_HEADER_LEN + valid_frame.len()) as u64
+        );
     }
 
     #[test]

--- a/src/core/page_cache.rs
+++ b/src/core/page_cache.rs
@@ -28,7 +28,7 @@ use crate::core::{
     page::{NodeMarker, Page, PageResult, Read, Write},
     page_replacement::ClockPolicy,
     storage_runtime::StorageRuntime,
-    transaction_manager::{PageUndo, page_lsn},
+    transaction_manager::PageRestore,
     {PAGE_SIZE, PageId},
 };
 
@@ -236,7 +236,7 @@ impl PageCache {
 
         frame.page_id.set(Some(new_page_id));
         frame.dirty.set(false);
-        frame.lsn.set(page_lsn(&data));
+        frame.lsn.set(ZERO_LSN);
         frame.pin_count.set(1);
 
         let mut meta = self.inner.meta.borrow_mut();
@@ -263,25 +263,30 @@ impl PageCache {
             .data
             .try_borrow()
             .map_err(|_| PageCacheError::PageImmutableBorrowConflict { page_id })?;
-        let flush_lsn = frame.lsn.get().max(page_lsn(&page));
-        self.inner.runtime.flush_wal_through(flush_lsn)?;
+        self.inner
+            .runtime
+            .flush_wal_through(frame.lsn.get())
+            .map_err(|err| PageCacheError::Transaction(Box::new(err)))?;
         self.inner.runtime.write_page(page_id, &page)?;
         frame.dirty.set(false);
         Ok(())
     }
 
-    pub(crate) fn restore_rollback_pages(&self, undo_pages: Vec<PageUndo>) -> PageCacheResult<()> {
-        for undo in undo_pages {
-            let pin = self.fetch_page(undo.page_id)?;
+    pub(crate) fn restore_rollback_pages(
+        &self,
+        restore_pages: Vec<PageRestore>,
+    ) -> PageCacheResult<()> {
+        for restore in restore_pages {
+            let pin = self.fetch_page(restore.page_id)?;
             let frame = &self.inner.frames[pin.frame_id];
             {
                 let mut data = frame.data.try_borrow_mut().map_err(|_| {
-                    PageCacheError::PageMutableBorrowConflict { page_id: undo.page_id }
+                    PageCacheError::PageMutableBorrowConflict { page_id: restore.page_id }
                 })?;
-                *data = undo.before;
+                *data = restore.image;
             }
             frame.dirty.set(true);
-            frame.lsn.set(frame.lsn.get().max(undo.lsn));
+            frame.lsn.set(restore.wal_flush_lsn);
         }
         Ok(())
     }
@@ -442,7 +447,7 @@ impl Drop for PageWriteGuard<'_> {
                 self.frame.lsn.set(update.lsn);
             }
             Ok(None) => {
-                self.frame.lsn.set(self.frame.lsn.get().max(page_lsn(&self.page)));
+                self.frame.lsn.set(ZERO_LSN);
             }
             Err(_) => {
                 *self.page = self.before;
@@ -461,14 +466,12 @@ mod tests {
 
     use super::*;
     use crate::core::disk_manager::DiskManager;
-    use crate::core::log_manager::{
-        LogManagerFlushError, LogRecord, LogRecordKind, OwnedLogRecordKind,
-        read_log_record_kinds_for_test,
-    };
+    use crate::core::log_manager::{OwnedLogRecordKind, read_log_record_kinds_for_test};
     use crate::core::page;
     use crate::core::page::format::PageKind;
     use crate::core::page::{Leaf, Page, Write};
     use crate::core::storage_runtime::StorageRuntime;
+    use crate::core::transaction_runtime::TransactionRuntime;
 
     /// Generates a deterministic page payload from a seed byte.
     fn page_with_pattern(seed: u8) -> [u8; PAGE_SIZE] {
@@ -516,14 +519,6 @@ mod tests {
         let mut page = [0u8; PAGE_SIZE];
         disk_manager.read_page(page_id, &mut page).unwrap();
         page
-    }
-
-    fn append_wal_through(runtime: &StorageRuntime, target_lsn: Lsn) {
-        for txn_id in 1..=target_lsn {
-            runtime
-                .append_log_transaction(txn_id, &[LogRecord { txn_id, kind: LogRecordKind::Begin }])
-                .unwrap();
-        }
     }
 
     #[test]
@@ -876,10 +871,9 @@ mod tests {
     }
 
     #[test]
-    fn flush_page_forces_wal_through_page_lsn_before_write() {
+    fn flush_page_ignores_lsn_loaded_from_disk() {
         let page = formatted_page_with_lsn(15, 7);
         let (file, runtime) = create_disk_with_pages(&[page]);
-        append_wal_through(&runtime, 7);
         let cache = PageCache::new(runtime, 1).unwrap();
 
         {
@@ -895,11 +889,10 @@ mod tests {
     }
 
     #[test]
-    fn dirty_page_eviction_forces_wal_through_page_lsn_before_write() {
+    fn dirty_page_eviction_ignores_lsn_loaded_from_disk() {
         let page0 = formatted_page_with_lsn(1, 13);
         let page1 = page_with_pattern(2);
         let (file, runtime) = create_disk_with_pages(&[page0, page1]);
-        append_wal_through(&runtime, 13);
         let cache = PageCache::new(runtime, 1).unwrap();
 
         {
@@ -916,11 +909,10 @@ mod tests {
     }
 
     #[test]
-    fn flush_all_forces_wal_through_each_dirty_page_lsn_before_each_write() {
+    fn flush_all_ignores_lsn_loaded_from_disk() {
         let page0 = formatted_page_with_lsn(4, 21);
         let page1 = formatted_page_with_lsn(5, 34);
         let (file, runtime) = create_disk_with_pages(&[page0, page1]);
-        append_wal_through(&runtime, 34);
         let cache = PageCache::new(runtime, 2).unwrap();
 
         {
@@ -944,28 +936,176 @@ mod tests {
     }
 
     #[test]
-    fn wal_flush_failure_prevents_page_write_and_leaves_frame_dirty() {
-        let page = formatted_page_with_lsn(15, 55);
+    fn transactional_page_flush_appends_and_flushes_pending_wal_before_write() {
+        let page = formatted_page_with_lsn(15, ZERO_LSN);
         let (file, runtime) = create_disk_with_pages(&[page]);
-        let cache = PageCache::new(runtime, 1).unwrap();
+        let cache = PageCache::new(Rc::clone(&runtime), 1).unwrap();
+
+        let txn_id = runtime.begin_transaction().unwrap();
 
         {
             let guard = cache.fetch_page(0).unwrap();
             guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 177;
         }
 
+        cache.flush_page(0).unwrap();
+
+        let flushed_page = read_disk_page(file.path(), 0);
+        assert_eq!(flushed_page[PAGE_SIZE - 1], 177);
+        assert!(!cache.inner.frames[0].dirty.get());
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 0 }),
+            ]
+        );
+    }
+
+    #[test]
+    fn transactional_page_flush_after_repeated_update_appends_one_latest_page_update() {
+        let page = formatted_page_with_lsn(15, ZERO_LSN);
+        let (file, runtime) = create_disk_with_pages(&[page]);
+        let cache = PageCache::new(Rc::clone(&runtime), 1).unwrap();
+
+        let txn_id = runtime.begin_transaction().unwrap();
+
+        {
+            let guard = cache.fetch_page(0).unwrap();
+            guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 177;
+        }
+        {
+            let guard = cache.fetch_page(0).unwrap();
+            guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 222;
+        }
+
+        cache.flush_page(0).unwrap();
+
+        let flushed_page = read_disk_page(file.path(), 0);
+        assert_eq!(flushed_page[PAGE_SIZE - 1], 222);
+        assert!(!cache.inner.frames[0].dirty.get());
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 0 }),
+            ]
+        );
+    }
+
+    #[test]
+    fn wal_flush_failure_prevents_transactional_page_write_and_leaves_frame_dirty() {
+        let page = formatted_page_with_lsn(15, ZERO_LSN);
+        let (file, runtime) = create_disk_with_pages(&[page]);
+        let cache = PageCache::new(Rc::clone(&runtime), 1).unwrap();
+
+        runtime.begin_transaction().unwrap();
+        {
+            let guard = cache.fetch_page(0).unwrap();
+            guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 177;
+        }
+        runtime.fail_next_wal_flush_for_test();
+
         let result = cache.flush_page(0);
 
-        assert!(matches!(
-            result,
-            Err(PageCacheError::WalFlush(LogManagerFlushError::LsnNotAppended {
-                requested_lsn: 55,
-                highest_appended_lsn: None,
-            }))
-        ));
+        assert!(matches!(result, Err(PageCacheError::Transaction(_))));
         let page_on_disk = read_disk_page(file.path(), 0);
         assert_eq!(page_on_disk[PAGE_SIZE - 1], page[PAGE_SIZE - 1]);
         assert!(cache.inner.frames[0].dirty.get());
+    }
+
+    #[test]
+    fn rollback_without_forced_wal_flush_restores_page_and_drops_buffered_records() {
+        let page = formatted_page_with_lsn(15, ZERO_LSN);
+        let (file, runtime) = create_disk_with_pages(&[page]);
+        let cache = PageCache::new(Rc::clone(&runtime), 1).unwrap();
+
+        let txn_id = runtime.begin_transaction().unwrap();
+        {
+            let guard = cache.fetch_page(0).unwrap();
+            guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 177;
+        }
+
+        let rollback = runtime.prepare_rollback_pages(txn_id).unwrap();
+        cache.restore_rollback_pages(rollback.pages).unwrap();
+        cache.flush_all().unwrap();
+        runtime.sync_database_file().unwrap();
+        runtime.finish_rollback(txn_id).unwrap();
+
+        assert_eq!(read_disk_page(file.path(), 0), page);
+        assert_eq!(read_log_record_kinds_for_test(file.path()), []);
+    }
+
+    #[test]
+    fn rollback_after_steal_flush_restores_page_and_writes_rollback_record() {
+        let page = formatted_page_with_lsn(15, ZERO_LSN);
+        let (file, runtime) = create_disk_with_pages(&[page]);
+        let cache = PageCache::new(Rc::clone(&runtime), 1).unwrap();
+
+        let txn_id = runtime.begin_transaction().unwrap();
+        {
+            let guard = cache.fetch_page(0).unwrap();
+            guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 177;
+        }
+        cache.flush_page(0).unwrap();
+
+        let rollback = runtime.prepare_rollback_pages(txn_id).unwrap();
+        cache.restore_rollback_pages(rollback.pages).unwrap();
+        cache.flush_all().unwrap();
+        runtime.sync_database_file().unwrap();
+        runtime.finish_rollback(txn_id).unwrap();
+
+        assert_eq!(read_disk_page(file.path(), 0), page);
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 0 }),
+                (txn_id, OwnedLogRecordKind::Rollback),
+            ]
+        );
+    }
+
+    #[test]
+    fn prepared_rollback_keeps_pending_wal_available_for_cache_eviction() {
+        let pages = [
+            formatted_page_with_lsn(10, ZERO_LSN),
+            formatted_page_with_lsn(20, ZERO_LSN),
+            formatted_page_with_lsn(30, ZERO_LSN),
+        ];
+        let (file, runtime) = create_disk_with_pages(&pages);
+        let cache = PageCache::new(Rc::clone(&runtime), 2).unwrap();
+        let transactions = TransactionRuntime::new(Rc::clone(&runtime), cache.clone());
+
+        let txn_id = transactions.begin_transaction().unwrap();
+        {
+            let guard = cache.fetch_page(0).unwrap();
+            guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 100;
+        }
+        {
+            let guard = cache.fetch_page(1).unwrap();
+            guard.write().unwrap().page_mut()[PAGE_SIZE - 1] = 110;
+        }
+
+        let rollback = runtime.prepare_rollback_pages(txn_id).unwrap();
+        {
+            let _guard = cache.fetch_page(2).unwrap();
+        }
+        cache.restore_rollback_pages(rollback.pages).unwrap();
+        cache.flush_all().unwrap();
+        runtime.sync_database_file().unwrap();
+        runtime.finish_rollback(txn_id).unwrap();
+
+        assert_eq!(read_disk_page(file.path(), 0), pages[0]);
+        assert_eq!(read_disk_page(file.path(), 1), pages[1]);
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 0 }),
+                (txn_id, OwnedLogRecordKind::Rollback),
+            ]
+        );
     }
 
     #[test]

--- a/src/core/recovery.rs
+++ b/src/core/recovery.rs
@@ -37,10 +37,11 @@ pub(crate) fn recover_from_wal(
     let max_txn_id = scan.max_txn_id;
     if scan.records.is_empty() {
         if max_txn_id > 0 || scan.truncated_tail {
-            truncate_wal(path)?;
+            truncate_wal(path, scan.last_assigned_lsn)?;
         }
         return Ok(RecoveryResult { max_txn_id });
     }
+    let last_assigned_lsn = scan.last_assigned_lsn;
 
     let mut transactions: HashMap<TxnId, TransactionRecovery> = HashMap::new();
     let mut committed_page_allocs = Vec::new();
@@ -98,7 +99,7 @@ pub(crate) fn recover_from_wal(
     }
 
     disk.sync()?;
-    truncate_wal(path)?;
+    truncate_wal(path, last_assigned_lsn)?;
     Ok(RecoveryResult { max_txn_id })
 }
 
@@ -151,6 +152,8 @@ mod tests {
         page::format::PageKind,
         storage_runtime::StorageRuntime,
     };
+
+    const WAL_FILE_HEADER_LEN: u64 = 24;
 
     fn formatted_page(seed: u8, lsn: Lsn) -> [u8; PAGE_SIZE] {
         let mut page = [seed; PAGE_SIZE];
@@ -376,8 +379,87 @@ mod tests {
                 .unwrap();
 
         assert_eq!(read_disk_page(file.path(), 0), after);
-        assert_eq!(wal_len(file.path()), 0);
+        assert_eq!(wal_len(file.path()), WAL_FILE_HEADER_LEN);
         assert_eq!(runtime.begin_transaction().unwrap(), 42);
+    }
+
+    #[test]
+    fn recovery_redoes_update_after_wal_truncation_despite_stale_page_lsn() {
+        let file = NamedTempFile::new().unwrap();
+        let initial = formatted_page(1, ZERO_LSN);
+        let first_update = formatted_page(2, 2);
+        let second_update = formatted_page(3, 3);
+        let old_wal_update = formatted_page(4, 4);
+        let new_wal_update = formatted_page(5, 2);
+
+        {
+            let mut disk = DiskManager::new(file.path()).unwrap();
+            disk.ensure_page_exists(0).unwrap();
+            disk.write_page(0, &initial).unwrap();
+        }
+
+        append_transaction(
+            file.path(),
+            1,
+            &[
+                LogRecord { txn_id: 1, kind: LogRecordKind::Begin },
+                LogRecord {
+                    txn_id: 1,
+                    kind: LogRecordKind::PageUpdate {
+                        page_id: 0,
+                        redo_data: &first_update,
+                        undo_data: &initial,
+                    },
+                },
+                LogRecord {
+                    txn_id: 1,
+                    kind: LogRecordKind::PageUpdate {
+                        page_id: 0,
+                        redo_data: &second_update,
+                        undo_data: &first_update,
+                    },
+                },
+                LogRecord {
+                    txn_id: 1,
+                    kind: LogRecordKind::PageUpdate {
+                        page_id: 0,
+                        redo_data: &old_wal_update,
+                        undo_data: &second_update,
+                    },
+                },
+                LogRecord { txn_id: 1, kind: LogRecordKind::Commit },
+            ],
+        );
+
+        {
+            let mut disk = DiskManager::new(file.path()).unwrap();
+            recover_from_wal(file.path(), &mut disk).unwrap();
+        }
+
+        assert_eq!(read_disk_page(file.path(), 0), old_wal_update);
+        assert_eq!(wal_len(file.path()), WAL_FILE_HEADER_LEN);
+
+        append_transaction(
+            file.path(),
+            2,
+            &[
+                LogRecord { txn_id: 2, kind: LogRecordKind::Begin },
+                LogRecord {
+                    txn_id: 2,
+                    kind: LogRecordKind::PageUpdate {
+                        page_id: 0,
+                        redo_data: &new_wal_update,
+                        undo_data: &old_wal_update,
+                    },
+                },
+                LogRecord { txn_id: 2, kind: LogRecordKind::Commit },
+            ],
+        );
+
+        let mut disk = DiskManager::new(file.path()).unwrap();
+        recover_from_wal(file.path(), &mut disk).unwrap();
+
+        assert_eq!(read_disk_page(file.path(), 0), new_wal_update);
     }
 
     #[test]

--- a/src/core/storage_runtime.rs
+++ b/src/core/storage_runtime.rs
@@ -4,9 +4,12 @@ use crate::core::{
     PAGE_SIZE, PageId,
     disk_manager::DiskManager,
     error::{DiskManagerError, StorageResult},
-    log_manager::{LogManager, LogManagerError, LogManagerFlushError, LogRecord, Lsn, TxnId},
+    log_manager::{LogManager, Lsn, TxnId},
     recovery::recover_from_wal,
-    transaction_manager::{LoggedPageUpdate, PageUndo, TransactionManager, TransactionSavepoint},
+    transaction_manager::{
+        LoggedPageUpdate, PageRestore, TransactionManager, TransactionRollback,
+        TransactionSavepoint,
+    },
 };
 
 /// Shared concrete storage runtime for database pages and the write-ahead log.
@@ -47,7 +50,7 @@ impl StorageRuntime {
     }
 
     pub(crate) fn record_page_alloc(&self, page_id: PageId) -> StorageResult<Option<Lsn>> {
-        self.transactions.borrow_mut().record_page_alloc(&mut self.log.borrow_mut(), page_id)
+        self.transactions.borrow_mut().record_page_alloc(page_id)
     }
 
     pub(crate) fn read_page(
@@ -70,21 +73,18 @@ impl StorageRuntime {
         self.disk.borrow().sync()
     }
 
-    pub(crate) fn flush_wal_through(&self, lsn: Lsn) -> Result<(), LogManagerFlushError> {
-        self.log.borrow_mut().flush_through(lsn)
-    }
-
-    pub(crate) fn append_log_transaction<'a>(
-        &self,
-        txn_id: TxnId,
-        records: &[LogRecord<'a>],
-    ) -> Result<Lsn, LogManagerError> {
-        self.log.borrow_mut().append_transaction(txn_id, records)
+    pub(crate) fn flush_wal_through(&self, lsn: Lsn) -> StorageResult<()> {
+        let mut log = self.log.borrow_mut();
+        self.transactions.borrow_mut().append_pending_through(&mut log, lsn)?;
+        log.flush_through(lsn)?;
+        Ok(())
     }
 
     #[cfg(test)]
     pub(crate) fn force_next_lsn_exhausted_for_test(&self) {
-        self.log.borrow_mut().force_next_lsn_exhausted_for_test();
+        if !self.transactions.borrow_mut().force_next_lsn_exhausted_for_test() {
+            self.log.borrow_mut().force_next_lsn_exhausted_for_test();
+        }
     }
 
     #[cfg(test)]
@@ -102,12 +102,7 @@ impl StorageRuntime {
         before: &[u8; PAGE_SIZE],
         after: &[u8; PAGE_SIZE],
     ) -> StorageResult<Option<LoggedPageUpdate>> {
-        let result = self.transactions.borrow_mut().record_page_update(
-            &mut self.log.borrow_mut(),
-            page_id,
-            before,
-            after,
-        );
+        let result = self.transactions.borrow_mut().record_page_update(page_id, before, after);
         if result.is_err() {
             self.transactions.borrow_mut().record_failure();
         }
@@ -137,12 +132,15 @@ impl StorageRuntime {
     pub(crate) fn rollback_to_savepoint(
         &self,
         savepoint: TransactionSavepoint,
-    ) -> StorageResult<Vec<PageUndo>> {
-        self.transactions.borrow_mut().rollback_to_savepoint(&mut self.log.borrow_mut(), savepoint)
+    ) -> StorageResult<Vec<PageRestore>> {
+        self.transactions.borrow_mut().rollback_to_savepoint(savepoint)
     }
 
-    pub(crate) fn take_rollback_pages(&self, txn_id: TxnId) -> StorageResult<Vec<PageUndo>> {
-        self.transactions.borrow_mut().take_rollback_pages(txn_id)
+    pub(crate) fn prepare_rollback_pages(
+        &self,
+        txn_id: TxnId,
+    ) -> StorageResult<TransactionRollback> {
+        self.transactions.borrow_mut().prepare_rollback_pages(txn_id)
     }
 
     pub(crate) fn finish_rollback(&self, txn_id: TxnId) -> StorageResult<()> {

--- a/src/core/transaction_manager.rs
+++ b/src/core/transaction_manager.rs
@@ -7,6 +7,8 @@
 //! commits. Rollback uses the in-memory undo images accumulated here; crash
 //! recovery uses the durable WAL records written by [`LogManager`].
 
+use std::collections::HashMap;
+
 use crate::core::{
     PAGE_SIZE, PageId,
     error::{InternalError, InvariantViolation, StorageError, StorageResult},
@@ -82,6 +84,7 @@ struct ActiveTransaction {
     txn_id: TxnId,
     last_lsn: Lsn,
     pending_records: Vec<PendingLogRecord>,
+    pending_page_updates: HashMap<PageId, usize>,
     undo_pages: Vec<PageUndo>,
     poisoned: bool,
 }
@@ -133,6 +136,7 @@ impl TransactionManager {
                 kind: PendingLogRecordKind::Begin,
                 appended: false,
             }],
+            pending_page_updates: HashMap::new(),
             undo_pages: Vec::new(),
             poisoned: false,
         });
@@ -187,6 +191,30 @@ impl TransactionManager {
             return Ok(None);
         };
 
+        if let Some(&pending_record_index) = active.pending_page_updates.get(&page_id) {
+            let record = &mut active.pending_records[pending_record_index];
+            if let PendingLogRecordKind::PageUpdate { redo_data, .. } = &mut record.kind {
+                let mut redo = *after;
+                stamp_page_lsn(&mut redo, record.lsn);
+                **redo_data = redo;
+                active.undo_pages.push(PageUndo {
+                    page_id,
+                    before: *before,
+                    after: redo,
+                    lsn: record.lsn,
+                    pending_record_index,
+                });
+                return Ok(Some(LoggedPageUpdate { lsn: record.lsn, redo }));
+            }
+
+            active.poisoned = true;
+            return Err(invariant(InvariantViolation::WalLog {
+                message: format!(
+                    "pending page-update index {pending_record_index} for page {page_id} did not point to a PageUpdate record"
+                ),
+            }));
+        }
+
         let lsn = match next_lsn(active.last_lsn) {
             Ok(lsn) => lsn,
             Err(err) => {
@@ -215,6 +243,7 @@ impl TransactionManager {
             lsn,
             pending_record_index,
         });
+        active.pending_page_updates.insert(page_id, pending_record_index);
         Ok(Some(LoggedPageUpdate { lsn, redo }))
     }
 
@@ -270,6 +299,17 @@ impl TransactionManager {
 
         for record in &mut active.pending_records[start..end] {
             record.appended = true;
+        }
+        for pending_record_index in start..end {
+            if let PendingLogRecordKind::PageUpdate { page_id, .. } =
+                &active.pending_records[pending_record_index].kind
+                && active
+                    .pending_page_updates
+                    .get(page_id)
+                    .is_some_and(|index| *index == pending_record_index)
+            {
+                active.pending_page_updates.remove(page_id);
+            }
         }
         Ok(())
     }
@@ -393,6 +433,7 @@ impl TransactionManager {
             };
             let mut redo = undo.before;
             stamp_page_lsn(&mut redo, lsn);
+            active.pending_page_updates.remove(&undo.page_id);
             active.pending_records.push(PendingLogRecord {
                 lsn,
                 kind: PendingLogRecordKind::PageUpdate {
@@ -555,7 +596,10 @@ mod tests {
     use super::*;
     use crate::core::{
         error::{InternalError, InvariantViolation},
-        log_manager::{LogManager, OwnedLogRecordKind, read_log_record_kinds_for_test},
+        log_manager::{
+            LogManager, OwnedLogRecordKind, RecoveryLogRecordKind, read_log_record_kinds_for_test,
+            read_recovery_log,
+        },
     };
 
     #[test]
@@ -597,7 +641,87 @@ mod tests {
     }
 
     #[test]
-    fn pending_page_updates_append_through_requested_lsn() {
+    fn repeated_page_updates_commit_as_one_page_update_record() {
+        let file = NamedTempFile::new().unwrap();
+        let mut log = LogManager::new(file.path()).unwrap();
+        let mut transactions = TransactionManager::new(0);
+        let before = [0; PAGE_SIZE];
+        let after_first = [1; PAGE_SIZE];
+        let after_second = [2; PAGE_SIZE];
+
+        let txn_id = transactions.begin(&mut log).unwrap();
+        let first_update = transactions.record_page_update(7, &before, &after_first).unwrap();
+        let second_update =
+            transactions.record_page_update(7, &after_first, &after_second).unwrap();
+        transactions.commit(&mut log, txn_id).unwrap();
+
+        assert_eq!(first_update.as_ref().map(|update| update.lsn), Some(2));
+        assert_eq!(second_update.as_ref().map(|update| update.lsn), Some(2));
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
+                (txn_id, OwnedLogRecordKind::Commit),
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesced_page_update_keeps_first_undo_and_latest_redo_image() {
+        let file = NamedTempFile::new().unwrap();
+        let mut log = LogManager::new(file.path()).unwrap();
+        let mut transactions = TransactionManager::new(0);
+        let before = [0; PAGE_SIZE];
+        let after_first = [1; PAGE_SIZE];
+        let after_second = [2; PAGE_SIZE];
+
+        let txn_id = transactions.begin(&mut log).unwrap();
+        transactions.record_page_update(7, &before, &after_first).unwrap();
+        transactions.record_page_update(7, &after_first, &after_second).unwrap();
+        transactions.commit(&mut log, txn_id).unwrap();
+
+        let scan = read_recovery_log(file.path()).unwrap();
+        match &scan.records[1].kind {
+            RecoveryLogRecordKind::PageUpdate { page_id, redo_data, undo_data } => {
+                assert_eq!(*page_id, 7);
+                assert_eq!(undo_data.as_ref(), &before);
+                assert_eq!(redo_data.as_ref(), &after_second);
+            }
+            kind => panic!("unexpected record kind: {kind:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_page_updates_coalesce_per_page_without_reordering() {
+        let file = NamedTempFile::new().unwrap();
+        let mut log = LogManager::new(file.path()).unwrap();
+        let mut transactions = TransactionManager::new(0);
+        let before_a = [0; PAGE_SIZE];
+        let after_a_first = [1; PAGE_SIZE];
+        let before_b = [10; PAGE_SIZE];
+        let after_b = [11; PAGE_SIZE];
+        let after_a_second = [2; PAGE_SIZE];
+
+        let txn_id = transactions.begin(&mut log).unwrap();
+        transactions.record_page_update(7, &before_a, &after_a_first).unwrap();
+        transactions.record_page_update(8, &before_b, &after_b).unwrap();
+        transactions.record_page_update(7, &after_a_first, &after_a_second).unwrap();
+        transactions.commit(&mut log, txn_id).unwrap();
+
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 8 }),
+                (txn_id, OwnedLogRecordKind::Commit),
+            ]
+        );
+    }
+
+    #[test]
+    fn page_update_after_append_creates_new_record_for_same_page() {
         let file = NamedTempFile::new().unwrap();
         let mut log = LogManager::new(file.path()).unwrap();
         let mut transactions = TransactionManager::new(0);
@@ -640,7 +764,7 @@ mod tests {
 
         assert_eq!(restore_pages.len(), 1);
         assert_eq!(restore_pages[0].page_id, 7);
-        assert_eq!(restore_pages[0].wal_flush_lsn, 4);
+        assert_eq!(restore_pages[0].wal_flush_lsn, 3);
         assert_eq!(read_log_record_kinds_for_test(file.path()), []);
 
         transactions.commit(&mut log, txn_id).unwrap();
@@ -649,7 +773,6 @@ mod tests {
             read_log_record_kinds_for_test(file.path()),
             [
                 (txn_id, OwnedLogRecordKind::Begin),
-                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
                 (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
                 (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
                 (txn_id, OwnedLogRecordKind::Commit),

--- a/src/core/transaction_manager.rs
+++ b/src/core/transaction_manager.rs
@@ -2,32 +2,47 @@
 //!
 //! The storage layer currently allows at most one active transaction per
 //! [`TransactionManager`]. While that transaction is active, page allocations
-//! and full-page updates are recorded in the write-ahead log before the dirty
-//! page is allowed to reach the database file. Rollback uses the in-memory undo
-//! images accumulated here; crash recovery uses the durable WAL records written
-//! by [`LogManager`].
+//! and full-page updates are assigned LSNs immediately, but WAL bytes are only
+//! appended when the write-ahead rule requires them or when the transaction
+//! commits. Rollback uses the in-memory undo images accumulated here; crash
+//! recovery uses the durable WAL records written by [`LogManager`].
 
 use crate::core::{
     PAGE_SIZE, PageId,
     error::{InternalError, InvariantViolation, StorageError, StorageResult},
-    log_manager::{LogManager, LogRecordKind, Lsn, TxnId, ZERO_LSN},
+    log_manager::{LogManager, LogManagerError, LogRecord, LogRecordKind, Lsn, TxnId, ZERO_LSN},
     page,
 };
 
-/// Full-page image needed to undo one page update during an explicit rollback.
-///
-/// Entries are collected in update order and later returned in reverse LSN
-/// order so a rollback restores the newest version of each page first.
 #[derive(Debug, Clone)]
-pub(crate) struct PageUndo {
+struct PageUndo {
+    /// Page to restore.
+    page_id: PageId,
+    /// Full page image captured before the logged update.
+    before: [u8; PAGE_SIZE],
+    /// Full page image installed by the logged update.
+    after: [u8; PAGE_SIZE],
+    /// LSN assigned to the update that this image undoes.
+    lsn: Lsn,
+    /// Index of the matching pending WAL record.
+    pending_record_index: usize,
+}
+
+/// Page image to install while rolling back in memory.
+#[derive(Debug, Clone)]
+pub(crate) struct PageRestore {
     /// Page to restore.
     pub(crate) page_id: PageId,
-    /// Full page image captured before the logged update.
-    pub(crate) before: [u8; PAGE_SIZE],
-    /// Full page image installed by the logged update.
-    pub(crate) after: [u8; PAGE_SIZE],
-    /// LSN assigned to the update that this image undoes.
-    pub(crate) lsn: Lsn,
+    /// Full page image to install.
+    pub(crate) image: [u8; PAGE_SIZE],
+    /// WAL dependency that must be durable before this restored image is written.
+    pub(crate) wal_flush_lsn: Lsn,
+}
+
+/// Physical rollback work for the active transaction.
+#[derive(Debug, Clone)]
+pub(crate) struct TransactionRollback {
+    pub(crate) pages: Vec<PageRestore>,
 }
 
 /// In-memory checkpoint for rolling back one statement inside a transaction.
@@ -52,8 +67,8 @@ pub(crate) struct LoggedPageUpdate {
 /// Tracks the single active transaction and its rollback state.
 ///
 /// `TransactionManager` is deliberately small: it assigns monotonically
-/// increasing transaction ids, appends transaction-control records, remembers
-/// in-memory undo images for explicit rollback, and marks the active
+/// increasing transaction ids, buffers or appends transaction-control records,
+/// remembers in-memory undo images for explicit rollback, and marks the active
 /// transaction as poisoned after an error that may have left its effects only
 /// partially logged.
 #[derive(Debug)]
@@ -66,8 +81,23 @@ pub(crate) struct TransactionManager {
 struct ActiveTransaction {
     txn_id: TxnId,
     last_lsn: Lsn,
+    pending_records: Vec<PendingLogRecord>,
     undo_pages: Vec<PageUndo>,
     poisoned: bool,
+}
+
+#[derive(Debug)]
+struct PendingLogRecord {
+    lsn: Lsn,
+    kind: PendingLogRecordKind,
+    appended: bool,
+}
+
+#[derive(Debug)]
+enum PendingLogRecordKind {
+    Begin,
+    PageUpdate { page_id: PageId, redo_data: Box<[u8; PAGE_SIZE]>, undo_data: Box<[u8; PAGE_SIZE]> },
+    PageAlloc { page_id: PageId },
 }
 
 impl TransactionManager {
@@ -80,7 +110,7 @@ impl TransactionManager {
         Self { max_txn_id, active: None }
     }
 
-    /// Begins the only active transaction and writes its `Begin` WAL record.
+    /// Begins the only active transaction and buffers its `Begin` WAL record.
     ///
     /// Returns an invariant violation if another transaction is already active
     /// or if the transaction-id counter is exhausted.
@@ -93,11 +123,16 @@ impl TransactionManager {
             .max_txn_id
             .checked_add(1)
             .ok_or_else(|| invariant(InvariantViolation::TransactionIdExhausted))?;
-        let lsn = log.append_record(txn_id, LogRecordKind::Begin)?;
+        let lsn = log.next_lsn()?;
         self.max_txn_id = txn_id;
         self.active = Some(ActiveTransaction {
             txn_id,
             last_lsn: lsn,
+            pending_records: vec![PendingLogRecord {
+                lsn,
+                kind: PendingLogRecordKind::Begin,
+                appended: false,
+            }],
             undo_pages: Vec::new(),
             poisoned: false,
         });
@@ -110,40 +145,40 @@ impl TransactionManager {
     /// Allocated page ids are currently not reclaimed during rollback; the WAL
     /// record exists so crash recovery can make committed allocations visible
     /// before replaying their updates.
-    pub(crate) fn record_page_alloc(
-        &mut self,
-        log: &mut LogManager,
-        page_id: PageId,
-    ) -> StorageResult<Option<Lsn>> {
+    pub(crate) fn record_page_alloc(&mut self, page_id: PageId) -> StorageResult<Option<Lsn>> {
         // Allocated page ids are not reclaimed on rollback until a freelist exists.
         let Some(active) = self.active.as_mut() else {
             return Ok(None);
         };
-        let lsn = match log.append_record(active.txn_id, LogRecordKind::PageAlloc { page_id }) {
+        let lsn = match next_lsn(active.last_lsn) {
             Ok(lsn) => lsn,
             Err(err) => {
                 active.poisoned = true;
-                return Err(err.into());
+                return Err(err);
             }
         };
+        active.pending_records.push(PendingLogRecord {
+            lsn,
+            kind: PendingLogRecordKind::PageAlloc { page_id },
+            appended: false,
+        });
         active.last_lsn = lsn;
         Ok(Some(lsn))
     }
 
-    /// Writes a full-page update record for the active transaction, if any.
+    /// Buffers a full-page update record for the active transaction, if any.
     ///
     /// When no transaction is active, the update is not logged and `Ok(None)`
     /// is returned. With an active transaction, this method reserves the next
-    /// LSN, stamps it into the redo image for current B+-tree pages, appends a
+    /// LSN, stamps it into the redo image for current B+-tree pages, buffers a
     /// `PageUpdate` WAL record containing both redo and undo full-page images,
     /// and remembers the undo image for explicit rollback.
     ///
-    /// If LSN reservation or WAL append fails, the active transaction is marked
+    /// If LSN reservation or WAL append later fails, the active transaction is marked
     /// poisoned. A poisoned transaction cannot commit because the caller can no
     /// longer prove that all page effects were logged.
     pub(crate) fn record_page_update(
         &mut self,
-        log: &mut LogManager,
         page_id: PageId,
         before: &[u8; PAGE_SIZE],
         after: &[u8; PAGE_SIZE],
@@ -152,30 +187,91 @@ impl TransactionManager {
             return Ok(None);
         };
 
-        let lsn = match log.next_lsn() {
+        let lsn = match next_lsn(active.last_lsn) {
             Ok(lsn) => lsn,
             Err(err) => {
                 active.poisoned = true;
-                return Err(err.into());
+                return Err(err);
             }
         };
         let mut redo = *after;
         stamp_page_lsn(&mut redo, lsn);
 
-        let appended_lsn = match log.append_record(
-            active.txn_id,
-            LogRecordKind::PageUpdate { page_id, redo_data: &redo, undo_data: before },
-        ) {
+        let pending_record_index = active.pending_records.len();
+        active.pending_records.push(PendingLogRecord {
+            lsn,
+            kind: PendingLogRecordKind::PageUpdate {
+                page_id,
+                redo_data: Box::new(redo),
+                undo_data: Box::new(*before),
+            },
+            appended: false,
+        });
+        active.last_lsn = lsn;
+        active.undo_pages.push(PageUndo {
+            page_id,
+            before: *before,
+            after: redo,
+            lsn,
+            pending_record_index,
+        });
+        Ok(Some(LoggedPageUpdate { lsn, redo }))
+    }
+
+    /// Appends buffered records up to `requested_lsn`, preserving record order.
+    pub(crate) fn append_pending_through(
+        &mut self,
+        log: &mut LogManager,
+        requested_lsn: Lsn,
+    ) -> StorageResult<()> {
+        if requested_lsn == ZERO_LSN {
+            return Ok(());
+        }
+
+        let Some(active) = self.active.as_mut() else {
+            return Ok(());
+        };
+
+        let Some(start) = active.pending_records.iter().position(|record| !record.appended) else {
+            return Ok(());
+        };
+        if active.pending_records[start].lsn > requested_lsn {
+            return Ok(());
+        }
+
+        let mut end = start;
+        while end < active.pending_records.len()
+            && !active.pending_records[end].appended
+            && active.pending_records[end].lsn <= requested_lsn
+        {
+            end += 1;
+        }
+
+        let records = active.pending_records[start..end]
+            .iter()
+            .map(|record| pending_log_record(active.txn_id, record))
+            .collect::<Vec<_>>();
+        let expected_lsn = active.pending_records[end - 1].lsn;
+        let appended_lsn = match log.append_transaction(active.txn_id, &records) {
             Ok(lsn) => lsn,
             Err(err) => {
                 active.poisoned = true;
                 return Err(err.into());
             }
         };
-        debug_assert_eq!(appended_lsn, lsn);
-        active.last_lsn = lsn;
-        active.undo_pages.push(PageUndo { page_id, before: *before, after: redo, lsn });
-        Ok(Some(LoggedPageUpdate { lsn, redo }))
+        if appended_lsn != expected_lsn {
+            active.poisoned = true;
+            return Err(invariant(InvariantViolation::WalLog {
+                message: format!(
+                    "pending WAL append assigned LSN {appended_lsn}, expected {expected_lsn}"
+                ),
+            }));
+        }
+
+        for record in &mut active.pending_records[start..end] {
+            record.appended = true;
+        }
+        Ok(())
     }
 
     /// Marks the active transaction as unsafe to commit.
@@ -218,9 +314,38 @@ impl TransactionManager {
             return Err(invariant(InvariantViolation::TransactionPoisoned { txn_id }));
         }
 
-        let lsn = log.append_record(txn_id, LogRecordKind::Commit)?;
+        let commit_lsn = match next_lsn(active.last_lsn) {
+            Ok(lsn) => lsn,
+            Err(err) => {
+                self.active.as_mut().expect("active transaction exists").poisoned = true;
+                return Err(err);
+            }
+        };
+        let mut records = active
+            .pending_records
+            .iter()
+            .filter(|record| !record.appended)
+            .map(|record| pending_log_record(txn_id, record))
+            .collect::<Vec<_>>();
+        records.push(LogRecord { txn_id, kind: LogRecordKind::Commit });
+        let appended_lsn = match log.append_transaction(txn_id, &records) {
+            Ok(lsn) => lsn,
+            Err(err) => {
+                self.active.as_mut().expect("active transaction exists").poisoned = true;
+                return Err(err.into());
+            }
+        };
+        if appended_lsn != commit_lsn {
+            self.active.as_mut().expect("active transaction exists").poisoned = true;
+            return Err(invariant(InvariantViolation::WalLog {
+                message: format!(
+                    "commit WAL append assigned LSN {appended_lsn}, expected {commit_lsn}"
+                ),
+            }));
+        }
+
         self.active = None;
-        log.flush_through(lsn)?;
+        log.flush_through(commit_lsn)?;
         Ok(())
     }
 
@@ -242,9 +367,8 @@ impl TransactionManager {
     /// these compensating updates in LSN order.
     pub(crate) fn rollback_to_savepoint(
         &mut self,
-        log: &mut LogManager,
         savepoint: TransactionSavepoint,
-    ) -> StorageResult<Vec<PageUndo>> {
+    ) -> StorageResult<Vec<PageRestore>> {
         let active = self.active.as_mut().ok_or_else(no_active_transaction)?;
         if active.txn_id != savepoint.txn_id {
             return Err(transaction_mismatch(active.txn_id, savepoint.txn_id));
@@ -260,36 +384,29 @@ impl TransactionManager {
         let rollback_pages = active.undo_pages[savepoint.undo_len..].to_vec();
         let mut restore_pages = Vec::with_capacity(rollback_pages.len());
         for undo in rollback_pages.into_iter().rev() {
-            let lsn = match log.next_lsn() {
+            let lsn = match next_lsn(active.last_lsn) {
                 Ok(lsn) => lsn,
                 Err(err) => {
                     active.poisoned = true;
-                    return Err(err.into());
+                    return Err(err);
                 }
             };
             let mut redo = undo.before;
             stamp_page_lsn(&mut redo, lsn);
-            let appended_lsn = match log.append_record(
-                active.txn_id,
-                LogRecordKind::PageUpdate {
-                    page_id: undo.page_id,
-                    redo_data: &redo,
-                    undo_data: &undo.after,
-                },
-            ) {
-                Ok(lsn) => lsn,
-                Err(err) => {
-                    active.poisoned = true;
-                    return Err(err.into());
-                }
-            };
-            debug_assert_eq!(appended_lsn, lsn);
-            active.last_lsn = lsn;
-            restore_pages.push(PageUndo {
-                page_id: undo.page_id,
-                before: redo,
-                after: undo.after,
+            active.pending_records.push(PendingLogRecord {
                 lsn,
+                kind: PendingLogRecordKind::PageUpdate {
+                    page_id: undo.page_id,
+                    redo_data: Box::new(redo),
+                    undo_data: Box::new(undo.after),
+                },
+                appended: false,
+            });
+            active.last_lsn = lsn;
+            restore_pages.push(PageRestore {
+                page_id: undo.page_id,
+                image: redo,
+                wal_flush_lsn: lsn,
             });
         }
 
@@ -297,22 +414,39 @@ impl TransactionManager {
         Ok(restore_pages)
     }
 
-    /// Removes the active transaction and returns its undo images for rollback.
+    /// Returns the active transaction's undo images for rollback.
     ///
-    /// The returned vector is ordered from newest update to oldest update. If
-    /// `txn_id` does not match the active transaction, the transaction is put
-    /// back before returning the mismatch error.
-    pub(crate) fn take_rollback_pages(&mut self, txn_id: TxnId) -> StorageResult<Vec<PageUndo>> {
-        let active = self.active.take().ok_or_else(no_active_transaction)?;
+    /// The returned vector is ordered from newest update to oldest update. The
+    /// active transaction stays available while callers restore pages because
+    /// cache eviction during restore may still need to append buffered WAL
+    /// records for dirty transaction pages.
+    pub(crate) fn prepare_rollback_pages(
+        &mut self,
+        txn_id: TxnId,
+    ) -> StorageResult<TransactionRollback> {
+        let active = self.active.as_ref().ok_or_else(no_active_transaction)?;
         if active.txn_id != txn_id {
-            let expected = active.txn_id;
-            self.active = Some(active);
-            return Err(transaction_mismatch(expected, txn_id));
+            return Err(transaction_mismatch(active.txn_id, txn_id));
         }
 
-        let mut undo_pages = active.undo_pages;
-        undo_pages.reverse();
-        Ok(undo_pages)
+        let mut pages = active
+            .undo_pages
+            .iter()
+            .rev()
+            .map(|undo| {
+                let appended = active
+                    .pending_records
+                    .get(undo.pending_record_index)
+                    .is_some_and(|record| record.appended);
+                PageRestore {
+                    page_id: undo.page_id,
+                    image: undo.before,
+                    wal_flush_lsn: if appended { undo.lsn } else { ZERO_LSN },
+                }
+            })
+            .collect::<Vec<_>>();
+        pages.shrink_to_fit();
+        Ok(TransactionRollback { pages })
     }
 
     /// Writes and flushes the `Rollback` record after undo pages reach disk.
@@ -324,9 +458,50 @@ impl TransactionManager {
         log: &mut LogManager,
         txn_id: TxnId,
     ) -> StorageResult<()> {
-        let lsn = log.append_record(txn_id, LogRecordKind::Rollback)?;
-        log.flush_through(lsn)?;
+        let active = self.active.take().ok_or_else(no_active_transaction)?;
+        if active.txn_id != txn_id {
+            let expected = active.txn_id;
+            self.active = Some(active);
+            return Err(transaction_mismatch(expected, txn_id));
+        }
+
+        if active.pending_records.iter().any(|record| record.appended) {
+            let lsn = log.append_record(txn_id, LogRecordKind::Rollback)?;
+            log.flush_through(lsn)?;
+        }
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_next_lsn_exhausted_for_test(&mut self) -> bool {
+        let Some(active) = self.active.as_mut() else {
+            return false;
+        };
+        active.last_lsn = Lsn::MAX;
+        true
+    }
+}
+
+fn next_lsn(current_lsn: Lsn) -> StorageResult<Lsn> {
+    current_lsn.checked_add(1).ok_or_else(|| LogManagerError::LsnExhausted.into())
+}
+
+fn pending_log_record(txn_id: TxnId, record: &PendingLogRecord) -> LogRecord<'_> {
+    LogRecord {
+        txn_id,
+        kind: match &record.kind {
+            PendingLogRecordKind::Begin => LogRecordKind::Begin,
+            PendingLogRecordKind::PageUpdate { page_id, redo_data, undo_data } => {
+                LogRecordKind::PageUpdate {
+                    page_id: *page_id,
+                    redo_data: redo_data.as_ref(),
+                    undo_data: undo_data.as_ref(),
+                }
+            }
+            PendingLogRecordKind::PageAlloc { page_id } => {
+                LogRecordKind::PageAlloc { page_id: *page_id }
+            }
+        },
     }
 }
 
@@ -386,23 +561,25 @@ mod tests {
     #[test]
     fn page_alloc_without_active_transaction_does_not_write_wal() {
         let file = NamedTempFile::new().unwrap();
-        let mut log = LogManager::new(file.path()).unwrap();
+        let _log = LogManager::new(file.path()).unwrap();
         let mut transactions = TransactionManager::new(0);
 
-        let lsn = transactions.record_page_alloc(&mut log, 7).unwrap();
+        let lsn = transactions.record_page_alloc(7).unwrap();
 
         assert_eq!(lsn, None);
         assert_eq!(read_log_record_kinds_for_test(file.path()), []);
     }
 
     #[test]
-    fn page_alloc_with_active_transaction_writes_wal_record() {
+    fn page_alloc_with_active_transaction_buffers_wal_until_commit() {
         let file = NamedTempFile::new().unwrap();
         let mut log = LogManager::new(file.path()).unwrap();
         let mut transactions = TransactionManager::new(0);
 
         let txn_id = transactions.begin(&mut log).unwrap();
-        let alloc_lsn = transactions.record_page_alloc(&mut log, 7).unwrap();
+        let alloc_lsn = transactions.record_page_alloc(7).unwrap();
+
+        assert_eq!(read_log_record_kinds_for_test(file.path()), []);
         transactions.commit(&mut log, txn_id).unwrap();
 
         assert_eq!(txn_id, 1);
@@ -420,6 +597,67 @@ mod tests {
     }
 
     #[test]
+    fn pending_page_updates_append_through_requested_lsn() {
+        let file = NamedTempFile::new().unwrap();
+        let mut log = LogManager::new(file.path()).unwrap();
+        let mut transactions = TransactionManager::new(0);
+        let before = [0; PAGE_SIZE];
+        let after_first = [1; PAGE_SIZE];
+        let after_second = [2; PAGE_SIZE];
+
+        let txn_id = transactions.begin(&mut log).unwrap();
+        transactions.record_page_update(7, &before, &after_first).unwrap();
+        transactions.append_pending_through(&mut log, 2).unwrap();
+        transactions.record_page_update(7, &after_first, &after_second).unwrap();
+        transactions.commit(&mut log, txn_id).unwrap();
+
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
+                (txn_id, OwnedLogRecordKind::Commit),
+            ]
+        );
+    }
+
+    #[test]
+    fn savepoint_rollback_buffers_compensation_record_until_commit() {
+        let file = NamedTempFile::new().unwrap();
+        let mut log = LogManager::new(file.path()).unwrap();
+        let mut transactions = TransactionManager::new(0);
+        let before = [0; PAGE_SIZE];
+        let after_first = [1; PAGE_SIZE];
+        let after_second = [2; PAGE_SIZE];
+
+        let txn_id = transactions.begin(&mut log).unwrap();
+        transactions.record_page_update(7, &before, &after_first).unwrap();
+        let savepoint = transactions.statement_savepoint(txn_id).unwrap();
+        transactions.record_page_update(7, &after_first, &after_second).unwrap();
+
+        let restore_pages = transactions.rollback_to_savepoint(savepoint).unwrap();
+
+        assert_eq!(restore_pages.len(), 1);
+        assert_eq!(restore_pages[0].page_id, 7);
+        assert_eq!(restore_pages[0].wal_flush_lsn, 4);
+        assert_eq!(read_log_record_kinds_for_test(file.path()), []);
+
+        transactions.commit(&mut log, txn_id).unwrap();
+
+        assert_eq!(
+            read_log_record_kinds_for_test(file.path()),
+            [
+                (txn_id, OwnedLogRecordKind::Begin),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
+                (txn_id, OwnedLogRecordKind::PageUpdate { page_id: 7 }),
+                (txn_id, OwnedLogRecordKind::Commit),
+            ]
+        );
+    }
+
+    #[test]
     fn rollback_to_invalid_savepoint_returns_error_without_panicking() {
         let file = NamedTempFile::new().unwrap();
         let mut log = LogManager::new(file.path()).unwrap();
@@ -427,7 +665,7 @@ mod tests {
 
         let txn_id = transactions.begin(&mut log).unwrap();
         let savepoint = TransactionSavepoint { txn_id, undo_len: 1 };
-        let result = transactions.rollback_to_savepoint(&mut log, savepoint);
+        let result = transactions.rollback_to_savepoint(savepoint);
 
         assert!(matches!(
             result,
@@ -450,14 +688,15 @@ mod tests {
         let after = [1; PAGE_SIZE];
 
         let txn_id = transactions.begin(&mut log).unwrap();
-        transactions.record_page_update(&mut log, 7, &before, &after).unwrap();
+        transactions.record_page_update(7, &before, &after).unwrap();
         log.fail_next_flush_for_test();
 
         let result = transactions.commit(&mut log, txn_id);
 
         assert!(result.is_err());
+        assert_eq!(transactions.active_transaction_id(), None);
         assert!(matches!(
-            transactions.take_rollback_pages(txn_id),
+            transactions.prepare_rollback_pages(txn_id),
             Err(StorageError::Internal(InternalError::InvariantViolation(
                 InvariantViolation::NoActiveTransaction
             )))

--- a/src/core/transaction_runtime.rs
+++ b/src/core/transaction_runtime.rs
@@ -54,11 +54,12 @@ impl TransactionRuntime {
     }
 
     pub(crate) fn rollback_transaction(&self, txn_id: TxnId) -> StorageResult<()> {
-        let undo_pages = self.runtime.take_rollback_pages(txn_id)?;
-        self.page_cache.restore_rollback_pages(undo_pages)?;
+        let rollback = self.runtime.prepare_rollback_pages(txn_id)?;
+        self.page_cache.restore_rollback_pages(rollback.pages)?;
         self.page_cache.flush_all()?;
         self.runtime.sync_database_file()?;
-        self.runtime.finish_rollback(txn_id)
+        self.runtime.finish_rollback(txn_id)?;
+        Ok(())
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Summary
- Batch WAL flushes to reduce write amplification and improve transaction throughput
- Update transaction and storage runtime paths to coordinate batched persistence
- Adjust catalog, page cache, and error handling to support the new write flow

## Testing
- Not run (not requested)