### PR TITLE
Refactor rowid primary key handling

### DIFF
--- a/src/core/catalog.rs
+++ b/src/core/catalog.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 use crate::{
-    core::{PageId, RowId, Tuple, TupleRef, Value, ValueRef},
+    core::{CatalogId, PageId, Tuple, TupleRef, Value, ValueRef},
     sql_parser::parser::stmt::{
         create_index::CreateIndexQuery,
         create_table::{ColumnConstraint, ColumnType, CreateTableQuery},
@@ -18,11 +18,11 @@ pub const SYS_INDEXES_ROOT_PAGE_ID: PageId = 2;
 pub const SYS_COLUMNS_ROOT_PAGE_ID: PageId = 3;
 
 /// Stable object id assigned to the `sys_tables` catalog table.
-pub const SYS_TABLES_TABLE_ID: RowId = 1;
+pub const SYS_TABLES_TABLE_ID: CatalogId = 1;
 /// Stable object id assigned to the `sys_indexes` catalog table.
-pub const SYS_INDEXES_TABLE_ID: RowId = 2;
+pub const SYS_INDEXES_TABLE_ID: CatalogId = 2;
 /// Stable object id assigned to the `sys_columns` catalog table.
-pub const SYS_COLUMNS_TABLE_ID: RowId = 3;
+pub const SYS_COLUMNS_TABLE_ID: CatalogId = 3;
 
 const SYS_TABLES_NAME: &str = "sys_tables";
 const SYS_INDEXES_NAME: &str = "sys_indexes";
@@ -128,14 +128,12 @@ pub struct TupleSchema {
 /// Catalog schema for a table B+-tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableSchema {
-    /// Stable row id for this table object in `sys_tables`.
-    pub table_id: RowId,
+    /// Stable id for this table object in `sys_tables`.
+    pub table_id: CatalogId,
     /// Table name.
     pub name: String,
     /// Root page id of the table's B+-tree.
     pub root_page_id: PageId,
-    /// Largest row id allocated for this table.
-    pub last_row_id: RowId,
     /// Schema of table rows stored in the tree values.
     pub row: TupleSchema,
 }
@@ -152,12 +150,12 @@ pub struct IndexColumnSchema {
 /// Catalog schema for a secondary-index B+-tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexSchema {
-    /// Stable row id for this index object in `sys_indexes`.
-    pub index_id: RowId,
+    /// Stable id for this index object in `sys_indexes`.
+    pub index_id: CatalogId,
     /// Index name.
     pub name: String,
     /// Table object id that this index belongs to.
-    pub table_id: RowId,
+    pub table_id: CatalogId,
     /// Root page id of the index B+-tree.
     pub root_page_id: PageId,
     /// Whether duplicate key tuples are rejected.
@@ -170,24 +168,22 @@ pub struct IndexSchema {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableCatalogRow {
     /// Stable table object id.
-    pub table_id: RowId,
+    pub table_id: CatalogId,
     /// Table name.
     pub name: String,
     /// Root page id of the table B+-tree.
     pub root_page_id: PageId,
-    /// Largest row id allocated for this table.
-    pub last_row_id: RowId,
 }
 
 /// Decoded row from `sys_indexes`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexCatalogRow {
     /// Stable index object id.
-    pub index_id: RowId,
+    pub index_id: CatalogId,
     /// Index name.
     pub name: String,
     /// Table object id that this index belongs to.
-    pub table_id: RowId,
+    pub table_id: CatalogId,
     /// Root page id of the index B+-tree.
     pub root_page_id: PageId,
     /// Whether duplicate key tuples are rejected.
@@ -197,12 +193,12 @@ pub struct IndexCatalogRow {
 /// Decoded row from `sys_columns`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnCatalogRow {
-    /// Stable catalog row id for this column record.
-    pub column_id: RowId,
+    /// Stable catalog id for this column record.
+    pub column_id: CatalogId,
     /// Kind of object whose tuple schema owns this column.
     pub object_kind: CatalogObjectKind,
     /// Object id from `sys_tables` or `sys_indexes`.
-    pub object_id: RowId,
+    pub object_id: CatalogId,
     /// Zero-based position of the column in its tuple schema.
     pub ordinal: u64,
     /// Column name.
@@ -214,7 +210,7 @@ pub struct ColumnCatalogRow {
     /// Whether this column participates in the object's primary key.
     pub primary_key: bool,
     /// Source table id for index columns, or `None` for table columns.
-    pub source_table_id: Option<RowId>,
+    pub source_table_id: Option<CatalogId>,
     /// Source table column ordinal for index columns, or `None` for table columns.
     pub source_column_ordinal: Option<u64>,
 }
@@ -243,13 +239,11 @@ pub struct SystemTupleSchema<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SystemTableSchema<'a> {
     /// Stable table object id.
-    pub table_id: RowId,
+    pub table_id: CatalogId,
     /// System table name.
     pub name: &'a str,
     /// Root page id reserved for this system table.
     pub root_page_id: PageId,
-    /// Largest row id allocated while bootstrapping this system table.
-    pub last_row_id: RowId,
     /// Row schema of the system table.
     pub row: SystemTupleSchema<'a>,
 }
@@ -258,24 +252,22 @@ pub struct SystemTableSchema<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SystemTableCatalogRow<'a> {
     /// Stable table object id.
-    pub table_id: RowId,
+    pub table_id: CatalogId,
     /// System table name.
     pub name: &'a str,
     /// Root page id reserved for this system table.
     pub root_page_id: PageId,
-    /// Largest row id allocated while bootstrapping this system table.
-    pub last_row_id: RowId,
 }
 
 /// Borrowed row written to `sys_columns` while bootstrapping the catalog.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SystemColumnCatalogRow<'a> {
-    /// Stable catalog row id for this column record.
-    pub column_id: RowId,
+    /// Stable catalog id for this column record.
+    pub column_id: CatalogId,
     /// Kind of object whose tuple schema owns this column.
     pub object_kind: CatalogObjectKind,
     /// Object id from `sys_tables` or `sys_indexes`.
-    pub object_id: RowId,
+    pub object_id: CatalogId,
     /// Zero-based position of the column in its tuple schema.
     pub ordinal: u64,
     /// Column name.
@@ -287,7 +279,7 @@ pub struct SystemColumnCatalogRow<'a> {
     /// Whether this column participates in the object's primary key.
     pub primary_key: bool,
     /// Source table id for index columns, or `None` for table columns.
-    pub source_table_id: Option<RowId>,
+    pub source_table_id: Option<CatalogId>,
     /// Source table column ordinal for index columns, or `None` for table columns.
     pub source_column_ordinal: Option<u64>,
 }
@@ -332,7 +324,7 @@ impl std::error::Error for CatalogError {}
 impl TableSchema {
     /// Builds a table schema from a parsed `CREATE TABLE` statement.
     pub fn from_create_table(
-        table_id: RowId,
+        table_id: CatalogId,
         root_page_id: PageId,
         query: &CreateTableQuery<'_>,
     ) -> Self {
@@ -340,7 +332,6 @@ impl TableSchema {
             table_id,
             name: query.table_name.to_owned(),
             root_page_id,
-            last_row_id: 0,
             row: TupleSchema::from_create_table_query(query),
         }
     }
@@ -351,7 +342,6 @@ impl TableSchema {
             table_id: self.table_id,
             name: self.name.clone(),
             root_page_id: self.root_page_id,
-            last_row_id: self.last_row_id,
         }
     }
 }
@@ -377,7 +367,7 @@ impl TupleSchema {
 impl IndexSchema {
     /// Builds an index schema from a parsed `CREATE INDEX` statement and source table schema.
     pub fn from_create_index(
-        index_id: RowId,
+        index_id: CatalogId,
         root_page_id: PageId,
         table: &TableSchema,
         query: &CreateIndexQuery<'_>,
@@ -431,21 +421,19 @@ impl TableCatalogRow {
     /// Encodes this catalog row as a storage tuple.
     pub fn encode(&self) -> Tuple {
         Tuple::new(vec![
-            Value::UnsignedInteger(self.table_id),
+            Value::Integer(self.table_id),
             Value::String(self.name.clone()),
             Value::UnsignedInteger(self.root_page_id),
-            Value::UnsignedInteger(self.last_row_id),
         ])
     }
 
     /// Decodes a `sys_tables` storage tuple.
     pub fn decode(tuple: &Tuple) -> Result<Self, CatalogError> {
-        expect_field_count(tuple, 4)?;
+        expect_field_count(tuple, 3)?;
         Ok(Self {
-            table_id: expect_unsigned(tuple, 0)?,
+            table_id: expect_integer(tuple, 0)?,
             name: expect_string(tuple, 1)?.to_owned(),
             root_page_id: expect_unsigned(tuple, 2)?,
-            last_row_id: expect_unsigned(tuple, 3)?,
         })
     }
 }
@@ -454,9 +442,9 @@ impl IndexCatalogRow {
     /// Encodes this catalog row as a storage tuple.
     pub fn encode(&self) -> Tuple {
         Tuple::new(vec![
-            Value::UnsignedInteger(self.index_id),
+            Value::Integer(self.index_id),
             Value::String(self.name.clone()),
-            Value::UnsignedInteger(self.table_id),
+            Value::Integer(self.table_id),
             Value::UnsignedInteger(self.root_page_id),
             Value::Boolean(self.unique),
         ])
@@ -466,9 +454,9 @@ impl IndexCatalogRow {
     pub fn decode(tuple: &Tuple) -> Result<Self, CatalogError> {
         expect_field_count(tuple, 5)?;
         Ok(Self {
-            index_id: expect_unsigned(tuple, 0)?,
+            index_id: expect_integer(tuple, 0)?,
             name: expect_string(tuple, 1)?.to_owned(),
-            table_id: expect_unsigned(tuple, 2)?,
+            table_id: expect_integer(tuple, 2)?,
             root_page_id: expect_unsigned(tuple, 3)?,
             unique: expect_bool(tuple, 4)?,
         })
@@ -479,15 +467,15 @@ impl ColumnCatalogRow {
     /// Encodes this catalog row as a storage tuple.
     pub fn encode(&self) -> Tuple {
         Tuple::new(vec![
-            Value::UnsignedInteger(self.column_id),
+            Value::Integer(self.column_id),
             Value::Integer(self.object_kind.catalog_tag()),
-            Value::UnsignedInteger(self.object_id),
+            Value::Integer(self.object_id),
             Value::UnsignedInteger(self.ordinal),
             Value::String(self.name.clone()),
             Value::Integer(self.data_type.catalog_tag()),
             Value::Boolean(self.nullable),
             Value::Boolean(self.primary_key),
-            optional_unsigned(self.source_table_id),
+            optional_integer(self.source_table_id),
             optional_unsigned(self.source_column_ordinal),
         ])
     }
@@ -496,15 +484,15 @@ impl ColumnCatalogRow {
     pub fn decode(tuple: &Tuple) -> Result<Self, CatalogError> {
         expect_field_count(tuple, 10)?;
         Ok(Self {
-            column_id: expect_unsigned(tuple, 0)?,
+            column_id: expect_integer(tuple, 0)?,
             object_kind: CatalogObjectKind::from_catalog_tag(expect_integer(tuple, 1)?)?,
-            object_id: expect_unsigned(tuple, 2)?,
+            object_id: expect_integer(tuple, 2)?,
             ordinal: expect_unsigned(tuple, 3)?,
             name: expect_string(tuple, 4)?.to_owned(),
             data_type: DataType::from_catalog_tag(expect_integer(tuple, 5)?)?,
             nullable: expect_bool(tuple, 6)?,
             primary_key: expect_bool(tuple, 7)?,
-            source_table_id: expect_optional_unsigned(tuple, 8)?,
+            source_table_id: expect_optional_integer(tuple, 8)?,
             source_column_ordinal: expect_optional_unsigned(tuple, 9)?,
         })
     }
@@ -516,7 +504,6 @@ impl SystemTableSchema<'_> {
             table_id: self.table_id,
             name: self.name,
             root_page_id: self.root_page_id,
-            last_row_id: self.last_row_id,
         }
     }
 }
@@ -524,10 +511,9 @@ impl SystemTableSchema<'_> {
 impl SystemTableCatalogRow<'_> {
     pub(crate) fn to_bytes(&self) -> std::io::Result<Vec<u8>> {
         let values = [
-            ValueRef::UnsignedInteger(self.table_id),
+            ValueRef::Integer(self.table_id),
             ValueRef::String(self.name),
             ValueRef::UnsignedInteger(self.root_page_id),
-            ValueRef::UnsignedInteger(self.last_row_id),
         ];
         TupleRef::new(&values).to_bytes()
     }
@@ -536,15 +522,15 @@ impl SystemTableCatalogRow<'_> {
 impl SystemColumnCatalogRow<'_> {
     pub(crate) fn to_bytes(&self) -> std::io::Result<Vec<u8>> {
         let values = [
-            ValueRef::UnsignedInteger(self.column_id),
+            ValueRef::Integer(self.column_id),
             ValueRef::Integer(self.object_kind.catalog_tag()),
-            ValueRef::UnsignedInteger(self.object_id),
+            ValueRef::Integer(self.object_id),
             ValueRef::UnsignedInteger(self.ordinal),
             ValueRef::String(self.name),
             ValueRef::Integer(self.data_type.catalog_tag()),
             ValueRef::Boolean(self.nullable),
             ValueRef::Boolean(self.primary_key),
-            optional_unsigned_ref(self.source_table_id),
+            optional_integer_ref(self.source_table_id),
             optional_unsigned_ref(self.source_column_ordinal),
         ];
         TupleRef::new(&values).to_bytes()
@@ -552,36 +538,31 @@ impl SystemColumnCatalogRow<'_> {
 }
 
 static SYS_TABLES_COLUMNS: &[SystemColumnSchema<'static>] = &[
-    column("table_id", DataType::UnsignedInteger, false, true),
+    column("table_id", DataType::Integer, false, true),
     column("name", DataType::Text, false, false),
     column("root_page_id", DataType::UnsignedInteger, false, false),
-    column("last_row_id", DataType::UnsignedInteger, false, false),
 ];
 
 static SYS_INDEXES_COLUMNS: &[SystemColumnSchema<'static>] = &[
-    column("index_id", DataType::UnsignedInteger, false, true),
+    column("index_id", DataType::Integer, false, true),
     column("name", DataType::Text, false, false),
-    column("table_id", DataType::UnsignedInteger, false, false),
+    column("table_id", DataType::Integer, false, false),
     column("root_page_id", DataType::UnsignedInteger, false, false),
     column("unique", DataType::Boolean, false, false),
 ];
 
 static SYS_COLUMNS_COLUMNS: &[SystemColumnSchema<'static>] = &[
-    column("column_id", DataType::UnsignedInteger, false, true),
+    column("column_id", DataType::Integer, false, true),
     column("object_kind", DataType::Integer, false, false),
-    column("object_id", DataType::UnsignedInteger, false, false),
+    column("object_id", DataType::Integer, false, false),
     column("ordinal", DataType::UnsignedInteger, false, false),
     column("name", DataType::Text, false, false),
     column("data_type", DataType::Integer, false, false),
     column("nullable", DataType::Boolean, false, false),
     column("primary_key", DataType::Boolean, false, false),
-    column("source_table_id", DataType::UnsignedInteger, true, false),
+    column("source_table_id", DataType::Integer, true, false),
     column("source_column_ordinal", DataType::UnsignedInteger, true, false),
 ];
-
-const SYSTEM_TABLE_ROW_COUNT: RowId = 3;
-const SYSTEM_COLUMN_ROW_COUNT: RowId =
-    (SYS_TABLES_COLUMNS.len() + SYS_INDEXES_COLUMNS.len() + SYS_COLUMNS_COLUMNS.len()) as RowId;
 
 /// Fixed schemas of all built-in system catalog tables.
 pub static SYSTEM_TABLE_SCHEMAS: &[SystemTableSchema<'static>] = &[
@@ -589,21 +570,18 @@ pub static SYSTEM_TABLE_SCHEMAS: &[SystemTableSchema<'static>] = &[
         table_id: SYS_TABLES_TABLE_ID,
         name: SYS_TABLES_NAME,
         root_page_id: SYS_TABLES_ROOT_PAGE_ID,
-        last_row_id: SYSTEM_TABLE_ROW_COUNT,
         row: SystemTupleSchema { columns: SYS_TABLES_COLUMNS },
     },
     SystemTableSchema {
         table_id: SYS_INDEXES_TABLE_ID,
         name: SYS_INDEXES_NAME,
         root_page_id: SYS_INDEXES_ROOT_PAGE_ID,
-        last_row_id: 0,
         row: SystemTupleSchema { columns: SYS_INDEXES_COLUMNS },
     },
     SystemTableSchema {
         table_id: SYS_COLUMNS_TABLE_ID,
         name: SYS_COLUMNS_NAME,
         root_page_id: SYS_COLUMNS_ROOT_PAGE_ID,
-        last_row_id: SYSTEM_COLUMN_ROW_COUNT,
         row: SystemTupleSchema { columns: SYS_COLUMNS_COLUMNS },
     },
 ];
@@ -650,8 +628,16 @@ fn optional_unsigned(value: Option<u64>) -> Value {
     value.map(Value::UnsignedInteger).unwrap_or(Value::Null)
 }
 
+fn optional_integer(value: Option<i32>) -> Value {
+    value.map(Value::Integer).unwrap_or(Value::Null)
+}
+
 fn optional_unsigned_ref(value: Option<u64>) -> ValueRef<'static> {
     value.map(ValueRef::UnsignedInteger).unwrap_or(ValueRef::Null)
+}
+
+fn optional_integer_ref(value: Option<i32>) -> ValueRef<'static> {
+    value.map(ValueRef::Integer).unwrap_or(ValueRef::Null)
 }
 
 fn expect_field_count(tuple: &Tuple, expected: usize) -> Result<(), CatalogError> {
@@ -695,6 +681,14 @@ fn expect_unsigned(tuple: &Tuple, index: usize) -> Result<u64, CatalogError> {
     match expect_value(tuple, index)? {
         Value::UnsignedInteger(value) => Ok(*value),
         _ => Err(CatalogError::InvalidFieldType { index, expected: "unsigned integer" }),
+    }
+}
+
+fn expect_optional_integer(tuple: &Tuple, index: usize) -> Result<Option<i32>, CatalogError> {
+    match expect_value(tuple, index)? {
+        Value::Null => Ok(None),
+        Value::Integer(value) => Ok(Some(*value)),
+        _ => Err(CatalogError::InvalidFieldType { index, expected: "nullable integer" }),
     }
 }
 

--- a/src/core/catalog_manager.rs
+++ b/src/core/catalog_manager.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::core::{
-    IndexSchema, OwnedTableRecord, PageId, RowId, TableSchema, Tuple, TupleSchema,
+    CatalogId, IndexSchema, OwnedTableRecord, PageId, TableSchema, Tuple, TupleSchema,
     catalog::{
         CatalogError, CatalogObjectKind, ColumnCatalogRow, ColumnSchema, IndexCatalogRow,
         IndexColumnSchema, SYS_COLUMNS_ROOT_PAGE_ID, SYS_INDEXES_ROOT_PAGE_ID,
@@ -10,7 +10,7 @@ use crate::core::{
     cursor::{IndexCursor, TableCursor},
     error::{
         ConstraintError, CorruptionComponent, CorruptionError, CorruptionKind,
-        InvalidArgumentError, LimitExceededError, StorageError, StorageResult,
+        InvalidArgumentError, StorageError, StorageResult,
     },
     pager::Pager,
 };
@@ -44,6 +44,7 @@ impl CatalogManager {
 
     /// Creates a cataloged table, allocates its root page, and records its columns.
     pub fn create_table(&self, name: &str, row: TupleSchema) -> StorageResult<TableSchema> {
+        validate_user_table_schema(name, &row)?;
         if self.table_catalog_rows()?.iter().any(|row| row.name == name) {
             return Err(StorageError::Constraint(ConstraintError::DuplicateTableName {
                 name: name.to_owned(),
@@ -52,8 +53,7 @@ impl CatalogManager {
 
         let table_id = self.next_object_id()?;
         let root_page_id = self.pager.create_table_tree()?.root_page_id();
-        let schema =
-            TableSchema { table_id, name: name.to_owned(), root_page_id, last_row_id: 0, row };
+        let schema = TableSchema { table_id, name: name.to_owned(), root_page_id, row };
 
         self.insert_table_catalog_row(&schema.catalog_row())?;
         for (column_id, (ordinal, column)) in
@@ -159,27 +159,6 @@ impl CatalogManager {
         self.pager.index_cursor(schema.root_page_id)
     }
 
-    /// Allocates and persists the next row id for a table.
-    pub fn allocate_table_row_id(&self, table: &TableSchema) -> StorageResult<RowId> {
-        let mut row = self
-            .table_catalog_rows()?
-            .into_iter()
-            .find(|row| row.table_id == table.table_id)
-            .ok_or_else(|| {
-                StorageError::InvalidArgument(InvalidArgumentError::TableNotFound {
-                    name: table.name.clone(),
-                })
-            })?;
-        let next_row_id = row.last_row_id.checked_add(1).ok_or_else(|| {
-            StorageError::LimitExceeded(LimitExceededError::RowIdExhausted {
-                table: table.name.clone(),
-            })
-        })?;
-        row.last_row_id = next_row_id;
-        self.update_table_catalog_row(&row)?;
-        Ok(next_row_id)
-    }
-
     fn initialize_or_validate_system_catalog(&self) -> StorageResult<()> {
         match self.pager.opened_page_count() {
             0 => Err(crate::core::database_header::missing_header()),
@@ -266,7 +245,6 @@ impl CatalogManager {
             table_id: table.table_id,
             name: table.name,
             root_page_id: table.root_page_id,
-            last_row_id: table.last_row_id,
             row: TupleSchema { columns: columns.into_iter().map(column_schema_from_row).collect() },
         })
     }
@@ -319,7 +297,7 @@ impl CatalogManager {
             .collect()
     }
 
-    fn next_object_id(&self) -> StorageResult<RowId> {
+    fn next_object_id(&self) -> StorageResult<CatalogId> {
         let max_table_id =
             self.table_catalog_rows()?.into_iter().map(|row| row.table_id).max().unwrap_or(0);
         let max_index_id =
@@ -327,7 +305,7 @@ impl CatalogManager {
         Ok(max_table_id.max(max_index_id) + 1)
     }
 
-    fn next_column_id(&self) -> StorageResult<RowId> {
+    fn next_column_id(&self) -> StorageResult<CatalogId> {
         Ok(self.column_catalog_rows()?.into_iter().map(|row| row.column_id).max().unwrap_or(0) + 1)
     }
 
@@ -372,12 +350,6 @@ impl CatalogManager {
         self.insert_catalog_row(SYS_TABLES_ROOT_PAGE_ID, row.table_id, &row.encode())
     }
 
-    fn update_table_catalog_row(&self, row: &TableCatalogRow) -> StorageResult<()> {
-        let mut cursor = self.pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID)?;
-        let bytes = row.encode().to_bytes()?;
-        cursor.update(row.table_id, &bytes)
-    }
-
     fn insert_index_catalog_row(&self, row: &IndexCatalogRow) -> StorageResult<()> {
         self.insert_catalog_row(SYS_INDEXES_ROOT_PAGE_ID, row.index_id, &row.encode())
     }
@@ -389,13 +361,46 @@ impl CatalogManager {
     fn insert_catalog_row(
         &self,
         root_page_id: PageId,
-        row_id: RowId,
+        table_key: CatalogId,
         tuple: &Tuple,
     ) -> StorageResult<()> {
         let mut cursor = self.pager.table_cursor(root_page_id)?;
         let bytes = tuple.to_bytes()?;
-        cursor.insert(row_id, &bytes)
+        cursor.insert(table_key, &bytes)
     }
+}
+
+fn validate_user_table_schema(name: &str, row: &TupleSchema) -> StorageResult<()> {
+    let primary_key_count = row.columns.iter().filter(|column| column.primary_key).count();
+    if primary_key_count != 1 {
+        return Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+            table: name.to_owned(),
+            reason: "tables must declare exactly one primary key".to_owned(),
+        }));
+    }
+
+    let Some(primary_key) = row.columns.first().filter(|column| column.primary_key) else {
+        return Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+            table: name.to_owned(),
+            reason: "primary key must be the first column".to_owned(),
+        }));
+    };
+
+    if primary_key.data_type != crate::core::DataType::Integer {
+        return Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+            table: name.to_owned(),
+            reason: "primary key must use INT type".to_owned(),
+        }));
+    }
+
+    if primary_key.nullable {
+        return Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+            table: name.to_owned(),
+            reason: "primary key cannot be nullable".to_owned(),
+        }));
+    }
+
+    Ok(())
 }
 
 fn missing_system_catalog_root(page_id: PageId) -> StorageError {
@@ -469,7 +474,7 @@ mod tests {
 
     use super::*;
     use crate::core::{
-        RowId, Tuple, TupleSchema,
+        CatalogId, Tuple, TupleSchema,
         catalog::{
             ColumnCatalogRow, ColumnSchema, DataType, IndexCatalogRow, SYS_COLUMNS_TABLE_ID,
             SYS_INDEXES_TABLE_ID, SYS_TABLES_TABLE_ID, TableCatalogRow, system_column_rows,
@@ -495,21 +500,18 @@ mod tests {
             SYS_TABLES_TABLE_ID,
             "sys_tables",
             SYS_TABLES_ROOT_PAGE_ID,
-            3,
         );
         assert_table_catalog_row(
             &mut tables,
             SYS_INDEXES_TABLE_ID,
             "sys_indexes",
             SYS_INDEXES_ROOT_PAGE_ID,
-            0,
         );
         assert_table_catalog_row(
             &mut tables,
             SYS_COLUMNS_TABLE_ID,
             "sys_columns",
             SYS_COLUMNS_ROOT_PAGE_ID,
-            system_column_rows().len() as RowId,
         );
 
         let mut columns = manager.pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
@@ -546,7 +548,6 @@ mod tests {
             SYS_TABLES_TABLE_ID,
             "sys_tables",
             SYS_TABLES_ROOT_PAGE_ID,
-            3,
         );
     }
 
@@ -585,7 +586,6 @@ mod tests {
         assert_eq!(table.table_id, 4);
         assert_eq!(table.name, "users");
         assert_eq!(table.root_page_id, 4);
-        assert_eq!(table.last_row_id, 0);
         assert_eq!(table.row, row_schema);
         assert_eq!(
             manager.table_cursor_by_name("users").unwrap().root_page_id(),
@@ -593,9 +593,9 @@ mod tests {
         );
 
         let mut tables = manager.pager.table_cursor(SYS_TABLES_ROOT_PAGE_ID).unwrap();
-        assert_table_catalog_row(&mut tables, table.table_id, "users", table.root_page_id, 0);
+        assert_table_catalog_row(&mut tables, table.table_id, "users", table.root_page_id);
 
-        let first_user_column_id = system_column_rows().len() as RowId + 1;
+        let first_user_column_id = system_column_rows().len() as CatalogId + 1;
         let mut columns = manager.pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
         assert_column_catalog_row(
             &mut columns,
@@ -612,6 +612,53 @@ mod tests {
                 source_column_ordinal: None,
             },
         );
+    }
+
+    #[test]
+    fn create_table_rejects_invalid_primary_key_shapes() {
+        let file = NamedTempFile::new().unwrap();
+        let manager = open(file.path()).unwrap();
+
+        let mut missing = users_schema();
+        missing.columns[0].primary_key = false;
+        assert!(matches!(
+            manager.create_table("missing_pk", missing),
+            Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+                table,
+                ..
+            })) if table == "missing_pk"
+        ));
+
+        let mut second = users_schema();
+        second.columns[0].primary_key = false;
+        second.columns[1].primary_key = true;
+        assert!(matches!(
+            manager.create_table("second_pk", second),
+            Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+                table,
+                ..
+            })) if table == "second_pk"
+        ));
+
+        let mut text = users_schema();
+        text.columns[0].data_type = DataType::Text;
+        assert!(matches!(
+            manager.create_table("text_pk", text),
+            Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+                table,
+                ..
+            })) if table == "text_pk"
+        ));
+
+        let mut nullable = users_schema();
+        nullable.columns[0].nullable = true;
+        assert!(matches!(
+            manager.create_table("nullable_pk", nullable),
+            Err(StorageError::InvalidArgument(InvalidArgumentError::InvalidPrimaryKey {
+                table,
+                ..
+            })) if table == "nullable_pk"
+        ));
     }
 
     #[test]
