### PR TITLE
Implement primary key range scan

### DIFF
--- a/src/core/access.rs
+++ b/src/core/access.rs
@@ -1,6 +1,6 @@
 use crate::core::{
-    IndexSchema, OwnedTableRecord, TableSchema, TupleSchema, Value, error::StorageResult,
-    record_manager::TableScan,
+    IndexSchema, OwnedTableRecord, TableKeyRange, TableSchema, TupleSchema, Value,
+    error::StorageResult, record_manager::TableScan,
 };
 
 pub(crate) trait SchemaAccess {
@@ -20,6 +20,12 @@ pub(crate) trait DdlAccess {
 
 pub(crate) trait RecordAccess {
     fn scan_table(&self, table: &TableSchema) -> StorageResult<TableScan>;
+
+    fn scan_table_range(
+        &self,
+        table: &TableSchema,
+        range: TableKeyRange,
+    ) -> StorageResult<TableScan>;
 
     fn insert_table_row(
         &self,

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::core::{
-    IndexSchema, OwnedTableRecord, TableSchema, TupleSchema, Value,
+    IndexSchema, OwnedTableRecord, TableKeyRange, TableSchema, TupleSchema, Value,
     access::{DdlAccess, RecordAccess, SchemaAccess},
     catalog_manager::CatalogManager,
     cursor::{IndexCursor, TableCursor},
@@ -132,6 +132,14 @@ impl Database {
         self.records.scan_table(table)
     }
 
+    pub(crate) fn scan_table_range(
+        &self,
+        table: &TableSchema,
+        range: TableKeyRange,
+    ) -> StorageResult<TableScan> {
+        self.records.scan_table_range(table, range)
+    }
+
     pub(crate) fn insert_table_row(
         &self,
         table: &TableSchema,
@@ -186,6 +194,14 @@ impl DdlAccess for Database {
 impl RecordAccess for Database {
     fn scan_table(&self, table: &TableSchema) -> StorageResult<TableScan> {
         Database::scan_table(self, table)
+    }
+
+    fn scan_table_range(
+        &self,
+        table: &TableSchema,
+        range: TableKeyRange,
+    ) -> StorageResult<TableScan> {
+        Database::scan_table_range(self, table, range)
     }
 
     fn insert_table_row(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 pub(crate) mod access;
 pub(crate) mod btree;
 pub(crate) mod catalog;
@@ -41,3 +43,79 @@ pub type PageId = u64;
 pub type CatalogId = i32;
 pub type TableKey = i32;
 pub(crate) type SlotId = u16;
+
+/// Inclusive or exclusive bound over table primary keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableKeyBound {
+    /// The bound includes the stored key value.
+    Inclusive(TableKey),
+    /// The bound excludes the stored key value.
+    Exclusive(TableKey),
+}
+
+impl TableKeyBound {
+    /// Returns the raw key value stored in this bound.
+    pub fn value(self) -> TableKey {
+        match self {
+            Self::Inclusive(value) | Self::Exclusive(value) => value,
+        }
+    }
+
+    /// Returns whether `key` satisfies this lower bound.
+    pub fn contains_lower(self, key: TableKey) -> bool {
+        match self {
+            Self::Inclusive(value) => key >= value,
+            Self::Exclusive(value) => key > value,
+        }
+    }
+
+    /// Returns whether `key` satisfies this upper bound.
+    pub fn contains_upper(self, key: TableKey) -> bool {
+        match self {
+            Self::Inclusive(value) => key <= value,
+            Self::Exclusive(value) => key < value,
+        }
+    }
+}
+
+impl fmt::Display for TableKeyBound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inclusive(value) => write!(f, "{value} inclusive"),
+            Self::Exclusive(value) => write!(f, "{value} exclusive"),
+        }
+    }
+}
+
+/// Ordered primary-key range for scanning a table B+-tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TableKeyRange {
+    /// Optional lower bound.
+    pub lower: Option<TableKeyBound>,
+    /// Optional upper bound.
+    pub upper: Option<TableKeyBound>,
+}
+
+impl TableKeyRange {
+    /// Returns a range with no lower or upper bound.
+    pub fn unbounded() -> Self {
+        Self::default()
+    }
+
+    /// Returns whether `key` is inside the range.
+    pub fn contains(self, key: TableKey) -> bool {
+        self.lower.is_none_or(|bound| bound.contains_lower(key))
+            && self.upper.is_none_or(|bound| bound.contains_upper(key))
+    }
+}
+
+impl fmt::Display for TableKeyRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.lower, self.upper) {
+            (None, None) => write!(f, "unbounded"),
+            (Some(lower), None) => write!(f, "lower={lower}"),
+            (None, Some(upper)) => write!(f, "upper={upper}"),
+            (Some(lower), Some(upper)) => write!(f, "lower={lower} upper={upper}"),
+        }
+    }
+}

--- a/src/core/page_cache.rs
+++ b/src/core/page_cache.rs
@@ -794,25 +794,16 @@ mod tests {
         let (_file, disk_manager) = create_disk_with_pages(&pages);
         let cache = PageCache::new(disk_manager, 2).unwrap();
 
-        cache.inner.frames[0].page_id.set(Some(0));
-        *cache.inner.frames[0].data.borrow_mut() = pages[0];
-        cache.inner.frames[0].dirty.set(false);
-        cache.inner.frames[0].pin_count.set(1);
-
-        cache.inner.frames[1].page_id.set(Some(1));
-        *cache.inner.frames[1].data.borrow_mut() = pages[1];
-        cache.inner.frames[1].dirty.set(false);
-        cache.inner.frames[1].pin_count.set(0);
-
-        let mut meta = cache.inner.meta.borrow_mut();
-        meta.page_table.insert(0, 0);
-        meta.page_table.insert(1, 1);
-        drop(meta);
+        let pinned = cache.fetch_page(0).unwrap();
+        {
+            let _unpinned = cache.fetch_page(1).unwrap();
+        }
 
         {
             let _guard = cache.fetch_page(2).unwrap();
         }
 
+        assert_eq!(pinned.page_id(), 0);
         assert_eq!(cache.inner.frames[0].page_id.get(), Some(0));
         let page_table = &cache.inner.meta.borrow().page_table;
         assert!(page_table.contains_key(&0));
@@ -826,20 +817,8 @@ mod tests {
         let (_file, disk_manager) = create_disk_with_pages(&pages);
         let cache = PageCache::new(disk_manager, 2).unwrap();
 
-        cache.inner.frames[0].page_id.set(Some(0));
-        *cache.inner.frames[0].data.borrow_mut() = pages[0];
-        cache.inner.frames[0].dirty.set(false);
-        cache.inner.frames[0].pin_count.set(1);
-
-        cache.inner.frames[1].page_id.set(Some(1));
-        *cache.inner.frames[1].data.borrow_mut() = pages[1];
-        cache.inner.frames[1].dirty.set(false);
-        cache.inner.frames[1].pin_count.set(1);
-
-        let mut meta = cache.inner.meta.borrow_mut();
-        meta.page_table.insert(0, 0);
-        meta.page_table.insert(1, 1);
-        drop(meta);
+        let _first = cache.fetch_page(0).unwrap();
+        let _second = cache.fetch_page(1).unwrap();
 
         let result = cache.fetch_page(2);
         assert!(matches!(result, Err(PageCacheError::NoEvictableFrame)));
@@ -1148,16 +1127,12 @@ mod tests {
 
     #[test]
     fn flush_page_returns_error_if_page_is_pinned() {
-        let page = page_with_pattern(8);
-        let pages = [page];
+        let pages = [page_with_pattern(8)];
         let (_file, disk_manager) = create_disk_with_pages(&pages);
         let cache = PageCache::new(disk_manager, 1).unwrap();
 
-        cache.inner.frames[0].page_id.set(Some(0));
-        *cache.inner.frames[0].data.borrow_mut() = page;
-        cache.inner.frames[0].dirty.set(true);
-        cache.inner.frames[0].pin_count.set(1);
-        cache.inner.meta.borrow_mut().page_table.insert(0, 0);
+        let guard = cache.fetch_page(0).unwrap();
+        guard.write().unwrap().page_mut()[0] = 99;
 
         let result = cache.flush_page(0);
         assert!(matches!(result, Err(PageCacheError::PinnedPage { page_id: 0 })));
@@ -1205,16 +1180,12 @@ mod tests {
 
     #[test]
     fn flush_all_returns_error_if_dirty_page_is_pinned() {
-        let page = page_with_pattern(19);
-        let pages = [page];
+        let pages = [page_with_pattern(19)];
         let (_file, disk_manager) = create_disk_with_pages(&pages);
         let cache = PageCache::new(disk_manager, 1).unwrap();
 
-        cache.inner.frames[0].page_id.set(Some(0));
-        *cache.inner.frames[0].data.borrow_mut() = page;
-        cache.inner.frames[0].dirty.set(true);
-        cache.inner.frames[0].pin_count.set(1);
-        cache.inner.meta.borrow_mut().page_table.insert(0, 0);
+        let guard = cache.fetch_page(0).unwrap();
+        guard.write().unwrap().page_mut()[0] = 99;
 
         let result = cache.flush_all();
         assert!(matches!(result, Err(PageCacheError::PinnedPage { page_id: 0 })));

--- a/src/core/record_manager.rs
+++ b/src/core/record_manager.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    DataType, OwnedTableRecord, TableKey, TableSchema, Tuple, Value,
+    DataType, OwnedTableRecord, TableKey, TableKeyBound, TableKeyRange, TableSchema, Tuple, Value,
     catalog_manager::CatalogManager,
     cursor::TableCursor,
     error::{ConstraintError, InvalidArgumentError, StorageError, StorageResult},
@@ -16,6 +16,8 @@ pub(crate) struct RecordManager {
 /// Iterator over owned records in one table.
 pub(crate) struct TableScan {
     cursor: TableCursor,
+    range: TableKeyRange,
+    initialized: bool,
     done: bool,
 }
 
@@ -25,7 +27,20 @@ impl RecordManager {
     }
 
     pub(crate) fn scan_table(&self, table: &TableSchema) -> StorageResult<TableScan> {
-        Ok(TableScan { cursor: self.catalog.table_cursor_by_name(&table.name)?, done: false })
+        self.scan_table_range(table, TableKeyRange::unbounded())
+    }
+
+    pub(crate) fn scan_table_range(
+        &self,
+        table: &TableSchema,
+        range: TableKeyRange,
+    ) -> StorageResult<TableScan> {
+        Ok(TableScan {
+            cursor: self.catalog.table_cursor_by_name(&table.name)?,
+            range,
+            initialized: false,
+            done: false,
+        })
     }
 
     pub(crate) fn insert_table_row(
@@ -91,8 +106,19 @@ impl Iterator for TableScan {
             return None;
         }
 
-        match self.cursor.next_owned_record() {
-            Ok(Some(record)) => Some(Ok(record)),
+        let record = if self.initialized {
+            self.cursor.next_owned_record()
+        } else {
+            self.initialized = true;
+            self.first_record()
+        };
+
+        match record {
+            Ok(Some(record)) if self.range.contains(record.table_key) => Some(Ok(record)),
+            Ok(Some(_)) => {
+                self.done = true;
+                None
+            }
             Ok(None) => {
                 self.done = true;
                 None
@@ -102,6 +128,38 @@ impl Iterator for TableScan {
                 Some(Err(error))
             }
         }
+    }
+}
+
+impl TableScan {
+    fn first_record(&mut self) -> StorageResult<Option<OwnedTableRecord>> {
+        match range_start(self.range.lower) {
+            RangeStart::At(start_key) => {
+                if self.cursor.seek_to_table_key(start_key)? {
+                    self.cursor.current_owned_record()
+                } else {
+                    Ok(None)
+                }
+            }
+            RangeStart::Unbounded => self.cursor.next_owned_record(),
+            RangeStart::Empty => Ok(None),
+        }
+    }
+}
+
+enum RangeStart {
+    At(TableKey),
+    Unbounded,
+    Empty,
+}
+
+fn range_start(lower: Option<TableKeyBound>) -> RangeStart {
+    match lower {
+        Some(TableKeyBound::Inclusive(value)) => RangeStart::At(value),
+        Some(TableKeyBound::Exclusive(value)) => {
+            value.checked_add(1).map_or(RangeStart::Empty, RangeStart::At)
+        }
+        None => RangeStart::Unbounded,
     }
 }
 
@@ -183,8 +241,8 @@ mod tests {
 
     use super::*;
     use crate::core::{
-        ColumnSchema, TupleSchema, catalog_manager::CatalogManager, cursor::IndexCursor,
-        index_manager::IndexManager, pager::Pager,
+        ColumnSchema, TableKeyBound, TableKeyRange, TupleSchema, catalog_manager::CatalogManager,
+        cursor::IndexCursor, index_manager::IndexManager, pager::Pager,
     };
 
     fn open(path: impl AsRef<std::path::Path>) -> StorageResult<(CatalogManager, RecordManager)> {
@@ -285,6 +343,65 @@ mod tests {
         let mut index: IndexCursor = catalog.index_cursor_by_name("idx_users_name").unwrap();
         assert_eq!(index.get(&name_key("Ada")).unwrap().unwrap().table_key, -5);
         assert_eq!(index.get(&name_key("Grace")).unwrap().unwrap().table_key, 20);
+    }
+
+    #[test]
+    fn scan_table_range_seeks_to_lower_bound_and_stops_at_upper_bound() {
+        let file = NamedTempFile::new().unwrap();
+        let (_catalog, records) = open(file.path()).unwrap();
+        let table = records.catalog.create_table("users", users_schema()).unwrap();
+
+        for id in [-5, 1, 3, 5, 7] {
+            records
+                .insert_table_row(
+                    &table,
+                    vec![
+                        Value::Integer(id),
+                        Value::String(format!("user{id}")),
+                        Value::Boolean(true),
+                    ],
+                )
+                .unwrap();
+        }
+
+        let range = TableKeyRange {
+            lower: Some(TableKeyBound::Exclusive(1)),
+            upper: Some(TableKeyBound::Exclusive(7)),
+        };
+        let keys = records
+            .scan_table_range(&table, range)
+            .unwrap()
+            .map(|record| record.unwrap().table_key)
+            .collect::<Vec<_>>();
+
+        assert_eq!(keys, vec![3, 5]);
+    }
+
+    #[test]
+    fn scan_table_range_with_exclusive_max_lower_is_empty() {
+        let file = NamedTempFile::new().unwrap();
+        let (_catalog, records) = open(file.path()).unwrap();
+        let table = records.catalog.create_table("users", users_schema()).unwrap();
+        records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(TableKey::MAX),
+                    Value::String("max".to_owned()),
+                    Value::Boolean(true),
+                ],
+            )
+            .unwrap();
+
+        let range =
+            TableKeyRange { lower: Some(TableKeyBound::Exclusive(TableKey::MAX)), upper: None };
+        let rows = records
+            .scan_table_range(&table, range)
+            .unwrap()
+            .collect::<StorageResult<Vec<_>>>()
+            .unwrap();
+
+        assert!(rows.is_empty());
     }
 
     #[test]

--- a/src/core/tuple.rs
+++ b/src/core/tuple.rs
@@ -884,9 +884,6 @@ mod tests {
         let tuple_ref = TupleRef::new(&borrowed_values);
         let owned_tuple = Tuple::new(borrowed_values.into_iter().map(Value::from).collect());
 
-        assert_eq!(tuple_ref.len(), 6);
-        assert!(!tuple_ref.is_empty());
-        assert_eq!(tuple_ref.values(), borrowed_values);
         assert_eq!(tuple_ref.to_bytes().unwrap(), owned_tuple.to_bytes().unwrap());
     }
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -265,6 +265,13 @@ impl<'db> Executor<'db> {
                     self.database.scan_table(&table)?.map(|record| record.map_err(Into::into));
                 Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
             }
+            PhysicalPlan::PrimaryKeyRangeScan { table, range } => {
+                let rows = self
+                    .database
+                    .scan_table_range(&table, range)?
+                    .map(|record| record.map_err(Into::into));
+                Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
+            }
             PhysicalPlan::Filter { input, predicate } => {
                 let output_inner = self.execute(*input)?;
                 let rows = output_inner.into_rows("FILTER")?.filter_map(move |row| match row {

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -597,6 +597,27 @@ fn select_with_projection_and_filter_executes_end_to_end() {
 }
 
 #[test]
+fn select_with_primary_key_range_returns_only_matching_rows() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, &insert_many_users_sql(25)).unwrap();
+
+    let output =
+        execute_sql(&database, "SELECT id FROM users WHERE 10 <= id AND id < 20;").unwrap();
+
+    let rows = collect_rows(output).unwrap();
+    assert_eq!(
+        rows.iter().map(|row| row.table_key).collect::<Vec<_>>(),
+        (10..20).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        rows.iter().map(values).collect::<Vec<_>>(),
+        (10..20).map(|id| vec![Value::Integer(id)]).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn insert_values_uses_primary_keys_and_persists_rows() {
     let dir = tempdir().unwrap();
     let database = Database::create(dir.path().join("test.db")).unwrap();
@@ -917,6 +938,22 @@ fn delete_where_removes_only_matching_rows() {
 }
 
 #[test]
+fn delete_where_primary_key_range_removes_only_matching_rows() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, &insert_many_users_sql(25)).unwrap();
+
+    let output = execute_sql(&database, "DELETE FROM users WHERE 10 <= id AND id < 20;").unwrap();
+
+    assert!(matches!(output, ExecutionOutput::RowsAffected(10)));
+    assert_user_row(&database, 9, "user9");
+    assert_user_row_absent(&database, 10);
+    assert_user_row_absent(&database, 19);
+    assert_user_row(&database, 20, "user20");
+}
+
+#[test]
 fn delete_without_matches_returns_zero_rows_affected() {
     let dir = tempdir().unwrap();
     let database = Database::create(dir.path().join("test.db")).unwrap();
@@ -1011,6 +1048,24 @@ fn update_where_replaces_only_matching_rows() {
         values(&row),
         vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Boolean(false)]
     );
+}
+
+#[test]
+fn update_where_primary_key_range_replaces_only_matching_rows() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, &insert_many_users_sql(25)).unwrap();
+
+    let output =
+        execute_sql(&database, "UPDATE users SET name = 'updated' WHERE 10 <= id AND id < 20;")
+            .unwrap();
+
+    assert!(matches!(output, ExecutionOutput::RowsAffected(10)));
+    assert_user_row(&database, 9, "user9");
+    assert_user_row(&database, 10, "updated");
+    assert_user_row(&database, 19, "updated");
+    assert_user_row(&database, 20, "user20");
 }
 
 #[test]

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     error::DatabaseError,
     planner::{BoundColumn, PlannedExpression, Planner},
-    session::Session,
+    session::{Session, SessionError},
     sql_parser::parser::Parser,
 };
 
@@ -1288,7 +1288,10 @@ fn commit_without_active_transaction_errors_and_later_implicit_statement_commits
         .unwrap();
     let mut session = Session::new(&database);
 
-    assert!(execute_sql_with_session(&mut session, "COMMIT;").is_err());
+    assert!(matches!(
+        execute_sql_with_session(&mut session, "COMMIT;"),
+        Err(DatabaseError::Session(SessionError::NoActiveTransaction))
+    ));
     execute_sql_with_session(
         &mut session,
         "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);",
@@ -1296,7 +1299,11 @@ fn commit_without_active_transaction_errors_and_later_implicit_statement_commits
     .unwrap();
 
     let mut users = database.table_cursor_by_name("users").unwrap();
-    assert!(users.get(1).unwrap().is_some());
+    let row = users.get(1).unwrap().expect("later implicit insert should commit");
+    assert_eq!(
+        values(&row),
+        vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Integer(1)]
+    );
 }
 
 #[test]
@@ -1315,7 +1322,12 @@ fn failed_commit_clears_session_when_storage_transaction_was_cleared() {
     .unwrap();
     database.fail_next_wal_flush_for_test();
 
-    assert!(execute_sql_with_session(&mut session, "COMMIT;").is_err());
+    assert!(matches!(
+        execute_sql_with_session(&mut session, "COMMIT;"),
+        Err(DatabaseError::Storage(StorageError::Io(error)))
+            if error.kind() == std::io::ErrorKind::Other
+                && error.to_string() == "injected WAL flush failure"
+    ));
     execute_sql_with_session(
         &mut session,
         "INSERT INTO users (id, name, active) VALUES (2, 'Linus', 1);",
@@ -1323,7 +1335,11 @@ fn failed_commit_clears_session_when_storage_transaction_was_cleared() {
     .unwrap();
 
     let mut users = database.table_cursor_by_name("users").unwrap();
-    assert!(users.get(2).unwrap().is_some());
+    let row = users.get(2).unwrap().expect("later implicit insert should commit");
+    assert_eq!(
+        values(&row),
+        vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Integer(1)]
+    );
 }
 
 #[test]
@@ -1334,7 +1350,10 @@ fn rollback_without_active_transaction_errors_and_later_implicit_statement_commi
         .unwrap();
     let mut session = Session::new(&database);
 
-    assert!(execute_sql_with_session(&mut session, "ROLLBACK;").is_err());
+    assert!(matches!(
+        execute_sql_with_session(&mut session, "ROLLBACK;"),
+        Err(DatabaseError::Session(SessionError::NoActiveTransaction))
+    ));
     execute_sql_with_session(
         &mut session,
         "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);",
@@ -1342,7 +1361,11 @@ fn rollback_without_active_transaction_errors_and_later_implicit_statement_commi
     .unwrap();
 
     let mut users = database.table_cursor_by_name("users").unwrap();
-    assert!(users.get(1).unwrap().is_some());
+    let row = users.get(1).unwrap().expect("later implicit insert should commit");
+    assert_eq!(
+        values(&row),
+        vec![Value::Integer(1), Value::String("Ada".to_owned()), Value::Integer(1)]
+    );
 }
 
 #[test]
@@ -1359,7 +1382,10 @@ fn nested_begin_errors_without_ending_outer_transaction() {
         "INSERT INTO users (id, name, active) VALUES (1, 'Ada', 1);",
     )
     .unwrap();
-    assert!(execute_sql_with_session(&mut session, "BEGIN;").is_err());
+    assert!(matches!(
+        execute_sql_with_session(&mut session, "BEGIN;"),
+        Err(DatabaseError::Session(SessionError::TransactionAlreadyActive { txn_id })) if txn_id > 0
+    ));
     execute_sql_with_session(&mut session, "ROLLBACK;").unwrap();
 
     let mut users = database.table_cursor_by_name("users").unwrap();
@@ -1515,7 +1541,7 @@ fn uncommitted_flushed_insert_is_undone_during_recovery() {
     database.create_table("users", users_schema()).unwrap();
     database.create_index("idx_users_name", "users", &["name"]).unwrap();
     database.flush().unwrap();
-    let txn_id = database.begin_transaction().unwrap();
+    database.begin_transaction().unwrap();
     let table = database.table_schema_by_name("users").unwrap();
 
     execute_insert_values(
@@ -1534,7 +1560,6 @@ fn uncommitted_flushed_insert_is_undone_during_recovery() {
     )
     .unwrap();
     database.flush().unwrap();
-    assert_eq!(txn_id, 1);
     std::mem::forget(database);
 
     let reopened = Database::open(&path).unwrap();

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -16,7 +16,8 @@ use thiserror::Error;
 
 use crate::{
     core::{
-        ColumnSchema, DataType, Database, TableSchema, TupleSchema, Value,
+        ColumnSchema, DataType, Database, TableKey, TableKeyBound, TableKeyRange, TableSchema,
+        TupleSchema, Value,
         access::SchemaAccess,
         error::{InvalidArgumentError, StorageError},
     },
@@ -158,6 +159,13 @@ pub enum PhysicalPlan {
         /// Table to scan.
         table: TableSchema,
     },
+    /// Scan rows from a table whose primary key falls in a bounded range.
+    PrimaryKeyRangeScan {
+        /// Table to scan.
+        table: TableSchema,
+        /// Primary-key range to scan.
+        range: TableKeyRange,
+    },
     /// Filter rows from an input physical operator.
     Filter {
         /// Input operator.
@@ -240,7 +248,8 @@ fn physical_plan_input(plan: &PhysicalPlan) -> Option<&PhysicalPlan> {
         | PhysicalPlan::Values { .. }
         | PhysicalPlan::InsertValues { .. }
         | PhysicalPlan::OneRow
-        | PhysicalPlan::FullTableScan { .. } => None,
+        | PhysicalPlan::FullTableScan { .. }
+        | PhysicalPlan::PrimaryKeyRangeScan { .. } => None,
     }
 }
 
@@ -266,6 +275,9 @@ fn physical_plan_label(plan: &PhysicalPlan) -> String {
         PhysicalPlan::Delete { table, .. } => format!("Delete table={}", table.name),
         PhysicalPlan::OneRow => "OneRow".to_owned(),
         PhysicalPlan::FullTableScan { table } => format!("FullTableScan table={}", table.name),
+        PhysicalPlan::PrimaryKeyRangeScan { table, range } => {
+            format!("PrimaryKeyRangeScan table={} range=[{}]", table.name, range)
+        }
         PhysicalPlan::Filter { predicate, .. } => format!("Filter predicate={predicate}"),
         PhysicalPlan::Sort { terms, .. } => format!("Sort terms=[{}]", display_list(terms)),
         PhysicalPlan::Project { expressions, .. } => {
@@ -648,10 +660,33 @@ impl<'db> Planner<'db> {
             LogicalPlan::TableScan { table } => {
                 Ok(PhysicalPlan::FullTableScan { table: table.clone() })
             }
-            LogicalPlan::Filter { input, predicate } => Ok(PhysicalPlan::Filter {
-                input: Box::new(self.physical_plan(input)?),
-                predicate: predicate.clone(),
-            }),
+            LogicalPlan::Filter { input, predicate } => match input.as_ref() {
+                LogicalPlan::TableScan { table } => {
+                    match primary_key_range_predicate(table, predicate) {
+                        Some(range_predicate) => {
+                            let scan = PhysicalPlan::PrimaryKeyRangeScan {
+                                table: table.clone(),
+                                range: range_predicate.range,
+                            };
+                            match range_predicate.residual {
+                                Some(residual) => Ok(PhysicalPlan::Filter {
+                                    input: Box::new(scan),
+                                    predicate: residual,
+                                }),
+                                None => Ok(scan),
+                            }
+                        }
+                        None => Ok(PhysicalPlan::Filter {
+                            input: Box::new(self.physical_plan(input)?),
+                            predicate: predicate.clone(),
+                        }),
+                    }
+                }
+                _ => Ok(PhysicalPlan::Filter {
+                    input: Box::new(self.physical_plan(input)?),
+                    predicate: predicate.clone(),
+                }),
+            },
             LogicalPlan::Sort { input, terms } => Ok(PhysicalPlan::Sort {
                 input: Box::new(self.physical_plan(input)?),
                 terms: terms.clone(),
@@ -753,6 +788,178 @@ fn literal_expression(expression: &Expression<'_>) -> Option<PlannedExpression> 
         Expression::Literal(literal) => Some(PlannedExpression::Literal(Value::from(literal))),
         _ => None,
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RangePredicate {
+    range: TableKeyRange,
+    residual: Option<PlannedExpression>,
+}
+
+fn primary_key_range_predicate(
+    table: &TableSchema,
+    predicate: &PlannedExpression,
+) -> Option<RangePredicate> {
+    let primary_key = table.row.columns.first()?;
+    if !primary_key.primary_key || primary_key.data_type != DataType::Integer {
+        return None;
+    }
+
+    range_predicate_from_expression(table, predicate)
+}
+
+fn range_predicate_from_expression(
+    table: &TableSchema,
+    expression: &PlannedExpression,
+) -> Option<RangePredicate> {
+    match expression {
+        PlannedExpression::Binary { left, op: Op::And, right } => {
+            let left = range_predicate_from_expression(table, left)?;
+            if let Some(left_residual) = left.residual {
+                return Some(RangePredicate {
+                    range: left.range,
+                    residual: Some(and_expression(left_residual, (**right).clone())),
+                });
+            }
+
+            match range_predicate_from_expression(table, right) {
+                Some(right) => Some(RangePredicate {
+                    range: combine_ranges(left.range, right.range),
+                    residual: right.residual,
+                }),
+                None => {
+                    Some(RangePredicate { range: left.range, residual: Some((**right).clone()) })
+                }
+            }
+        }
+        PlannedExpression::Binary { left, op, right } => {
+            range_from_comparison(table, left, *op, right)
+                .map(|range| RangePredicate { range, residual: None })
+        }
+        PlannedExpression::Literal(_)
+        | PlannedExpression::Column(_)
+        | PlannedExpression::Unary { .. } => None,
+    }
+}
+
+fn and_expression(left: PlannedExpression, right: PlannedExpression) -> PlannedExpression {
+    PlannedExpression::Binary { left: Box::new(left), op: Op::And, right: Box::new(right) }
+}
+
+fn range_from_comparison(
+    table: &TableSchema,
+    left: &PlannedExpression,
+    op: Op,
+    right: &PlannedExpression,
+) -> Option<TableKeyRange> {
+    match (left, right) {
+        (PlannedExpression::Column(column), PlannedExpression::Literal(Value::Integer(value)))
+            if is_table_primary_key(table, column) =>
+        {
+            range_from_column_comparison(op, *value)
+        }
+        (PlannedExpression::Literal(Value::Integer(value)), PlannedExpression::Column(column))
+            if is_table_primary_key(table, column) =>
+        {
+            range_from_literal_comparison(op, *value)
+        }
+        _ => None,
+    }
+}
+
+fn is_table_primary_key(table: &TableSchema, column: &BoundColumn) -> bool {
+    column.table == table.name && column.ordinal == 0 && table.row.columns[0].primary_key
+}
+
+fn range_from_column_comparison(op: Op, value: TableKey) -> Option<TableKeyRange> {
+    match op {
+        Op::EqualsEquals => Some(TableKeyRange {
+            lower: Some(TableKeyBound::Inclusive(value)),
+            upper: Some(TableKeyBound::Inclusive(value)),
+        }),
+        Op::GreaterThan => {
+            Some(TableKeyRange { lower: Some(TableKeyBound::Exclusive(value)), upper: None })
+        }
+        Op::GreaterThanOrEqual => {
+            Some(TableKeyRange { lower: Some(TableKeyBound::Inclusive(value)), upper: None })
+        }
+        Op::LessThan => {
+            Some(TableKeyRange { lower: None, upper: Some(TableKeyBound::Exclusive(value)) })
+        }
+        Op::LessThanOrEqual => {
+            Some(TableKeyRange { lower: None, upper: Some(TableKeyBound::Inclusive(value)) })
+        }
+        Op::And | Op::Or | Op::NotEquals | Op::Not | Op::Add | Op::Sub | Op::Mul | Op::Div => None,
+    }
+}
+
+fn range_from_literal_comparison(op: Op, value: TableKey) -> Option<TableKeyRange> {
+    match op {
+        Op::EqualsEquals => Some(TableKeyRange {
+            lower: Some(TableKeyBound::Inclusive(value)),
+            upper: Some(TableKeyBound::Inclusive(value)),
+        }),
+        Op::LessThan => {
+            Some(TableKeyRange { lower: Some(TableKeyBound::Exclusive(value)), upper: None })
+        }
+        Op::LessThanOrEqual => {
+            Some(TableKeyRange { lower: Some(TableKeyBound::Inclusive(value)), upper: None })
+        }
+        Op::GreaterThan => {
+            Some(TableKeyRange { lower: None, upper: Some(TableKeyBound::Exclusive(value)) })
+        }
+        Op::GreaterThanOrEqual => {
+            Some(TableKeyRange { lower: None, upper: Some(TableKeyBound::Inclusive(value)) })
+        }
+        Op::And | Op::Or | Op::NotEquals | Op::Not | Op::Add | Op::Sub | Op::Mul | Op::Div => None,
+    }
+}
+
+fn combine_ranges(left: TableKeyRange, right: TableKeyRange) -> TableKeyRange {
+    TableKeyRange {
+        lower: tightest_lower(left.lower, right.lower),
+        upper: tightest_upper(left.upper, right.upper),
+    }
+}
+
+fn tightest_lower(
+    left: Option<TableKeyBound>,
+    right: Option<TableKeyBound>,
+) -> Option<TableKeyBound> {
+    match (left, right) {
+        (None, bound) | (bound, None) => bound,
+        (Some(left), Some(right)) => {
+            if left.value() > right.value() {
+                Some(left)
+            } else if right.value() > left.value() || bound_is_exclusive(right) {
+                Some(right)
+            } else {
+                Some(left)
+            }
+        }
+    }
+}
+
+fn tightest_upper(
+    left: Option<TableKeyBound>,
+    right: Option<TableKeyBound>,
+) -> Option<TableKeyBound> {
+    match (left, right) {
+        (None, bound) | (bound, None) => bound,
+        (Some(left), Some(right)) => {
+            if left.value() < right.value() {
+                Some(left)
+            } else if right.value() < left.value() || bound_is_exclusive(right) {
+                Some(right)
+            } else {
+                Some(left)
+            }
+        }
+    }
+}
+
+fn bound_is_exclusive(bound: TableKeyBound) -> bool {
+    matches!(bound, TableKeyBound::Exclusive(_))
 }
 
 impl From<&Literal<'_>> for Value {
@@ -1000,7 +1207,16 @@ mod tests {
         let PhysicalPlan::Update { input, .. } = &plan.physical else {
             panic!("expected physical update plan: {plan:?}");
         };
-        assert!(matches!(input.as_ref(), PhysicalPlan::Filter { .. }));
+        assert!(matches!(
+            input.as_ref(),
+            PhysicalPlan::PrimaryKeyRangeScan {
+                range: TableKeyRange {
+                    lower: Some(TableKeyBound::Inclusive(1)),
+                    upper: Some(TableKeyBound::Inclusive(1)),
+                },
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -1074,7 +1290,16 @@ mod tests {
         let PhysicalPlan::Delete { input, .. } = &plan.physical else {
             panic!("expected physical delete plan: {plan:?}");
         };
-        assert!(matches!(input.as_ref(), PhysicalPlan::Filter { .. }));
+        assert!(matches!(
+            input.as_ref(),
+            PhysicalPlan::PrimaryKeyRangeScan {
+                range: TableKeyRange {
+                    lower: Some(TableKeyBound::Inclusive(1)),
+                    upper: Some(TableKeyBound::Inclusive(1)),
+                },
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -1141,6 +1366,167 @@ mod tests {
     }
 
     #[test]
+    fn select_primary_key_range_uses_range_scan() {
+        let (_dir, database) = database_with_users();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE 10 <= id AND id < 20;");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::PrimaryKeyRangeScan { table, range } = input.as_ref() else {
+            panic!("expected primary key range scan under project: {plan:?}");
+        };
+        assert_eq!(table.name, "users");
+        assert_eq!(
+            *range,
+            TableKeyRange {
+                lower: Some(TableKeyBound::Inclusive(10)),
+                upper: Some(TableKeyBound::Exclusive(20)),
+            }
+        );
+    }
+
+    #[test]
+    fn select_primary_key_equality_uses_single_key_range_scan() {
+        let (_dir, database) = database_with_users();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE id == 10;");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::PrimaryKeyRangeScan { range, .. } = input.as_ref() else {
+            panic!("expected primary key range scan under project: {plan:?}");
+        };
+        assert_eq!(
+            *range,
+            TableKeyRange {
+                lower: Some(TableKeyBound::Inclusive(10)),
+                upper: Some(TableKeyBound::Inclusive(10)),
+            }
+        );
+    }
+
+    #[test]
+    fn select_primary_key_range_with_residual_filter_uses_range_scan() {
+        let (_dir, database) = database_with_users();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE id < 10 AND age == 7;");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, predicate } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        assert_eq!(
+            predicate,
+            &PlannedExpression::Binary {
+                left: Box::new(PlannedExpression::Column(bound(
+                    "users",
+                    "age",
+                    2,
+                    DataType::Integer
+                ))),
+                op: Op::EqualsEquals,
+                right: Box::new(PlannedExpression::Literal(Value::Integer(7))),
+            }
+        );
+        let PhysicalPlan::PrimaryKeyRangeScan { range, .. } = input.as_ref() else {
+            panic!("expected primary key range scan under residual filter: {plan:?}");
+        };
+        assert_eq!(
+            *range,
+            TableKeyRange { lower: None, upper: Some(TableKeyBound::Exclusive(10)) }
+        );
+    }
+
+    #[test]
+    fn select_multiple_primary_key_bounds_with_residual_filter_uses_combined_range_scan() {
+        let (_dir, database) = database_with_users();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE 1 <= id AND id <= 10 AND age == 7;");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, predicate } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        assert_eq!(
+            predicate,
+            &PlannedExpression::Binary {
+                left: Box::new(PlannedExpression::Column(bound(
+                    "users",
+                    "age",
+                    2,
+                    DataType::Integer
+                ))),
+                op: Op::EqualsEquals,
+                right: Box::new(PlannedExpression::Literal(Value::Integer(7))),
+            }
+        );
+        let PhysicalPlan::PrimaryKeyRangeScan { range, .. } = input.as_ref() else {
+            panic!("expected primary key range scan under residual filter: {plan:?}");
+        };
+        assert_eq!(
+            *range,
+            TableKeyRange {
+                lower: Some(TableKeyBound::Inclusive(1)),
+                upper: Some(TableKeyBound::Inclusive(10)),
+            }
+        );
+    }
+
+    #[test]
+    fn select_non_leading_primary_key_range_stays_full_table_scan() {
+        let (_dir, database) = database_with_users();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE age == 7 AND id < 10;");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected filter under project: {plan:?}");
+        };
+        assert!(
+            matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")
+        );
+    }
+
+    #[test]
+    fn select_secondary_index_column_range_stays_full_table_scan() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE 'Ada' <= name AND name < 'Linus';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected filter under project: {plan:?}");
+        };
+        assert!(
+            matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")
+        );
+    }
+
+    #[test]
     fn explain_select_wraps_planned_select() {
         let (_dir, database) = database_with_users();
         let planner = Planner::new(&database);
@@ -1163,7 +1549,16 @@ mod tests {
             expressions,
             &[PlannedExpression::Column(bound("users", "name", 1, DataType::Text))]
         );
-        assert!(matches!(input.as_ref(), PhysicalPlan::Filter { .. }));
+        assert!(matches!(
+            input.as_ref(),
+            PhysicalPlan::PrimaryKeyRangeScan {
+                range: TableKeyRange {
+                    lower: Some(TableKeyBound::Inclusive(1)),
+                    upper: Some(TableKeyBound::Inclusive(1)),
+                },
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/sql_parser/parser/expr.rs
+++ b/src/sql_parser/parser/expr.rs
@@ -204,34 +204,19 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_function_struct_usage() {
-        // Test direct field access
-        let sum_func = AggregateFunction {
-            kind: AggregateFunctionKind::Sum,
-            expr: Box::new(Expression::Identifier("salary")),
-        };
-
-        assert_eq!(sum_func.kind, AggregateFunctionKind::Sum);
-        assert_eq!(*sum_func.expr, Expression::Identifier("salary"));
-        assert_eq!(format!("{}", sum_func), "SUM(salary)");
-
-        // Test different aggregate kinds
-        let kinds = vec![
-            AggregateFunctionKind::Count,
-            AggregateFunctionKind::Avg,
-            AggregateFunctionKind::Max,
-            AggregateFunctionKind::Min,
-            AggregateFunctionKind::StdDev,
+    fn aggregate_functions_display_with_their_argument() {
+        let cases = [
+            (AggregateFunctionKind::Count, Expression::Wildcard, "COUNT(*)"),
+            (AggregateFunctionKind::Avg, Expression::Identifier("salary"), "AVG(salary)"),
+            (AggregateFunctionKind::Max, Expression::Identifier("salary"), "MAX(salary)"),
+            (AggregateFunctionKind::Min, Expression::Identifier("salary"), "MIN(salary)"),
+            (AggregateFunctionKind::StdDev, Expression::Identifier("salary"), "STDDEV(salary)"),
         ];
 
-        for kind in kinds {
-            let agg = AggregateFunction { kind, expr: Box::new(Expression::Wildcard) };
+        for (kind, expr, expected) in cases {
+            let aggregate = AggregateFunction { kind, expr: Box::new(expr) };
 
-            // Test that kind field is accessible
-            assert_eq!(agg.kind, kind);
-
-            // Test that expression field is accessible
-            assert_eq!(*agg.expr, Expression::Wildcard);
+            assert_eq!(aggregate.to_string(), expected);
         }
     }
 }

--- a/tests/sql_parser_roundtrip.rs
+++ b/tests/sql_parser_roundtrip.rs
@@ -349,15 +349,17 @@ fn parenthesized_expression_display_loses_grouping() {
     let displayed = parsed.to_string();
     let reparsed = parse_statement(&displayed);
 
+    assert_eq!(displayed, "SELECT (alpha + beta) * gamma;");
     assert_eq!(parsed, reparsed, "displayed SQL: {displayed}");
 }
 
 #[test]
-fn float_literals_with_zero_fraction_display_as_integers() {
+fn float_literals_with_zero_fraction_keep_fractional_display() {
     let sql = "SELECT 0.0;";
     let parsed = parse_statement(sql);
     let displayed = parsed.to_string();
     let reparsed = parse_statement(&displayed);
 
+    assert_eq!(displayed, "SELECT 0.0;");
     assert_eq!(parsed, reparsed, "displayed SQL: {displayed}");
 }


### PR DESCRIPTION

For scans such as `... WHERE a <= id AND id <= b`, move cursor directly to first row with `id >= a` and then scan rows while `id <= b`.

This is only usable for queries filtering on the table's primary key.
This scan does not use any table indexes.