@@ -647,7 +694,7 @@ mod tests {
         );
 
         let index_column_id =
-            system_column_rows().len() as RowId + table.row.columns.len() as RowId + 1;
+            system_column_rows().len() as CatalogId + table.row.columns.len() as CatalogId + 1;
         let mut columns = manager.pager.table_cursor(SYS_COLUMNS_ROOT_PAGE_ID).unwrap();
         assert_column_catalog_row(
             &mut columns,
@@ -683,37 +730,17 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn allocate_table_row_id_persists_last_row_id() {
-        let file = NamedTempFile::new().unwrap();
-        {
-            let manager = open(file.path()).unwrap();
-            let table = manager.create_table("users", users_schema()).unwrap();
-
-            assert_eq!(manager.allocate_table_row_id(&table).unwrap(), 1);
-            assert_eq!(manager.allocate_table_row_id(&table).unwrap(), 2);
-            assert_eq!(manager.table_schema_by_name("users").unwrap().last_row_id, 2);
-            manager.flush().unwrap();
-        }
-
-        let manager = open(file.path()).unwrap();
-        let table = manager.table_schema_by_name("users").unwrap();
-        assert_eq!(table.last_row_id, 2);
-        assert_eq!(manager.allocate_table_row_id(&table).unwrap(), 3);
-    }
-
     fn assert_table_catalog_row(
         tables: &mut TableCursor,
-        table_id: RowId,
+        table_id: CatalogId,
         name: &str,
         root_page_id: PageId,
-        last_row_id: RowId,
     ) {
         let record = tables.get(table_id).unwrap().expect("system table row should exist");
         let tuple = Tuple::from_bytes(&record.record).unwrap();
         assert_eq!(
             TableCatalogRow::decode(&tuple).unwrap(),
-            TableCatalogRow { table_id, name: name.to_owned(), root_page_id, last_row_id }
+            TableCatalogRow { table_id, name: name.to_owned(), root_page_id }
         );
     }
 

--- a/src/core/cursor.rs
+++ b/src/core/cursor.rs
@@ -3,43 +3,43 @@
 use std::fmt::{self, Display};
 
 use crate::core::{
-    RowId, Tuple,
+    TableKey, Tuple,
     btree::{CursorState, OwnedRecord, Record, TreeCursor},
     error::StorageResult,
     page::{CellCorruption, PageError},
 };
 
-const ROW_ID_SIZE: usize = size_of::<RowId>();
+const TABLE_KEY_SIZE: usize = size_of::<TableKey>();
 
-fn encode_table_row_id(row_id: RowId) -> [u8; ROW_ID_SIZE] {
-    row_id.to_be_bytes()
+fn encode_table_key(table_key: TableKey) -> [u8; TABLE_KEY_SIZE] {
+    (table_key ^ TableKey::MIN).to_be_bytes()
 }
 
-fn decode_table_row_id(key: &[u8]) -> StorageResult<RowId> {
-    let bytes: [u8; ROW_ID_SIZE] = key.try_into().map_err(|_| PageError::CorruptCell {
+fn decode_table_key(key: &[u8]) -> StorageResult<TableKey> {
+    let bytes: [u8; TABLE_KEY_SIZE] = key.try_into().map_err(|_| PageError::CorruptCell {
         slot_index: 0,
-        kind: CellCorruption::InvalidTableRowIdKeyLength { actual: key.len() },
+        kind: CellCorruption::InvalidTableKeyLength { actual: key.len() },
     })?;
-    Ok(RowId::from_be_bytes(bytes))
+    Ok(TableKey::from_be_bytes(bytes) ^ TableKey::MIN)
 }
 
-fn encode_index_row_id(row_id: RowId) -> [u8; ROW_ID_SIZE] {
-    row_id.to_le_bytes()
+fn encode_index_table_key(table_key: TableKey) -> [u8; TABLE_KEY_SIZE] {
+    encode_table_key(table_key)
 }
 
-fn decode_index_row_id(value: &[u8]) -> StorageResult<RowId> {
-    let bytes: [u8; ROW_ID_SIZE] = value.try_into().map_err(|_| PageError::CorruptCell {
+fn decode_index_table_key(value: &[u8]) -> StorageResult<TableKey> {
+    let bytes: [u8; TABLE_KEY_SIZE] = value.try_into().map_err(|_| PageError::CorruptCell {
         slot_index: 0,
-        kind: CellCorruption::InvalidIndexRowIdValueLength { actual: value.len() },
+        kind: CellCorruption::InvalidIndexTableKeyValueLength { actual: value.len() },
     })?;
-    Ok(RowId::from_le_bytes(bytes))
+    Ok(TableKey::from_be_bytes(bytes) ^ TableKey::MIN)
 }
 
 /// Stable, owned table record snapshot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OwnedTableRecord {
-    /// Row id that identifies this table record.
-    pub row_id: RowId,
+    /// Primary-key table key that identifies this table record.
+    pub table_key: TableKey,
     /// Encoded table record bytes.
     pub record: Box<[u8]>,
 }
@@ -61,18 +61,18 @@ impl Display for OwnedTableRecord {
 /// Borrowed table record view valid only for the callback that receives it.
 #[derive(Debug, Clone, Copy)]
 pub struct TableRecordView<'a> {
-    row_id: RowId,
+    table_key: TableKey,
     record: &'a [u8],
 }
 
 impl<'a> TableRecordView<'a> {
-    fn new(row_id: RowId, record: &'a [u8]) -> Self {
-        Self { row_id, record }
+    fn new(table_key: TableKey, record: &'a [u8]) -> Self {
+        Self { table_key, record }
     }
 
-    /// Returns the row id that identifies this table record.
-    pub fn row_id(&self) -> RowId {
-        self.row_id
+    /// Returns the primary-key table key that identifies this table record.
+    pub fn table_key(&self) -> TableKey {
+        self.table_key
     }
 
     /// Returns the encoded table record bytes.
@@ -86,20 +86,20 @@ impl<'a> TableRecordView<'a> {
 pub struct OwnedIndexEntry {
     /// Encoded secondary-index key bytes.
     pub key: Box<[u8]>,
-    /// Table row id referenced by this secondary-index key.
-    pub row_id: RowId,
+    /// Table primary-key value referenced by this secondary-index key.
+    pub table_key: TableKey,
 }
 
 /// Borrowed secondary-index entry view valid only for the callback that receives it.
 #[derive(Debug, Clone, Copy)]
 pub struct IndexEntryView<'a> {
     key: &'a [u8],
-    row_id: RowId,
+    table_key: TableKey,
 }
 
 impl<'a> IndexEntryView<'a> {
-    fn new(key: &'a [u8], row_id: RowId) -> Self {
-        Self { key, row_id }
+    fn new(key: &'a [u8], table_key: TableKey) -> Self {
+        Self { key, table_key }
     }
 
     /// Returns the encoded secondary-index key bytes.
@@ -107,9 +107,9 @@ impl<'a> IndexEntryView<'a> {
         self.key
     }
 
-    /// Returns the table row id referenced by this secondary-index key.
-    pub fn row_id(&self) -> RowId {
-        self.row_id
+    /// Returns the table primary-key value referenced by this secondary-index key.
+    pub fn table_key(&self) -> TableKey {
+        self.table_key
     }
 }
 
@@ -118,7 +118,7 @@ impl<'a> IndexEntryView<'a> {
 /// Inline records keep the backing page pinned internally and expose bytes only
 /// through callbacks. Overflow records may still be materialized by the raw tree.
 pub struct TableRecord {
-    row_id: RowId,
+    table_key: TableKey,
     raw: Record,
 }
 
@@ -127,11 +127,11 @@ pub struct TableRecord {
 /// Inline entries keep the backing page pinned internally and expose key bytes
 /// only through callbacks. Overflow keys may still be materialized by the raw tree.
 pub struct IndexEntry {
-    row_id: RowId,
+    table_key: TableKey,
     raw: Record,
 }
 
-/// Typed cursor for a table B+-tree keyed by row id.
+/// Typed cursor for a table B+-tree keyed by table key.
 #[derive(Clone)]
 pub struct TableCursor {
     inner: TreeCursor,
@@ -169,73 +169,99 @@ impl TableCursor {
         self.inner.seek_to_first()
     }
 
-    /// Positions the cursor on the first table record whose row id is greater
-    /// than or equal to `row_id`.
-    pub fn seek_to_row_id(&mut self, row_id: RowId) -> StorageResult<bool> {
-        self.inner.seek_to_key(&encode_table_row_id(row_id))
+    /// Positions the cursor on the first table record whose key is greater than
+    /// or equal to `table_key`.
+    pub fn seek_to_table_key(&mut self, table_key: TableKey) -> StorageResult<bool> {
+        self.inner.seek_to_key(&encode_table_key(table_key))
     }
 
     /// Reads the currently selected table record, if any.
     pub fn current_record(&self) -> StorageResult<Option<TableRecord>> {
-        self.inner.current()?.map(TableRecord::try_from).transpose()
+        self.inner.current()?.map(|record| self.table_record_from_raw(record)).transpose()
     }
 
     /// Reads the currently selected table record as a stable owned snapshot, if any.
     pub fn current_owned_record(&self) -> StorageResult<Option<OwnedTableRecord>> {
-        self.inner.current_owned()?.map(OwnedTableRecord::try_from).transpose()
+        self.inner
+            .current_owned()?
+            .map(|record| self.owned_table_record_from_raw(record))
+            .transpose()
     }
 
-    /// Advances to the next table record in row-id order.
+    /// Advances to the next table record in table key order.
     pub fn next_record(&mut self) -> StorageResult<Option<TableRecord>> {
-        self.inner.next_record()?.map(TableRecord::try_from).transpose()
+        self.inner.next_record()?.map(|record| self.table_record_from_raw(record)).transpose()
     }
 
     /// Advances to the next table record and returns a stable owned snapshot.
     pub fn next_owned_record(&mut self) -> StorageResult<Option<OwnedTableRecord>> {
-        self.inner.next_owned_record()?.map(OwnedTableRecord::try_from).transpose()
+        self.inner
+            .next_owned_record()?
+            .map(|record| self.owned_table_record_from_raw(record))
+            .transpose()
     }
 
-    /// Moves to the previous table record in row-id order.
+    /// Moves to the previous table record in table key order.
     pub fn prev_record(&mut self) -> StorageResult<Option<TableRecord>> {
-        self.inner.prev_record()?.map(TableRecord::try_from).transpose()
+        self.inner.prev_record()?.map(|record| self.table_record_from_raw(record)).transpose()
     }
 
     /// Moves to the previous table record and returns a stable owned snapshot.
     pub fn prev_owned_record(&mut self) -> StorageResult<Option<OwnedTableRecord>> {
-        self.inner.prev_owned_record()?.map(OwnedTableRecord::try_from).transpose()
-    }
-
-    /// Inserts a table record keyed by `row_id`.
-    pub fn insert(&mut self, row_id: RowId, record: &[u8]) -> StorageResult<()> {
-        self.inner.insert(&encode_table_row_id(row_id), record)
-    }
-
-    /// Looks up a table record by row id.
-    pub fn get(&mut self, row_id: RowId) -> StorageResult<Option<OwnedTableRecord>> {
         self.inner
-            .get_owned(&encode_table_row_id(row_id))?
-            .map(OwnedTableRecord::try_from)
+            .prev_owned_record()?
+            .map(|record| self.owned_table_record_from_raw(record))
             .transpose()
     }
 
-    /// Looks up a table record by row id and returns a stable owned snapshot.
-    pub fn get_owned_record(&mut self, row_id: RowId) -> StorageResult<Option<OwnedTableRecord>> {
-        self.get(row_id)
+    /// Inserts a table record keyed by `table_key`.
+    pub fn insert(&mut self, table_key: TableKey, record: &[u8]) -> StorageResult<()> {
+        self.inner.insert(&encode_table_key(table_key), record)
     }
 
-    /// Looks up a table record by row id without eagerly copying page-resident bytes.
-    pub fn get_record(&mut self, row_id: RowId) -> StorageResult<Option<TableRecord>> {
-        self.inner.get(&encode_table_row_id(row_id))?.map(TableRecord::try_from).transpose()
+    /// Looks up a table record by table key.
+    pub fn get(&mut self, table_key: TableKey) -> StorageResult<Option<OwnedTableRecord>> {
+        self.inner
+            .get_owned(&encode_table_key(table_key))?
+            .map(|record| self.owned_table_record_from_raw(record))
+            .transpose()
     }
 
-    /// Replaces the encoded record bytes stored for an existing `row_id`.
-    pub fn update(&mut self, row_id: RowId, record: &[u8]) -> StorageResult<()> {
-        self.inner.update(&encode_table_row_id(row_id), record)
+    /// Looks up a table record by table key and returns a stable owned snapshot.
+    pub fn get_owned_record(
+        &mut self,
+        table_key: TableKey,
+    ) -> StorageResult<Option<OwnedTableRecord>> {
+        self.get(table_key)
     }
 
-    /// Deletes the table record identified by `row_id`.
-    pub fn delete(&mut self, row_id: RowId) -> StorageResult<()> {
-        self.inner.delete(&encode_table_row_id(row_id))
+    /// Looks up a table record by table key without eagerly copying page-resident bytes.
+    pub fn get_record(&mut self, table_key: TableKey) -> StorageResult<Option<TableRecord>> {
+        self.inner
+            .get(&encode_table_key(table_key))?
+            .map(|record| self.table_record_from_raw(record))
+            .transpose()
+    }
+
+    /// Replaces the encoded record bytes stored for an existing `table_key`.
+    pub fn update(&mut self, table_key: TableKey, record: &[u8]) -> StorageResult<()> {
+        self.inner.update(&encode_table_key(table_key), record)
+    }
+
+    /// Deletes the table record identified by `table_key`.
+    pub fn delete(&mut self, table_key: TableKey) -> StorageResult<()> {
+        self.inner.delete(&encode_table_key(table_key))
+    }
+
+    fn owned_table_record_from_raw(&self, raw: OwnedRecord) -> StorageResult<OwnedTableRecord> {
+        raw.with_key_value(|key, value| {
+            Ok(OwnedTableRecord { table_key: decode_table_key(key)?, record: value.into() })
+        })
+    }
+
+    fn table_record_from_raw(&self, raw: Record) -> StorageResult<TableRecord> {
+        let table_key = raw.with_key(decode_table_key)??;
+        Ok(TableRecord { table_key, raw })
     }
 }
 
@@ -301,9 +327,9 @@ impl IndexCursor {
         self.inner.prev_owned_record()?.map(OwnedIndexEntry::try_from).transpose()
     }
 
-    /// Inserts an index entry from `key` to `row_id`.
-    pub fn insert(&mut self, key: &[u8], row_id: RowId) -> StorageResult<()> {
-        self.inner.insert(key, &encode_index_row_id(row_id))
+    /// Inserts an index entry from `key` to `table_key`.
+    pub fn insert(&mut self, key: &[u8], table_key: TableKey) -> StorageResult<()> {
+        self.inner.insert(key, &encode_index_table_key(table_key))
     }
 
     /// Looks up an index entry by key.
@@ -321,9 +347,9 @@ impl IndexCursor {
         self.inner.get(key)?.map(IndexEntry::try_from).transpose()
     }
 
-    /// Replaces the row id stored for an existing index `key`.
-    pub fn update(&mut self, key: &[u8], row_id: RowId) -> StorageResult<()> {
-        self.inner.update(key, &encode_index_row_id(row_id))
+    /// Replaces the table key stored for an existing index `key`.
+    pub fn update(&mut self, key: &[u8], table_key: TableKey) -> StorageResult<()> {
+        self.inner.update(key, &encode_index_table_key(table_key))
     }
 
     /// Deletes the index entry identified by `key`.
@@ -333,14 +359,14 @@ impl IndexCursor {
 }
 
 impl TableRecord {
-    /// Returns the row id that identifies this table record.
-    pub fn row_id(&self) -> RowId {
-        self.row_id
+    /// Returns the primary-key table key that identifies this table record.
+    pub fn table_key(&self) -> TableKey {
+        self.table_key
     }
 
     /// Executes `f` with a borrowed table record view.
     pub fn with_view<R>(&self, f: impl FnOnce(TableRecordView<'_>) -> R) -> StorageResult<R> {
-        self.raw.with_value(|record| f(TableRecordView::new(self.row_id, record)))
+        self.raw.with_value(|record| f(TableRecordView::new(self.table_key, record)))
     }
 
     /// Executes `f` with a borrowed view of the encoded table record bytes.
@@ -350,19 +376,22 @@ impl TableRecord {
 
     /// Returns a stable, owned snapshot of this table record.
     pub fn to_owned_record(&self) -> StorageResult<OwnedTableRecord> {
-        self.raw.to_owned_record()?.try_into()
+        self.raw.with_value(|record| OwnedTableRecord {
+            table_key: self.table_key,
+            record: record.into(),
+        })
     }
 }
 
 impl IndexEntry {
-    /// Returns the table row id referenced by this secondary-index key.
-    pub fn row_id(&self) -> RowId {
-        self.row_id
+    /// Returns the table primary-key value referenced by this secondary-index key.
+    pub fn table_key(&self) -> TableKey {
+        self.table_key
     }
 
     /// Executes `f` with a borrowed secondary-index entry view.
     pub fn with_view<R>(&self, f: impl FnOnce(IndexEntryView<'_>) -> R) -> StorageResult<R> {
-        self.raw.with_key(|key| f(IndexEntryView::new(key, self.row_id)))
+        self.raw.with_key(|key| f(IndexEntryView::new(key, self.table_key)))
     }
 
     /// Executes `f` with a borrowed view of the encoded secondary-index key bytes.
@@ -396,32 +425,19 @@ impl fmt::Debug for IndexCursor {
 
 impl fmt::Debug for TableRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TableRecord").field("row_id", &self.row_id).field("raw", &self.raw).finish()
+        f.debug_struct("TableRecord")
+            .field("table_key", &self.table_key)
+            .field("raw", &self.raw)
+            .finish()
     }
 }
 
 impl fmt::Debug for IndexEntry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("IndexEntry").field("row_id", &self.row_id).field("raw", &self.raw).finish()
-    }
-}
-
-impl TryFrom<OwnedRecord> for OwnedTableRecord {
-    type Error = crate::core::error::StorageError;
-
-    fn try_from(raw: OwnedRecord) -> Result<Self, Self::Error> {
-        raw.with_key_value(|key, value| {
-            Ok(Self { row_id: decode_table_row_id(key)?, record: value.into() })
-        })
-    }
-}
-
-impl TryFrom<Record> for TableRecord {
-    type Error = crate::core::error::StorageError;
-
-    fn try_from(raw: Record) -> Result<Self, Self::Error> {
-        let row_id = raw.with_key(decode_table_row_id)??;
-        Ok(Self { row_id, raw })
+        f.debug_struct("IndexEntry")
+            .field("table_key", &self.table_key)
+            .field("raw", &self.raw)
+            .finish()
     }
 }
 
@@ -429,8 +445,8 @@ impl TryFrom<Record> for IndexEntry {
     type Error = crate::core::error::StorageError;
 
     fn try_from(raw: Record) -> Result<Self, Self::Error> {
-        let row_id = raw.with_value(decode_index_row_id)??;
-        Ok(Self { row_id, raw })
+        let table_key = raw.with_value(decode_index_table_key)??;
+        Ok(Self { table_key, raw })
     }
 }
 
@@ -439,7 +455,7 @@ impl TryFrom<OwnedRecord> for OwnedIndexEntry {
 
     fn try_from(raw: OwnedRecord) -> Result<Self, Self::Error> {
         raw.with_key_value(|key, value| {
-            Ok(Self { key: key.into(), row_id: decode_index_row_id(value)? })
+            Ok(Self { key: key.into(), table_key: decode_index_table_key(value)? })
         })
     }
 }
@@ -487,13 +503,13 @@ mod tests {
         cursor.insert(42, b"old record").unwrap();
         assert_eq!(
             cursor.get(42).unwrap(),
-            Some(OwnedTableRecord { row_id: 42, record: Box::from(&b"old record"[..]) })
+            Some(OwnedTableRecord { table_key: 42, record: Box::from(&b"old record"[..]) })
         );
 
         cursor.update(42, b"new record").unwrap();
         assert_eq!(
             cursor.get(42).unwrap(),
-            Some(OwnedTableRecord { row_id: 42, record: Box::from(&b"new record"[..]) })
+            Some(OwnedTableRecord { table_key: 42, record: Box::from(&b"new record"[..]) })
         );
 
         cursor.delete(42).unwrap();
@@ -507,11 +523,11 @@ mod tests {
         cursor.insert(42, b"record bytes").unwrap();
         let record = cursor.get_record(42).unwrap().expect("record should exist");
 
-        assert_eq!(record.row_id(), 42);
+        assert_eq!(record.table_key(), 42);
         assert_eq!(record.with_record(|bytes| bytes.to_vec()).unwrap(), b"record bytes");
         assert_eq!(
             record.to_owned_record().unwrap(),
-            OwnedTableRecord { row_id: 42, record: Box::from(&b"record bytes"[..]) }
+            OwnedTableRecord { table_key: 42, record: Box::from(&b"record bytes"[..]) }
         );
         assert!(cursor.get_record(404).unwrap().is_none());
     }
@@ -525,27 +541,27 @@ mod tests {
 
         assert!(cursor.seek_to_first().unwrap());
         let first = cursor.current_record().unwrap().expect("first record should exist");
-        assert_eq!(first.row_id(), 10);
+        assert_eq!(first.table_key(), 10);
         assert_eq!(first.with_record(|bytes| bytes.to_vec()).unwrap(), b"ten");
 
         assert_eq!(
             cursor.next_owned_record().unwrap(),
-            Some(OwnedTableRecord { row_id: 20, record: Box::from(&b"twenty"[..]) })
+            Some(OwnedTableRecord { table_key: 20, record: Box::from(&b"twenty"[..]) })
         );
         assert_eq!(
             cursor.next_owned_record().unwrap(),
-            Some(OwnedTableRecord { row_id: 30, record: Box::from(&b"thirty"[..]) })
+            Some(OwnedTableRecord { table_key: 30, record: Box::from(&b"thirty"[..]) })
         );
         assert!(cursor.next_owned_record().unwrap().is_none());
 
-        assert!(cursor.seek_to_row_id(20).unwrap());
+        assert!(cursor.seek_to_table_key(20).unwrap());
         assert_eq!(
             cursor.current_owned_record().unwrap(),
-            Some(OwnedTableRecord { row_id: 20, record: Box::from(&b"twenty"[..]) })
+            Some(OwnedTableRecord { table_key: 20, record: Box::from(&b"twenty"[..]) })
         );
         assert_eq!(
             cursor.prev_owned_record().unwrap(),
-            Some(OwnedTableRecord { row_id: 10, record: Box::from(&b"ten"[..]) })
+            Some(OwnedTableRecord { table_key: 10, record: Box::from(&b"ten"[..]) })
         );
     }
 
@@ -556,13 +572,13 @@ mod tests {
         cursor.insert(b"email:ada@example.test", 7).unwrap();
         assert_eq!(
             cursor.get(b"email:ada@example.test").unwrap(),
-            Some(OwnedIndexEntry { key: Box::from(&b"email:ada@example.test"[..]), row_id: 7 })
+            Some(OwnedIndexEntry { key: Box::from(&b"email:ada@example.test"[..]), table_key: 7 })
         );
 
         cursor.update(b"email:ada@example.test", 9).unwrap();
         assert_eq!(
             cursor.get(b"email:ada@example.test").unwrap(),
-            Some(OwnedIndexEntry { key: Box::from(&b"email:ada@example.test"[..]), row_id: 9 })
+            Some(OwnedIndexEntry { key: Box::from(&b"email:ada@example.test"[..]), table_key: 9 })
         );
 
         cursor.delete(b"email:ada@example.test").unwrap();
@@ -577,11 +593,11 @@ mod tests {
         let entry =
             cursor.get_entry(b"email:ada@example.test").unwrap().expect("entry should exist");
 
-        assert_eq!(entry.row_id(), 7);
+        assert_eq!(entry.table_key(), 7);
         assert_eq!(entry.with_key(|key| key.to_vec()).unwrap(), b"email:ada@example.test");
         assert_eq!(
             entry.to_owned_entry().unwrap(),
-            OwnedIndexEntry { key: Box::from(&b"email:ada@example.test"[..]), row_id: 7 }
+            OwnedIndexEntry { key: Box::from(&b"email:ada@example.test"[..]), table_key: 7 }
         );
         assert!(cursor.get_entry(b"missing").unwrap().is_none());
     }
@@ -595,31 +611,31 @@ mod tests {
 
         assert!(cursor.seek_to_first().unwrap());
         let first = cursor.current_entry().unwrap().expect("first entry should exist");
-        assert_eq!(first.row_id(), 10);
+        assert_eq!(first.table_key(), 10);
         assert_eq!(first.with_key(|key| key.to_vec()).unwrap(), b"alpha");
         assert_eq!(
-            first.with_view(|entry| (entry.key().to_vec(), entry.row_id())).unwrap(),
+            first.with_view(|entry| (entry.key().to_vec(), entry.table_key())).unwrap(),
             (b"alpha".to_vec(), 10)
         );
 
         assert_eq!(
             cursor.next_owned_entry().unwrap(),
-            Some(OwnedIndexEntry { key: Box::from(&b"bravo"[..]), row_id: 20 })
+            Some(OwnedIndexEntry { key: Box::from(&b"bravo"[..]), table_key: 20 })
         );
         assert_eq!(
             cursor.next_owned_entry().unwrap(),
-            Some(OwnedIndexEntry { key: Box::from(&b"charlie"[..]), row_id: 30 })
+            Some(OwnedIndexEntry { key: Box::from(&b"charlie"[..]), table_key: 30 })
         );
         assert!(cursor.next_owned_entry().unwrap().is_none());
 
         assert!(cursor.seek_to_key(b"b").unwrap());
         assert_eq!(
             cursor.current_owned_entry().unwrap(),
-            Some(OwnedIndexEntry { key: Box::from(&b"bravo"[..]), row_id: 20 })
+            Some(OwnedIndexEntry { key: Box::from(&b"bravo"[..]), table_key: 20 })
         );
         assert_eq!(
             cursor.prev_owned_entry().unwrap(),
-            Some(OwnedIndexEntry { key: Box::from(&b"alpha"[..]), row_id: 10 })
+            Some(OwnedIndexEntry { key: Box::from(&b"alpha"[..]), table_key: 10 })
         );
     }
 
@@ -670,7 +686,7 @@ mod tests {
         table.insert(500, &large_record).unwrap();
         assert_eq!(
             table.get(500).unwrap(),
-            Some(OwnedTableRecord { row_id: 500, record: large_record.into_boxed_slice() })
+            Some(OwnedTableRecord { table_key: 500, record: large_record.into_boxed_slice() })
         );
 
         let mut index = temp_index_cursor(16);
@@ -678,7 +694,7 @@ mod tests {
         index.insert(&large_key, 900).unwrap();
         assert_eq!(
             index.get(&large_key).unwrap(),
-            Some(OwnedIndexEntry { key: large_key.into_boxed_slice(), row_id: 900 })
+            Some(OwnedIndexEntry { key: large_key.into_boxed_slice(), table_key: 900 })
         );
     }
 
@@ -688,14 +704,14 @@ mod tests {
         let large_record = vec![0xaa; PAGE_SIZE * 2];
         table.insert(500, &large_record).unwrap();
         let record = table.get_record(500).unwrap().expect("large table record should exist");
-        assert_eq!(record.row_id(), 500);
+        assert_eq!(record.table_key(), 500);
         assert_eq!(record.with_record(|bytes| bytes.to_vec()).unwrap(), large_record);
 
         let mut index = temp_index_cursor(16);
         let large_key = vec![0xbb; PAGE_SIZE * 2];
         index.insert(&large_key, 900).unwrap();
         let entry = index.get_entry(&large_key).unwrap().expect("large index entry should exist");
-        assert_eq!(entry.row_id(), 900);
+        assert_eq!(entry.table_key(), 900);
         assert_eq!(entry.with_key(|key| key.to_vec()).unwrap(), large_key);
     }
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use crate::core::{
     log_manager::{LogManagerError, LogManagerFlushError, Lsn, TxnId},
     page::{CellCorruption, PageCorruption, PageError},
-    {PAGE_SIZE, PageId, RowId},
+    {PAGE_SIZE, PageId, TableKey},
 };
 
 #[derive(Debug, Error)]
@@ -92,10 +92,10 @@ pub enum CorruptionKind {
     CellLengthTooSmall,
     #[error("cell length runs past the usable page bounds")]
     CellLengthOutOfBounds,
-    #[error("table row-id key has invalid length {actual}")]
-    InvalidTableRowIdKeyLength { actual: usize },
-    #[error("index row-id value has invalid length {actual}")]
-    InvalidIndexRowIdValueLength { actual: usize },
+    #[error("table key has invalid length {actual}")]
+    InvalidTableKeyLength { actual: usize },
+    #[error("index table-key value has invalid length {actual}")]
+    InvalidIndexTableKeyValueLength { actual: usize },
     #[error("overflow chain ended before {expected} bytes could be read")]
     OverflowChainTooShort { expected: usize, actual: usize },
     #[error("overflow chain has extra pages after {expected} bytes were read")]
@@ -106,8 +106,8 @@ pub enum CorruptionKind {
     UnexpectedSystemCatalogRoot { expected: PageId, actual: PageId },
     #[error("invalid catalog row in {table}: {reason}")]
     InvalidCatalogRow { table: &'static str, reason: String },
-    #[error("invalid table record in {table} row {row_id}: {reason}")]
-    InvalidTableRecord { table: String, row_id: RowId, reason: String },
+    #[error("invalid table record in {table} key {table_key}: {reason}")]
+    InvalidTableRecord { table: String, table_key: TableKey, reason: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -140,6 +140,10 @@ pub enum InvalidArgumentError {
     EmptyIndexColumns,
     #[error("table {table} row has {values} values for {columns} columns")]
     TableRowValueCount { table: String, columns: usize, values: usize },
+    #[error("invalid primary key for table {table}: {reason}")]
+    InvalidPrimaryKey { table: String, reason: String },
+    #[error("cannot update primary key column {column} on table {table}")]
+    PrimaryKeyUpdate { table: String, column: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -150,8 +154,6 @@ pub enum LimitExceededError {
     CellTooLarge { len: usize, max: usize },
     #[error("cache capacity exhausted")]
     CacheCapacityExhausted,
-    #[error("row id space exhausted for table {table}")]
-    RowIdExhausted { table: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -416,11 +418,11 @@ fn map_cell_corruption(kind: CellCorruption) -> CorruptionKind {
     match kind {
         CellCorruption::LengthTooSmall => CorruptionKind::CellLengthTooSmall,
         CellCorruption::LengthOutOfBounds => CorruptionKind::CellLengthOutOfBounds,
-        CellCorruption::InvalidTableRowIdKeyLength { actual } => {
-            CorruptionKind::InvalidTableRowIdKeyLength { actual }
+        CellCorruption::InvalidTableKeyLength { actual } => {
+            CorruptionKind::InvalidTableKeyLength { actual }
         }
-        CellCorruption::InvalidIndexRowIdValueLength { actual } => {
-            CorruptionKind::InvalidIndexRowIdValueLength { actual }
+        CellCorruption::InvalidIndexTableKeyValueLength { actual } => {
+            CorruptionKind::InvalidIndexTableKeyValueLength { actual }
         }
     }
 }

--- a/src/core/index_manager.rs
+++ b/src/core/index_manager.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    IndexSchema, OwnedTableRecord, RowId, TableSchema, Tuple, TupleView, Value,
+    IndexSchema, OwnedTableRecord, TableKey, TableSchema, Tuple, TupleView, Value,
     catalog_manager::CatalogManager,
     error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
 };
@@ -35,7 +35,7 @@ impl IndexManager {
         for index in self.catalog.index_schemas_for_table(table)? {
             let key = index_key_from_record(table, &index, record)?;
             let mut index_cursor = self.catalog.index_cursor_by_name(&index.name)?;
-            index_cursor.insert(&key, record.row_id)?;
+            index_cursor.insert(&key, record.table_key)?;
         }
 
         Ok(())
@@ -61,7 +61,7 @@ impl IndexManager {
 
         while let Some(record) = table_cursor.next_owned_record()? {
             let key = index_key_from_record(table, index, &record)?;
-            index_cursor.insert(&key, record.row_id)?;
+            index_cursor.insert(&key, record.table_key)?;
         }
 
         Ok(())
@@ -74,7 +74,7 @@ fn index_key_from_record(
     record: &OwnedTableRecord,
 ) -> StorageResult<Vec<u8>> {
     let tuple = TupleView::parse(&record.record).map_err(|error| {
-        invalid_table_record(table, record.row_id, format!("invalid tuple bytes: {error}"))
+        invalid_table_record(table, record.table_key, format!("invalid tuple bytes: {error}"))
     })?;
     let mut values = Vec::with_capacity(index.columns.len());
 
@@ -83,7 +83,7 @@ fn index_key_from_record(
         let value = tuple.values().nth(ordinal).ok_or_else(|| {
             invalid_table_record(
                 table,
-                record.row_id,
+                record.table_key,
                 format!(
                     "index {} references source column ordinal {ordinal}, but row has {} values",
                     index.name,
@@ -97,11 +97,11 @@ fn index_key_from_record(
     Tuple::new(values).to_bytes().map_err(StorageError::from)
 }
 
-fn invalid_table_record(table: &TableSchema, row_id: RowId, reason: String) -> StorageError {
+fn invalid_table_record(table: &TableSchema, table_key: TableKey, reason: String) -> StorageError {
     StorageError::Corruption(CorruptionError {
         component: CorruptionComponent::Catalog,
         page_id: None,
-        kind: CorruptionKind::InvalidTableRecord { table: table.name.clone(), row_id, reason },
+        kind: CorruptionKind::InvalidTableRecord { table: table.name.clone(), table_key, reason },
     })
 }
 
@@ -172,7 +172,7 @@ mod tests {
         indexes.create_index("idx_users_name", "users", &["name"]).unwrap();
 
         let mut index = catalog.index_cursor_by_name("idx_users_name").unwrap();
-        assert_eq!(index.get(&name_key("Ada")).unwrap().unwrap().row_id, 1);
-        assert_eq!(index.get(&name_key("Grace")).unwrap().unwrap().row_id, 2);
+        assert_eq!(index.get(&name_key("Ada")).unwrap().unwrap().table_key, 1);
+        assert_eq!(index.get(&name_key("Grace")).unwrap().unwrap().table_key, 2);
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -38,5 +38,6 @@ pub use tuple::{EncodedTupleView, Tuple, TupleRef, TupleView, Value, ValueRef};
 pub(crate) const PAGE_SIZE: usize = 4096;
 
 pub type PageId = u64;
-pub type RowId = u64;
+pub type CatalogId = i32;
+pub type TableKey = i32;
 pub(crate) type SlotId = u16;

--- a/src/core/page/error.rs
+++ b/src/core/page/error.rs
@@ -89,10 +89,10 @@ pub(crate) enum CellCorruption {
     /// The encoded cell length runs past the usable page region.
     #[error("cell length runs past the usable page bounds")]
     LengthOutOfBounds,
-    /// A table row-id key had the wrong encoded length.
-    #[error("table row-id key has invalid length {actual}")]
-    InvalidTableRowIdKeyLength { actual: usize },
-    /// An index row-id value had the wrong encoded length.
-    #[error("index row-id value has invalid length {actual}")]
-    InvalidIndexRowIdValueLength { actual: usize },
+    /// A table key had the wrong encoded length.
+    #[error("table key has invalid length {actual}")]
+    InvalidTableKeyLength { actual: usize },
+    /// An index table key value had the wrong encoded length.
+    #[error("index table-key value has invalid length {actual}")]
+    InvalidIndexTableKeyValueLength { actual: usize },
 }

--- a/src/core/record_manager.rs
+++ b/src/core/record_manager.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    DataType, OwnedTableRecord, TableSchema, Tuple, Value,
+    DataType, OwnedTableRecord, TableKey, TableSchema, Tuple, Value,
     catalog_manager::CatalogManager,
     cursor::TableCursor,
     error::{ConstraintError, InvalidArgumentError, StorageError, StorageResult},
@@ -35,12 +35,12 @@ impl RecordManager {
     ) -> StorageResult<OwnedTableRecord> {
         validate_table_row(table, &values)?;
 
+        let table_key = table_key_from_values(table, &values)?;
         let record = Tuple::new(values).to_bytes()?;
-        let row_id = self.catalog.allocate_table_row_id(table)?;
         let mut table_cursor = self.catalog.table_cursor_by_name(&table.name)?;
-        table_cursor.insert(row_id, &record)?;
+        table_cursor.insert(table_key, &record)?;
 
-        let record = OwnedTableRecord { row_id, record: record.into_boxed_slice() };
+        let record = OwnedTableRecord { table_key, record: record.into_boxed_slice() };
         self.indexes.insert_index_entries(table, &record)?;
         Ok(record)
     }
@@ -52,7 +52,7 @@ impl RecordManager {
     ) -> StorageResult<()> {
         self.indexes.delete_index_entries(table, record)?;
         let mut table_cursor = self.catalog.table_cursor_by_name(&table.name)?;
-        table_cursor.delete(record.row_id)
+        table_cursor.delete(record.table_key)
     }
 
     pub(crate) fn update_table_row(
@@ -62,14 +62,21 @@ impl RecordManager {
         values: Vec<Value>,
     ) -> StorageResult<OwnedTableRecord> {
         validate_table_row(table, &values)?;
+        let updated_table_key = table_key_from_values(table, &values)?;
+        if updated_table_key != record.table_key {
+            return Err(StorageError::InvalidArgument(InvalidArgumentError::PrimaryKeyUpdate {
+                table: table.name.clone(),
+                column: table.row.columns[0].name.clone(),
+            }));
+        }
 
         let updated = Tuple::new(values).to_bytes()?;
         let updated =
-            OwnedTableRecord { row_id: record.row_id, record: updated.into_boxed_slice() };
+            OwnedTableRecord { table_key: record.table_key, record: updated.into_boxed_slice() };
 
         self.indexes.delete_index_entries(table, record)?;
         let mut table_cursor = self.catalog.table_cursor_by_name(&table.name)?;
-        table_cursor.update(record.row_id, &updated.record)?;
+        table_cursor.update(record.table_key, &updated.record)?;
         self.indexes.insert_index_entries(table, &updated)?;
 
         Ok(updated)
@@ -127,6 +134,25 @@ fn validate_table_row(table: &TableSchema, values: &[Value]) -> StorageResult<()
     }
 
     Ok(())
+}
+
+fn table_key_from_values(table: &TableSchema, values: &[Value]) -> StorageResult<TableKey> {
+    match values.first() {
+        Some(Value::Integer(value)) => Ok(*value),
+        Some(Value::Null) => Err(StorageError::Constraint(ConstraintError::NullValue {
+            column: table.row.columns[0].name.clone(),
+        })),
+        Some(value) => Err(StorageError::Constraint(ConstraintError::ColumnTypeMismatch {
+            column: table.row.columns[0].name.clone(),
+            expected: DataType::Integer,
+            actual: value_type_name(value),
+        })),
+        None => Err(StorageError::InvalidArgument(InvalidArgumentError::TableRowValueCount {
+            table: table.name.clone(),
+            columns: table.row.columns.len(),
+            values: 0,
+        })),
+    }
 }
 
 fn value_matches_data_type(value: &Value, data_type: DataType) -> bool {
@@ -221,16 +247,102 @@ mod tests {
         let mut index: IndexCursor = catalog.index_cursor_by_name("idx_users_name").unwrap();
         let entry = index.get(&name_key("Ada")).unwrap().expect("index should track inserted row");
 
-        assert_eq!(inserted.row_id, 1);
+        assert_eq!(inserted.table_key, 1);
         assert_eq!(
             values(&stored),
             vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true)]
         );
-        assert_eq!(entry.row_id, 1);
+        assert_eq!(entry.table_key, 1);
     }
 
     #[test]
-    fn insert_table_row_rejects_null_before_allocating_row_id() {
+    fn insert_table_row_uses_explicit_primary_key_for_table_and_index_pointers() {
+        let file = NamedTempFile::new().unwrap();
+        let (catalog, records) = open(file.path()).unwrap();
+        let indexes = IndexManager::new(catalog.clone());
+        let table = catalog.create_table("users", users_schema()).unwrap();
+        indexes.create_index("idx_users_name", "users", &["name"]).unwrap();
+
+        records
+            .insert_table_row(
+                &table,
+                vec![Value::Integer(20), Value::String("Grace".to_owned()), Value::Boolean(true)],
+            )
+            .unwrap();
+        records
+            .insert_table_row(
+                &table,
+                vec![Value::Integer(-5), Value::String("Ada".to_owned()), Value::Boolean(false)],
+            )
+            .unwrap();
+
+        let mut users = catalog.table_cursor_by_name("users").unwrap();
+        assert!(users.get(20).unwrap().is_some());
+        assert!(users.get(-5).unwrap().is_some());
+        assert!(users.seek_to_first().unwrap());
+        assert_eq!(users.current_owned_record().unwrap().unwrap().table_key, -5);
+
+        let mut index: IndexCursor = catalog.index_cursor_by_name("idx_users_name").unwrap();
+        assert_eq!(index.get(&name_key("Ada")).unwrap().unwrap().table_key, -5);
+        assert_eq!(index.get(&name_key("Grace")).unwrap().unwrap().table_key, 20);
+    }
+
+    #[test]
+    fn insert_table_row_rejects_duplicate_primary_key() {
+        let file = NamedTempFile::new().unwrap();
+        let (catalog, records) = open(file.path()).unwrap();
+        let table = catalog.create_table("users", users_schema()).unwrap();
+
+        records
+            .insert_table_row(
+                &table,
+                vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true)],
+            )
+            .unwrap();
+        let error = records
+            .insert_table_row(
+                &table,
+                vec![Value::Integer(1), Value::String("Grace".to_owned()), Value::Boolean(false)],
+            )
+            .unwrap_err();
+
+        assert!(matches!(error, StorageError::Constraint(ConstraintError::DuplicateKey)));
+    }
+
+    #[test]
+    fn update_table_row_rejects_primary_key_change() {
+        let file = NamedTempFile::new().unwrap();
+        let (catalog, records) = open(file.path()).unwrap();
+        let table = catalog.create_table("users", users_schema()).unwrap();
+        let inserted = records
+            .insert_table_row(
+                &table,
+                vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true)],
+            )
+            .unwrap();
+
+        let error = records
+            .update_table_row(
+                &table,
+                &inserted,
+                vec![Value::Integer(2), Value::String("Ada".to_owned()), Value::Boolean(false)],
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            StorageError::InvalidArgument(InvalidArgumentError::PrimaryKeyUpdate {
+                table,
+                column,
+            }) if table == "users" && column == "id"
+        ));
+        let mut users = catalog.table_cursor_by_name("users").unwrap();
+        assert!(users.get(1).unwrap().is_some());
+        assert!(users.get(2).unwrap().is_none());
+    }
+
+    #[test]
+    fn insert_table_row_rejects_null_before_writing_row() {
         let file = NamedTempFile::new().unwrap();
         let (catalog, records) = open(file.path()).unwrap();
         let table = catalog.create_table("users", users_schema()).unwrap();
@@ -246,13 +358,12 @@ mod tests {
             error,
             StorageError::Constraint(ConstraintError::NullValue { column }) if column == "active"
         ));
-        assert_eq!(catalog.table_schema_by_name("users").unwrap().last_row_id, 0);
         let mut users = catalog.table_cursor_by_name("users").unwrap();
         assert!(users.get(1).unwrap().is_none());
     }
 
     #[test]
-    fn insert_table_row_rejects_wrong_type_before_allocating_row_id() {
+    fn insert_table_row_rejects_wrong_type_before_writing_row() {
         let file = NamedTempFile::new().unwrap();
         let (catalog, records) = open(file.path()).unwrap();
         let table = catalog.create_table("users", users_schema()).unwrap();
@@ -276,7 +387,6 @@ mod tests {
                 actual: "text",
             }) if column == "active"
         ));
-        assert_eq!(catalog.table_schema_by_name("users").unwrap().last_row_id, 0);
         let mut users = catalog.table_cursor_by_name("users").unwrap();
         assert!(users.get(1).unwrap().is_none());
     }

--- a/src/executor/expression.rs
+++ b/src/executor/expression.rs
@@ -1,6 +1,7 @@
 use crate::{
     core::{
-        OwnedTableRecord as TableRecord, TableSchema, Tuple, TupleView, Value, access::RecordAccess,
+        OwnedTableRecord as TableRecord, TableKey, TableSchema, Tuple, TupleView, Value,
+        access::RecordAccess,
     },
     planner::{BoundColumn, PlannedExpression, UpdateAssignment},
     sql_parser::parser::op::Op,
@@ -11,7 +12,7 @@ use super::{ExecutionOutput, ExecutorError, ExecutorResult, RowStream};
 /// Evaluates one planned scalar expression against a record.
 ///
 /// The result is represented as a single-column [`TableRecord`] that preserves
-/// the input record's row id. This is primarily useful for tests and callers
+/// the input record's table key. This is primarily useful for tests and callers
 /// that need expression evaluation without building a full projection plan.
 pub fn evaluate_expression(
     expression: &PlannedExpression,
@@ -23,10 +24,10 @@ pub fn evaluate_expression(
 /// Executes a `VALUES` plan as a stream of evaluated literal rows.
 ///
 /// Each values row is evaluated against an empty synthetic record. The row's
-/// position in the `VALUES` list becomes the result row id.
+/// position in the `VALUES` list becomes the result table key.
 pub(super) fn execute_values(rows: Vec<Vec<PlannedExpression>>) -> ExecutorResult<ExecutionOutput> {
-    let rows = rows.into_iter().enumerate().map(|(row_id, expressions)| {
-        let input = empty_record(row_id as u64)?;
+    let rows = rows.into_iter().enumerate().map(|(table_key, expressions)| {
+        let input = empty_record(table_key as TableKey)?;
         evaluate_expressions(&expressions, &input)
     });
     Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
@@ -145,7 +146,7 @@ fn evaluate_expressions_in_context(
         .iter()
         .map(|expression| evaluate_value(expression, context))
         .collect::<ExecutorResult<Vec<_>>>()?;
-    record_from_values(context.row_id, values)
+    record_from_values(context.table_key, values)
 }
 
 /// Evaluates a scalar expression to one typed value.
@@ -177,11 +178,11 @@ pub(super) fn evaluate_value(
 
 /// Parsed view of an input record used while evaluating expressions.
 ///
-/// The context keeps the original row id so projected records preserve their
+/// The context keeps the original table key so projected records preserve their
 /// source identity, and it keeps a zero-copy tuple view so column references can
 /// read typed values by ordinal.
 pub(super) struct EvaluationContext<'a> {
-    row_id: u64,
+    table_key: TableKey,
     tuple: TupleView<'a>,
 }
 
@@ -189,7 +190,7 @@ impl<'a> EvaluationContext<'a> {
     /// Parses the encoded tuple bytes from `record`.
     pub(super) fn from_record(record: &'a TableRecord) -> ExecutorResult<Self> {
         let tuple = TupleView::parse(&record.record).map_err(ExecutorError::InvalidTuple)?;
-        Ok(Self { row_id: record.row_id, tuple })
+        Ok(Self { table_key: record.table_key, tuple })
     }
 
     /// Reads the value for a planner-bound column reference.
@@ -352,15 +353,18 @@ fn compare_ordered<T: PartialOrd>(left: &T, op: Op, right: &T) -> bool {
     }
 }
 
-/// Builds an encoded empty record with the provided row id.
-pub(super) fn empty_record(row_id: u64) -> ExecutorResult<TableRecord> {
-    record_from_values(row_id, Vec::new())
+/// Builds an encoded empty record with the provided table key.
+pub(super) fn empty_record(table_key: TableKey) -> ExecutorResult<TableRecord> {
+    record_from_values(table_key, Vec::new())
 }
 
 /// Builds a table record from owned typed values.
-pub(super) fn record_from_values(row_id: u64, values: Vec<Value>) -> ExecutorResult<TableRecord> {
+pub(super) fn record_from_values(
+    table_key: TableKey,
+    values: Vec<Value>,
+) -> ExecutorResult<TableRecord> {
     let record = record_bytes_from_values(values)?;
-    Ok(TableRecord { row_id, record: record.into_boxed_slice() })
+    Ok(TableRecord { table_key, record: record.into_boxed_slice() })
 }
 
 /// Serializes typed values using the tuple storage format.

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -5,7 +5,7 @@ use tempfile::tempdir;
 use super::*;
 use crate::{
     core::{
-        ColumnSchema, DataType, PAGE_SIZE, Tuple, TupleSchema,
+        ColumnSchema, DataType, PAGE_SIZE, TableKey, Tuple, TupleSchema,
         error::{ConstraintError, InternalError, InvariantViolation, StorageError},
     },
     error::DatabaseError,
@@ -14,8 +14,8 @@ use crate::{
     sql_parser::parser::Parser,
 };
 
-fn record(row_id: u64, values: Vec<Value>) -> TableRecord {
-    record_from_values(row_id, values).unwrap()
+fn record(table_key: TableKey, values: Vec<Value>) -> TableRecord {
+    record_from_values(table_key, values).unwrap()
 }
 
 fn values(record: &TableRecord) -> Vec<Value> {
@@ -146,29 +146,29 @@ fn insert_many_users_sql(count: u64) -> String {
     sql
 }
 
-fn assert_user_row(database: &Database, row_id: u64, expected_name: &str) {
+fn assert_user_row(database: &Database, table_key: TableKey, expected_name: &str) {
     let mut users = database.table_cursor_by_name("users").unwrap();
-    let row = users.get(row_id).unwrap().expect("user row should exist");
+    let row = users.get(table_key).unwrap().expect("user row should exist");
     assert_eq!(
         values(&row),
         vec![
-            Value::Integer(row_id as i32),
+            Value::Integer(table_key),
             Value::String(expected_name.to_owned()),
             Value::Boolean(true),
         ]
     );
 }
 
-fn assert_name_index_entry(database: &Database, name: &str, row_id: u64) {
+fn assert_name_index_entry(database: &Database, name: &str, table_key: TableKey) {
     let mut index = database.index_cursor_by_name("idx_users_name").unwrap();
     let key = Tuple::new(vec![Value::String(name.to_owned())]).to_bytes().unwrap();
     let entry = index.get(&key).unwrap().expect("index entry should exist");
-    assert_eq!(entry.row_id, row_id);
+    assert_eq!(entry.table_key, table_key);
 }
 
-fn assert_user_row_absent(database: &Database, row_id: u64) {
+fn assert_user_row_absent(database: &Database, table_key: TableKey) {
     let mut users = database.table_cursor_by_name("users").unwrap();
-    assert!(users.get(row_id).unwrap().is_none());
+    assert!(users.get(table_key).unwrap().is_none());
 }
 
 fn assert_name_index_absent(database: &Database, name: &str) {
@@ -184,7 +184,7 @@ fn single_literal_expression_produces_one_column_record() {
         evaluate_expression(&PlannedExpression::Literal(Value::String("Ada".to_owned())), &input)
             .unwrap();
 
-    assert_eq!(output.row_id, 7);
+    assert_eq!(output.table_key, 7);
     assert_eq!(values(&output), vec![Value::String("Ada".to_owned())]);
 }
 
@@ -196,7 +196,7 @@ fn single_column_expression_reads_bound_ordinal() {
         evaluate_expression(&PlannedExpression::Column(bound("name", 1, DataType::Text)), &input)
             .unwrap();
 
-    assert_eq!(output.row_id, 8);
+    assert_eq!(output.table_key, 8);
     assert_eq!(values(&output), vec![Value::String("Grace".to_owned())]);
 }
 
@@ -225,7 +225,7 @@ fn project_evaluates_multiple_expressions_in_order() {
     let rows = collect_rows(executor.execute(plan).unwrap()).unwrap();
 
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].row_id, 0);
+    assert_eq!(rows[0].table_key, 0);
     assert_eq!(values(&rows[0]), vec![Value::Integer(5), Value::Integer(9)]);
 }
 
@@ -592,12 +592,12 @@ fn select_with_projection_and_filter_executes_end_to_end() {
     let rows = collect_rows(executor.execute(plan.physical).unwrap()).unwrap();
 
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].row_id, 1);
+    assert_eq!(rows[0].table_key, 1);
     assert_eq!(values(&rows[0]), vec![Value::String("Ada".to_owned())]);
 }
 
 #[test]
-fn insert_values_allocates_row_ids_and_persists_rows() {
+fn insert_values_uses_primary_keys_and_persists_rows() {
     let dir = tempdir().unwrap();
     let database = Database::create(dir.path().join("test.db")).unwrap();
     database.create_table("users", users_schema()).unwrap();
@@ -613,7 +613,6 @@ fn insert_values_allocates_row_ids_and_persists_rows() {
     let output = executor.execute(plan.physical).unwrap();
 
     assert!(matches!(output, ExecutionOutput::RowsAffected(2)));
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 2);
 
     let mut users = database.table_cursor_by_name("users").unwrap();
     let first = users.get(1).unwrap().expect("first inserted row should exist");
@@ -642,7 +641,6 @@ fn insert_values_rejects_omitted_non_nullable_columns() {
     let mut executor = Executor::new(&database);
 
     assert!(executor.execute(plan).is_err_and(|error| is_null_value_error(error, "active")));
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
 }
 
 #[test]
@@ -664,7 +662,6 @@ fn insert_values_rejects_values_with_wrong_type() {
         DataType::Integer,
         "text"
     )));
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
 }
 
 #[test]
@@ -685,11 +682,10 @@ fn insert_values_rejects_null_for_non_nullable_columns() {
     let mut executor = Executor::new(&database);
 
     assert!(executor.execute(plan).is_err_and(|error| is_null_value_error(error, "name")));
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
 }
 
 #[test]
-fn failed_insert_does_not_advance_last_row_id() {
+fn failed_insert_does_not_write_partial_row() {
     let dir = tempdir().unwrap();
     let database = Database::create(dir.path().join("test.db")).unwrap();
     database.create_table("users", users_schema()).unwrap();
@@ -705,7 +701,6 @@ fn failed_insert_does_not_advance_last_row_id() {
         vec![vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(true)]],
     );
     executor.execute(valid).unwrap();
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
 
     let invalid = insert_values_plan(
         &database,
@@ -724,7 +719,6 @@ fn failed_insert_does_not_advance_last_row_id() {
     assert!(executor.execute(invalid).is_err_and(|error| {
         is_type_mismatch_error(error, "active", DataType::Boolean, "text")
     }));
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
 
     let mut users = database.table_cursor_by_name("users").unwrap();
     assert!(users.get(2).unwrap().is_none());
@@ -745,7 +739,6 @@ fn failed_multi_row_insert_rolls_back_rows_already_inserted_in_statement() {
         is_database_type_mismatch_error(error, "active", DataType::Boolean, "text")
     }));
 
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 0);
     let mut users = database.table_cursor_by_name("users").unwrap();
     assert!(users.get(1).unwrap().is_none());
     assert!(users.get(2).unwrap().is_none());
@@ -784,16 +777,15 @@ fn failed_multi_row_insert_in_explicit_transaction_rolls_back_statement_before_c
     let mut index = reopened.index_cursor_by_name("idx_users_name").unwrap();
     let ada = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
     let linus = Tuple::new(vec![Value::String("Linus".to_owned())]).to_bytes().unwrap();
-    let row = users.get(1).unwrap().expect("successful statement should commit");
+    let row = users.get(2).unwrap().expect("successful statement should commit");
 
-    assert_eq!(reopened.table_schema_by_name("users").unwrap().last_row_id, 1);
     assert_eq!(
         values(&row),
         vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Boolean(true)]
     );
-    assert!(users.get(2).unwrap().is_none());
+    assert!(users.get(1).unwrap().is_none());
     assert!(index.get(&ada).unwrap().is_none());
-    assert_eq!(index.get(&linus).unwrap().unwrap().row_id, 1);
+    assert_eq!(index.get(&linus).unwrap().unwrap().table_key, 2);
 }
 
 #[test]
@@ -862,7 +854,7 @@ fn create_index_backfills_existing_table_rows() {
     let key = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
     let entry = index.get(&key).unwrap().expect("index entry should be backfilled");
 
-    assert_eq!(entry.row_id, 1);
+    assert_eq!(entry.table_key, 1);
 }
 
 #[test]
@@ -885,7 +877,7 @@ fn insert_values_updates_existing_secondary_indexes() {
     let key = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
     let entry = index.get(&key).unwrap().expect("index entry should track inserted row");
 
-    assert_eq!(entry.row_id, 1);
+    assert_eq!(entry.table_key, 1);
 }
 
 #[test]
@@ -1043,16 +1035,30 @@ fn update_assignment_expression_reads_original_row_values() {
     execute_sql(&database, "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE);")
         .unwrap();
 
-    execute_sql(&database, "UPDATE users SET id = id + 1, active = NOT active WHERE id == 1;")
-        .unwrap();
+    execute_sql(&database, "UPDATE users SET active = NOT active WHERE id == 1;").unwrap();
 
     let mut users = database.table_cursor_by_name("users").unwrap();
-    let row = users.get(1).unwrap().expect("row id should be preserved");
+    let row = users.get(1).unwrap().expect("table key should be preserved");
     assert_eq!(
         values(&row),
-        vec![Value::Integer(2), Value::String("Ada".to_owned()), Value::Boolean(false)]
+        vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Boolean(false)]
     );
-    assert!(users.get(2).unwrap().is_none());
+}
+
+#[test]
+fn update_rejects_primary_key_assignment() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "INSERT INTO users (id, name, active) VALUES (1, 'Ada', TRUE);")
+        .unwrap();
+
+    assert!(matches!(
+        execute_sql(&database, "UPDATE users SET id = id + 1 WHERE id == 1;"),
+        Err(DatabaseError::Planner(crate::planner::PlannerError::PrimaryKeyUpdate { column }))
+            if column == "id"
+    ));
+    assert_user_row(&database, 1, "Ada");
 }
 
 #[test]
@@ -1182,7 +1188,6 @@ COMMIT;
 
     assert_eq!(schema.name, "users");
     assert_eq!(schema.row.columns.len(), 3);
-    assert_eq!(schema.last_row_id, 2);
     assert_name_index_entry(&reopened, "Ada", 1);
     assert_name_index_entry(&reopened, "Grace", 2);
 }
@@ -1208,7 +1213,6 @@ ROLLBACK;
     );
 
     let mut users = database.table_cursor_by_name("users").unwrap();
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
     assert!(users.get(1).unwrap().is_some());
     assert!(users.get(2).unwrap().is_none());
     assert!(database.table_schema_by_name("rolled_back").is_err());
@@ -1382,14 +1386,13 @@ fn dropping_session_with_active_transaction_rolls_back_and_releases_database_han
         .unwrap();
 
     let mut users = database.table_cursor_by_name("users").unwrap();
-    let row = users.get(1).unwrap().expect("new statement should commit after session drop");
+    let row = users.get(2).unwrap().expect("new statement should commit after session drop");
 
-    assert_eq!(database.table_schema_by_name("users").unwrap().last_row_id, 1);
     assert_eq!(
         values(&row),
         vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Boolean(true)]
     );
-    assert!(users.get(2).unwrap().is_none());
+    assert!(users.get(1).unwrap().is_none());
 }
 
 #[test]
@@ -1448,7 +1451,6 @@ fn committed_large_insert_with_btree_splits_recovers_from_wal_after_crash() {
 
     let reopened = Database::open(&path).unwrap();
 
-    assert_eq!(reopened.table_schema_by_name("users").unwrap().last_row_id, 500);
     assert_user_row(&reopened, 1, "user1");
     assert_user_row(&reopened, 250, "user250");
     assert_user_row(&reopened, 500, "user500");
@@ -1501,7 +1503,6 @@ fn failed_indexed_multi_row_insert_rolls_back_after_reopen() {
     let mut index = reopened.index_cursor_by_name("idx_users_name").unwrap();
     let ada = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
 
-    assert_eq!(reopened.table_schema_by_name("users").unwrap().last_row_id, 0);
     assert!(users.get(1).unwrap().is_none());
     assert!(index.get(&ada).unwrap().is_none());
 }
@@ -1541,7 +1542,6 @@ fn uncommitted_flushed_insert_is_undone_during_recovery() {
     let mut index = reopened.index_cursor_by_name("idx_users_name").unwrap();
     let ada = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
 
-    assert_eq!(reopened.table_schema_by_name("users").unwrap().last_row_id, 0);
     assert!(users.get(1).unwrap().is_none());
     assert!(index.get(&ada).unwrap().is_none());
 }
@@ -1691,6 +1691,6 @@ fn select_without_from_executes_through_one_row_and_project() {
     let rows = collect_rows(executor.execute(plan.physical).unwrap()).unwrap();
 
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].row_id, 0);
+    assert_eq!(rows[0].table_key, 0);
     assert_eq!(values(&rows[0]), vec![Value::Integer(3)]);
 }

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -392,6 +392,9 @@ pub enum PlannerError {
     /// A `CREATE INDEX` column list named the same column more than once.
     #[error("duplicate index column: {column}")]
     DuplicateIndexColumn { column: String },
+    /// An `UPDATE` attempted to modify a primary-key column.
+    #[error("cannot update primary key column: {column}")]
+    PrimaryKeyUpdate { column: String },
     /// A values row does not provide exactly one value for each target column.
     #[error("insert row has {values} values for {columns} columns")]
     InsertColumnValueCount { columns: usize, values: usize },
@@ -544,8 +547,12 @@ impl<'db> Planner<'db> {
                     column: assignment.column.to_owned(),
                 });
             }
+            let column = bind_column(&table, assignment.column)?;
+            if table.row.columns[column.ordinal].primary_key {
+                return Err(PlannerError::PrimaryKeyUpdate { column: column.name });
+            }
             assignments.push(UpdateAssignment {
-                column: bind_column(&table, assignment.column)?,
+                column,
                 expression: self.bind_expression(&assignment.expression, Some(&table))?,
             });
         }

--- a/src/sql_parser/error.rs
+++ b/src/sql_parser/error.rs
@@ -35,6 +35,7 @@ pub enum SQLErrorKind<'a> {
     UnterminatedStatement,
     UnterminatedString,
     DuplicateConstraint { column: &'a str, constraint: ColumnConstraint },
+    InvalidPrimaryKey { reason: &'static str },
 }
 
 impl Display for SQLErrorKind<'_> {
@@ -93,6 +94,9 @@ impl Display for SQLErrorKind<'_> {
             }
             SQLErrorKind::DuplicateConstraint { column, constraint } => {
                 write!(f, "Duplicate constraint for column '{column}': {constraint}")
+            }
+            SQLErrorKind::InvalidPrimaryKey { reason } => {
+                write!(f, "Invalid primary key: {reason}")
             }
         }
     }

--- a/src/sql_parser/parser/stmt/create_table.rs
+++ b/src/sql_parser/parser/stmt/create_table.rs
@@ -90,6 +90,7 @@ impl<'a> Parser<'a> {
         self.lexer.expect_token(TokenKind::LeftParen)?;
 
         let columns = self.parse_comma_separated_list(|p| p.parse_column_definition())?;
+        validate_primary_key(&columns, self.lexer.position)?;
 
         self.lexer.expect_token(TokenKind::RightParen)?;
         self.lexer.expect_token(TokenKind::Semicolon)?;
@@ -133,6 +134,47 @@ impl<'a> Parser<'a> {
     }
 }
 
+fn validate_primary_key<'a>(columns: &[Column<'a>], pos: usize) -> Result<(), SQLError<'a>> {
+    let primary_keys: Vec<_> = columns
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| column.constraints.contains(&ColumnConstraint::PrimaryKey))
+        .collect();
+
+    if primary_keys.len() != 1 {
+        return Err(SQLError::new(
+            SQLErrorKind::InvalidPrimaryKey {
+                reason: "tables must declare exactly one primary key",
+            },
+            pos,
+        ));
+    }
+
+    let (ordinal, column) = primary_keys[0];
+    if ordinal != 0 {
+        return Err(SQLError::new(
+            SQLErrorKind::InvalidPrimaryKey { reason: "primary key must be the first column" },
+            pos,
+        ));
+    }
+
+    if column.column_type != ColumnType::Int {
+        return Err(SQLError::new(
+            SQLErrorKind::InvalidPrimaryKey { reason: "primary key must use INT type" },
+            pos,
+        ));
+    }
+
+    if column.constraints.contains(&ColumnConstraint::Nullable) {
+        return Err(SQLError::new(
+            SQLErrorKind::InvalidPrimaryKey { reason: "primary key cannot be nullable" },
+            pos,
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,13 +186,17 @@ mod tests {
 
     #[test]
     fn test_parse_simple_create_table() {
-        let s = "CREATE TABLE users (id INT, name TEXT, age INT);";
+        let s = "CREATE TABLE users (id INT PRIMARY KEY, name TEXT, age INT);";
         let mut parser = Parser::new(s);
 
         let expected_query = CreateTableQuery {
             table_name: "users",
             columns: vec![
-                Column { name: "id", column_type: ColumnType::Int, constraints: Vec::new() },
+                Column {
+                    name: "id",
+                    column_type: ColumnType::Int,
+                    constraints: Vec::from([ColumnConstraint::PrimaryKey]),
+                },
                 Column { name: "name", column_type: ColumnType::Text, constraints: Vec::new() },
                 Column { name: "age", column_type: ColumnType::Int, constraints: Vec::new() },
             ],
@@ -162,13 +208,17 @@ mod tests {
 
     #[test]
     fn test_parse_create_table_with_all_types() {
-        let s = "CREATE TABLE products (id INT, name TEXT, price FLOAT);";
+        let s = "CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price FLOAT);";
         let mut parser = Parser::new(s);
 
         let expected_query = CreateTableQuery {
             table_name: "products",
             columns: vec![
-                Column { name: "id", column_type: ColumnType::Int, constraints: Vec::new() },
+                Column {
+                    name: "id",
+                    column_type: ColumnType::Int,
+                    constraints: Vec::from([ColumnConstraint::PrimaryKey]),
+                },
                 Column { name: "name", column_type: ColumnType::Text, constraints: Vec::new() },
                 Column { name: "price", column_type: ColumnType::Float, constraints: Vec::new() },
             ],
@@ -180,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_parse_create_table_with_single_column() {
-        let s = "CREATE TABLE single_column (id INT);";
+        let s = "CREATE TABLE single_column (id INT PRIMARY KEY);";
         let mut parser = Parser::new(s);
 
         let expected_query = CreateTableQuery {
@@ -188,7 +238,7 @@ mod tests {
             columns: vec![Column {
                 name: "id",
                 column_type: ColumnType::Int,
-                constraints: Vec::new(),
+                constraints: Vec::from([ColumnConstraint::PrimaryKey]),
             }],
         };
 
@@ -211,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_create_table_with_missing_table_name() {
-        let s = "CREATE TABLE (id INT);";
+        let s = "CREATE TABLE (id INT PRIMARY KEY);";
         let mut parser = Parser::new(s);
 
         let err = SQLError {
@@ -245,13 +295,17 @@ mod tests {
 
     #[test]
     fn test_create_table_with_nullable_constraint() {
-        let s = "CREATE TABLE users (id INT, name TEXT NULLABLE);";
+        let s = "CREATE TABLE users (id INT PRIMARY KEY, name TEXT NULLABLE);";
         let mut parser = Parser::new(s);
 
         let expected_query = CreateTableQuery {
             table_name: "users",
             columns: vec![
-                Column { name: "id", column_type: ColumnType::Int, constraints: Vec::new() },
+                Column {
+                    name: "id",
+                    column_type: ColumnType::Int,
+                    constraints: Vec::from([ColumnConstraint::PrimaryKey]),
+                },
                 Column {
                     name: "name",
                     column_type: ColumnType::Text,
@@ -266,7 +320,7 @@ mod tests {
 
     #[test]
     fn test_columns_not_nullable_by_default() {
-        let s = "CREATE TABLE test (a INT);";
+        let s = "CREATE TABLE test (a INT PRIMARY KEY);";
         let mut parser = Parser::new(s);
 
         let expected_query = CreateTableQuery {
@@ -274,11 +328,62 @@ mod tests {
             columns: vec![Column {
                 name: "a",
                 column_type: ColumnType::Int,
-                constraints: Vec::new(),
+                constraints: Vec::from([ColumnConstraint::PrimaryKey]),
             }],
         };
 
         let expected = CreateTable(expected_query);
         assert_eq!(Ok(expected), parser.stmt());
+    }
+
+    #[test]
+    fn create_table_requires_exactly_one_primary_key() {
+        let mut parser = Parser::new("CREATE TABLE users (id INT, name TEXT);");
+
+        assert!(matches!(
+            parser.stmt(),
+            Err(SQLError { kind: SQLErrorKind::InvalidPrimaryKey { .. }, .. })
+        ));
+    }
+
+    #[test]
+    fn create_table_rejects_multiple_primary_keys() {
+        let mut parser =
+            Parser::new("CREATE TABLE users (id INT PRIMARY KEY, other INT PRIMARY KEY);");
+
+        assert!(matches!(
+            parser.stmt(),
+            Err(SQLError { kind: SQLErrorKind::InvalidPrimaryKey { .. }, .. })
+        ));
+    }
+
+    #[test]
+    fn create_table_requires_primary_key_first() {
+        let mut parser = Parser::new("CREATE TABLE users (name TEXT, id INT PRIMARY KEY);");
+
+        assert!(matches!(
+            parser.stmt(),
+            Err(SQLError { kind: SQLErrorKind::InvalidPrimaryKey { .. }, .. })
+        ));
+    }
+
+    #[test]
+    fn create_table_requires_integer_primary_key() {
+        let mut parser = Parser::new("CREATE TABLE users (id TEXT PRIMARY KEY);");
+
+        assert!(matches!(
+            parser.stmt(),
+            Err(SQLError { kind: SQLErrorKind::InvalidPrimaryKey { .. }, .. })
+        ));
+    }
+
+    #[test]
+    fn create_table_rejects_nullable_primary_key() {
+        let mut parser = Parser::new("CREATE TABLE users (id INT PRIMARY KEY NULLABLE);");
+
+        assert!(matches!(
+            parser.stmt(),
+            Err(SQLError { kind: SQLErrorKind::InvalidPrimaryKey { .. }, .. })
+        ));
     }
 }

--- a/tests/sql_parser_roundtrip.rs
+++ b/tests/sql_parser_roundtrip.rs
@@ -219,24 +219,20 @@ fn draw_explain_select(tc: &TestCase) -> String {
 
 fn draw_create_table(tc: &TestCase) -> String {
     let table = draw_identifier(tc);
-    let columns = (0..draw_non_empty_len(tc, 5))
-        .map(|_| {
-            let column_type = match draw_index(tc, 3) {
-                0 => "INT",
-                1 => "FLOAT",
-                2 => "TEXT",
-                _ => unreachable!(),
-            };
-            let mut column = format!("{} {column_type}", draw_identifier(tc));
-            if draw_bool(tc) {
-                column.push_str(" PRIMARY KEY");
-            }
-            if draw_bool(tc) {
-                column.push_str(" NULLABLE");
-            }
-            column
-        })
-        .collect::<Vec<_>>();
+    let mut columns = vec![format!("{} INT PRIMARY KEY", draw_identifier(tc))];
+    columns.extend((0..draw_index(tc, 5)).map(|_| {
+        let column_type = match draw_index(tc, 3) {
+            0 => "INT",
+            1 => "FLOAT",
+            2 => "TEXT",
+            _ => unreachable!(),
+        };
+        let mut column = format!("{} {column_type}", draw_identifier(tc));
+        if draw_bool(tc) {
+            column.push_str(" NULLABLE");
+        }
+        column
+    }));
 
     format!("CREATE TABLE {table} ({});", columns.join(", "))
 }


### PR DESCRIPTION
Replace `rowid` system with table primary keys.
This change removes the need for an index mapping primary keys to `rowid`s.
This will in turn reduce write amplification since the `primary key -> rowid` index will not need to be updated.
The change will also remove the need for an index scan for queries with a filter on the table's primary key, such as: `... WHERE 10 < id AND id <= 20 ...`.
This is because we can now move the table cursor directly to the first row with `id > 10`, and skip the intermediate index.