### PR TITLE
Implement rudimentary index scans

### DIFF
--- a/src/core/access.rs
+++ b/src/core/access.rs
@@ -1,10 +1,13 @@
 use crate::core::{
     IndexSchema, OwnedTableRecord, TableKeyRange, TableSchema, TupleSchema, Value,
-    error::StorageResult, record_manager::TableScan,
+    error::StorageResult,
+    record_manager::{IndexScan, TableScan},
 };
 
 pub(crate) trait SchemaAccess {
     fn table_schema_by_name(&self, name: &str) -> StorageResult<TableSchema>;
+
+    fn index_schemas_for_table(&self, table: &TableSchema) -> StorageResult<Vec<IndexSchema>>;
 }
 
 pub(crate) trait DdlAccess {
@@ -26,6 +29,13 @@ pub(crate) trait RecordAccess {
         table: &TableSchema,
         range: TableKeyRange,
     ) -> StorageResult<TableScan>;
+
+    fn scan_index(
+        &self,
+        table: &TableSchema,
+        index: &IndexSchema,
+        key_prefix: Vec<u8>,
+    ) -> StorageResult<IndexScan>;
 
     fn insert_table_row(
         &self,

--- a/src/core/access.rs
+++ b/src/core/access.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    IndexSchema, OwnedTableRecord, TableKeyRange, TableSchema, TupleSchema, Value,
+    IndexKeyRange, IndexSchema, OwnedTableRecord, TableKeyRange, TableSchema, TupleSchema, Value,
     error::StorageResult,
     record_manager::{IndexScan, TableScan},
 };
@@ -34,7 +34,7 @@ pub(crate) trait RecordAccess {
         &self,
         table: &TableSchema,
         index: &IndexSchema,
-        key_prefix: Vec<u8>,
+        key_range: IndexKeyRange,
     ) -> StorageResult<IndexScan>;
 
     fn insert_table_row(

--- a/src/core/cursor.rs
+++ b/src/core/cursor.rs
@@ -27,6 +27,13 @@ fn encode_index_table_key(table_key: TableKey) -> [u8; TABLE_KEY_SIZE] {
     encode_table_key(table_key)
 }
 
+pub(crate) fn encode_index_entry_key(index_key: &[u8], table_key: TableKey) -> Vec<u8> {
+    let mut key = Vec::with_capacity(index_key.len() + TABLE_KEY_SIZE);
+    key.extend_from_slice(index_key);
+    key.extend_from_slice(&encode_table_key(table_key));
+    key
+}
+
 fn decode_index_table_key(value: &[u8]) -> StorageResult<TableKey> {
     let bytes: [u8; TABLE_KEY_SIZE] = value.try_into().map_err(|_| PageError::CorruptCell {
         slot_index: 0,

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::core::{
-    IndexSchema, OwnedTableRecord, TableKeyRange, TableSchema, TupleSchema, Value,
+    IndexKeyRange, IndexSchema, OwnedTableRecord, TableKeyRange, TableSchema, TupleSchema, Value,
     access::{DdlAccess, RecordAccess, SchemaAccess},
     catalog_manager::CatalogManager,
     cursor::{IndexCursor, TableCursor},
@@ -212,9 +212,9 @@ impl RecordAccess for Database {
         &self,
         table: &TableSchema,
         index: &IndexSchema,
-        key_prefix: Vec<u8>,
+        key_range: IndexKeyRange,
     ) -> StorageResult<IndexScan> {
-        self.records.scan_index(table, index, key_prefix)
+        self.records.scan_index(table, index, key_range)
     }
 
     fn insert_table_row(

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -9,7 +9,7 @@ use crate::core::{
     index_manager::IndexManager,
     log_manager::TxnId,
     pager::Pager,
-    record_manager::{RecordManager, TableScan},
+    record_manager::{IndexScan, RecordManager, TableScan},
     transaction_manager::TransactionSavepoint,
     transaction_runtime::TransactionRuntime,
 };
@@ -174,6 +174,10 @@ impl SchemaAccess for Database {
     fn table_schema_by_name(&self, name: &str) -> StorageResult<TableSchema> {
         Database::table_schema_by_name(self, name)
     }
+
+    fn index_schemas_for_table(&self, table: &TableSchema) -> StorageResult<Vec<IndexSchema>> {
+        Database::index_schemas_for_table(self, table)
+    }
 }
 
 impl DdlAccess for Database {
@@ -202,6 +206,15 @@ impl RecordAccess for Database {
         range: TableKeyRange,
     ) -> StorageResult<TableScan> {
         Database::scan_table_range(self, table, range)
+    }
+
+    fn scan_index(
+        &self,
+        table: &TableSchema,
+        index: &IndexSchema,
+        key_prefix: Vec<u8>,
+    ) -> StorageResult<IndexScan> {
+        self.records.scan_index(table, index, key_prefix)
     }
 
     fn insert_table_row(

--- a/src/core/index_manager.rs
+++ b/src/core/index_manager.rs
@@ -1,6 +1,7 @@
 use crate::core::{
     IndexSchema, OwnedTableRecord, TableKey, TableSchema, Tuple, TupleView, Value,
     catalog_manager::CatalogManager,
+    cursor::encode_index_entry_key,
     error::{CorruptionComponent, CorruptionError, CorruptionKind, StorageError, StorageResult},
 };
 
@@ -34,6 +35,7 @@ impl IndexManager {
     ) -> StorageResult<()> {
         for index in self.catalog.index_schemas_for_table(table)? {
             let key = index_key_from_record(table, &index, record)?;
+            let key = encode_index_entry_key(&key, record.table_key);
             let mut index_cursor = self.catalog.index_cursor_by_name(&index.name)?;
             index_cursor.insert(&key, record.table_key)?;
         }
@@ -48,6 +50,7 @@ impl IndexManager {
     ) -> StorageResult<()> {
         for index in self.catalog.index_schemas_for_table(table)? {
             let key = index_key_from_record(table, &index, record)?;
+            let key = encode_index_entry_key(&key, record.table_key);
             let mut index_cursor = self.catalog.index_cursor_by_name(&index.name)?;
             index_cursor.delete(&key)?;
         }
@@ -61,6 +64,7 @@ impl IndexManager {
 
         while let Some(record) = table_cursor.next_owned_record()? {
             let key = index_key_from_record(table, index, &record)?;
+            let key = encode_index_entry_key(&key, record.table_key);
             index_cursor.insert(&key, record.table_key)?;
         }
 
@@ -150,6 +154,10 @@ mod tests {
         Tuple::new(vec![Value::String(name.to_owned())]).to_bytes().unwrap()
     }
 
+    fn name_entry_key(name: &str, table_key: TableKey) -> Vec<u8> {
+        encode_index_entry_key(&name_key(name), table_key)
+    }
+
     #[test]
     fn create_index_backfills_existing_table_rows() {
         let file = NamedTempFile::new().unwrap();
@@ -172,7 +180,41 @@ mod tests {
         indexes.create_index("idx_users_name", "users", &["name"]).unwrap();
 
         let mut index = catalog.index_cursor_by_name("idx_users_name").unwrap();
-        assert_eq!(index.get(&name_key("Ada")).unwrap().unwrap().table_key, 1);
-        assert_eq!(index.get(&name_key("Grace")).unwrap().unwrap().table_key, 2);
+        assert_eq!(index.get(&name_entry_key("Ada", 1)).unwrap().unwrap().table_key, 1);
+        assert_eq!(index.get(&name_entry_key("Grace", 2)).unwrap().unwrap().table_key, 2);
+    }
+
+    #[test]
+    fn create_index_backfills_duplicate_index_values() {
+        let file = NamedTempFile::new().unwrap();
+        let (catalog, indexes) = open(file.path()).unwrap();
+        let records = RecordManager::new(catalog.clone(), indexes.clone());
+        let table = catalog.create_table("users", users_schema()).unwrap();
+        records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(1),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(true),
+                ],
+            )
+            .unwrap();
+        records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(2),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(false),
+                ],
+            )
+            .unwrap();
+
+        indexes.create_index("idx_users_name", "users", &["name"]).unwrap();
+
+        let mut index = catalog.index_cursor_by_name("idx_users_name").unwrap();
+        assert_eq!(index.get(&name_entry_key("Engineering", 1)).unwrap().unwrap().table_key, 1);
+        assert_eq!(index.get(&name_entry_key("Engineering", 2)).unwrap().unwrap().table_key, 2);
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -44,6 +44,62 @@ pub type CatalogId = i32;
 pub type TableKey = i32;
 pub(crate) type SlotId = u16;
 
+/// Inclusive or exclusive bound over encoded secondary-index B+-tree keys.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexKeyBound {
+    /// The bound includes the stored key bytes.
+    Inclusive(Vec<u8>),
+    /// The bound excludes the stored key bytes.
+    Exclusive(Vec<u8>),
+}
+
+impl IndexKeyBound {
+    /// Returns the encoded key bytes stored in this bound.
+    pub(crate) fn key(&self) -> &[u8] {
+        match self {
+            Self::Inclusive(key) | Self::Exclusive(key) => key,
+        }
+    }
+
+    /// Returns whether `key` satisfies this lower bound.
+    pub(crate) fn contains_lower(&self, key: &[u8]) -> bool {
+        match self {
+            Self::Inclusive(value) => key >= value,
+            Self::Exclusive(value) => key > value,
+        }
+    }
+
+    /// Returns whether `key` satisfies this upper bound.
+    pub(crate) fn contains_upper(&self, key: &[u8]) -> bool {
+        match self {
+            Self::Inclusive(value) => key <= value,
+            Self::Exclusive(value) => key < value,
+        }
+    }
+}
+
+/// Ordered key-byte range for scanning a secondary-index B+-tree.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IndexKeyRange {
+    /// Optional lower bound.
+    pub lower: Option<IndexKeyBound>,
+    /// Optional upper bound.
+    pub upper: Option<IndexKeyBound>,
+}
+
+impl IndexKeyRange {
+    /// Returns whether `key` is inside the range.
+    pub(crate) fn contains(&self, key: &[u8]) -> bool {
+        self.lower.as_ref().is_none_or(|bound| bound.contains_lower(key))
+            && self.upper.as_ref().is_none_or(|bound| bound.contains_upper(key))
+    }
+
+    /// Returns whether `key` has moved beyond this range's upper bound.
+    pub(crate) fn is_past_upper(&self, key: &[u8]) -> bool {
+        self.upper.as_ref().is_some_and(|bound| !bound.contains_upper(key))
+    }
+}
+
 /// Inclusive or exclusive bound over table primary keys.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TableKeyBound {

--- a/src/core/record_manager.rs
+++ b/src/core/record_manager.rs
@@ -1,6 +1,6 @@
 use crate::core::{
-    CorruptionComponent, CorruptionError, CorruptionKind, DataType, IndexSchema, OwnedTableRecord,
-    TableKey, TableKeyBound, TableKeyRange, TableSchema, Tuple, Value,
+    CorruptionComponent, CorruptionError, CorruptionKind, DataType, IndexKeyRange, IndexSchema,
+    OwnedTableRecord, TableKey, TableKeyBound, TableKeyRange, TableSchema, Tuple, Value,
     catalog_manager::CatalogManager,
     cursor::{IndexCursor, TableCursor},
     error::{ConstraintError, InvalidArgumentError, StorageError, StorageResult},
@@ -27,7 +27,7 @@ pub(crate) struct IndexScan {
     table: TableSchema,
     table_cursor: TableCursor,
     index_cursor: IndexCursor,
-    key_prefix: Vec<u8>,
+    key_range: IndexKeyRange,
     initialized: bool,
     done: bool,
 }
@@ -58,13 +58,13 @@ impl RecordManager {
         &self,
         table: &TableSchema,
         index: &IndexSchema,
-        key_prefix: Vec<u8>,
+        key_range: IndexKeyRange,
     ) -> StorageResult<IndexScan> {
         Ok(IndexScan {
             table: table.clone(),
             table_cursor: self.catalog.table_cursor_by_name(&table.name)?,
             index_cursor: self.catalog.index_cursor_by_name(&index.name)?,
-            key_prefix,
+            key_range,
             initialized: false,
             done: false,
         })
@@ -133,38 +133,43 @@ impl Iterator for IndexScan {
             return None;
         }
 
-        let entry = if self.initialized {
-            self.index_cursor.next_owned_entry()
-        } else {
-            self.initialized = true;
-            self.first_entry()
-        };
+        loop {
+            let entry = if self.initialized {
+                self.index_cursor.next_owned_entry()
+            } else {
+                self.initialized = true;
+                self.first_entry()
+            };
 
-        match entry {
-            Ok(Some(entry)) if entry.key.starts_with(&self.key_prefix) => {
-                match self.table_cursor.get_owned_record(entry.table_key) {
-                    Ok(Some(record)) => Some(Ok(record)),
+            match entry {
+                Ok(Some(entry)) if self.key_range.is_past_upper(&entry.key) => {
+                    self.done = true;
+                    return None;
+                }
+                Ok(Some(entry)) if !self.key_range.contains(&entry.key) => continue,
+                Ok(Some(entry)) => match self.table_cursor.get_owned_record(entry.table_key) {
+                    Ok(Some(record)) => return Some(Ok(record)),
                     Ok(None) => {
                         self.done = true;
-                        Some(Err(invalid_index_entry(
+                        return Some(Err(invalid_index_entry(
                             &self.table,
                             entry.table_key,
                             "index entry references missing table row",
-                        )))
+                        )));
                     }
                     Err(error) => {
                         self.done = true;
-                        Some(Err(error))
+                        return Some(Err(error));
                     }
+                },
+                Ok(None) => {
+                    self.done = true;
+                    return None;
                 }
-            }
-            Ok(Some(_)) | Ok(None) => {
-                self.done = true;
-                None
-            }
-            Err(error) => {
-                self.done = true;
-                Some(Err(error))
+                Err(error) => {
+                    self.done = true;
+                    return Some(Err(error));
+                }
             }
         }
     }
@@ -172,10 +177,21 @@ impl Iterator for IndexScan {
 
 impl IndexScan {
     fn first_entry(&mut self) -> StorageResult<Option<crate::core::OwnedIndexEntry>> {
-        if self.index_cursor.seek_to_key(&self.key_prefix)? {
-            self.index_cursor.current_owned_entry()
-        } else {
-            Ok(None)
+        match self.key_range.lower.as_ref() {
+            Some(lower) => {
+                if self.index_cursor.seek_to_key(lower.key())? {
+                    self.index_cursor.current_owned_entry()
+                } else {
+                    Ok(None)
+                }
+            }
+            None => {
+                if self.index_cursor.seek_to_first()? {
+                    self.index_cursor.current_owned_entry()
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 }

--- a/src/core/record_manager.rs
+++ b/src/core/record_manager.rs
@@ -1,7 +1,8 @@
 use crate::core::{
-    DataType, OwnedTableRecord, TableKey, TableKeyBound, TableKeyRange, TableSchema, Tuple, Value,
+    CorruptionComponent, CorruptionError, CorruptionKind, DataType, IndexSchema, OwnedTableRecord,
+    TableKey, TableKeyBound, TableKeyRange, TableSchema, Tuple, Value,
     catalog_manager::CatalogManager,
-    cursor::TableCursor,
+    cursor::{IndexCursor, TableCursor},
     error::{ConstraintError, InvalidArgumentError, StorageError, StorageResult},
     index_manager::IndexManager,
 };
@@ -17,6 +18,16 @@ pub(crate) struct RecordManager {
 pub(crate) struct TableScan {
     cursor: TableCursor,
     range: TableKeyRange,
+    initialized: bool,
+    done: bool,
+}
+
+/// Iterator over table rows referenced by matching secondary-index entries.
+pub(crate) struct IndexScan {
+    table: TableSchema,
+    table_cursor: TableCursor,
+    index_cursor: IndexCursor,
+    key_prefix: Vec<u8>,
     initialized: bool,
     done: bool,
 }
@@ -38,6 +49,22 @@ impl RecordManager {
         Ok(TableScan {
             cursor: self.catalog.table_cursor_by_name(&table.name)?,
             range,
+            initialized: false,
+            done: false,
+        })
+    }
+
+    pub(crate) fn scan_index(
+        &self,
+        table: &TableSchema,
+        index: &IndexSchema,
+        key_prefix: Vec<u8>,
+    ) -> StorageResult<IndexScan> {
+        Ok(IndexScan {
+            table: table.clone(),
+            table_cursor: self.catalog.table_cursor_by_name(&table.name)?,
+            index_cursor: self.catalog.index_cursor_by_name(&index.name)?,
+            key_prefix,
             initialized: false,
             done: false,
         })
@@ -95,6 +122,61 @@ impl RecordManager {
         self.indexes.insert_index_entries(table, &updated)?;
 
         Ok(updated)
+    }
+}
+
+impl Iterator for IndexScan {
+    type Item = StorageResult<OwnedTableRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let entry = if self.initialized {
+            self.index_cursor.next_owned_entry()
+        } else {
+            self.initialized = true;
+            self.first_entry()
+        };
+
+        match entry {
+            Ok(Some(entry)) if entry.key.starts_with(&self.key_prefix) => {
+                match self.table_cursor.get_owned_record(entry.table_key) {
+                    Ok(Some(record)) => Some(Ok(record)),
+                    Ok(None) => {
+                        self.done = true;
+                        Some(Err(invalid_index_entry(
+                            &self.table,
+                            entry.table_key,
+                            "index entry references missing table row",
+                        )))
+                    }
+                    Err(error) => {
+                        self.done = true;
+                        Some(Err(error))
+                    }
+                }
+            }
+            Ok(Some(_)) | Ok(None) => {
+                self.done = true;
+                None
+            }
+            Err(error) => {
+                self.done = true;
+                Some(Err(error))
+            }
+        }
+    }
+}
+
+impl IndexScan {
+    fn first_entry(&mut self) -> StorageResult<Option<crate::core::OwnedIndexEntry>> {
+        if self.index_cursor.seek_to_key(&self.key_prefix)? {
+            self.index_cursor.current_owned_entry()
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -233,6 +315,18 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Float(_) => "float",
         Value::UnsignedInteger(_) => "unsigned integer",
     }
+}
+
+fn invalid_index_entry(table: &TableSchema, table_key: TableKey, reason: &str) -> StorageError {
+    StorageError::Corruption(CorruptionError {
+        component: CorruptionComponent::Catalog,
+        page_id: None,
+        kind: CorruptionKind::InvalidTableRecord {
+            table: table.name.clone(),
+            table_key,
+            reason: reason.to_owned(),
+        },
+    })
 }
 
 #[cfg(test)]

--- a/src/core/record_manager.rs
+++ b/src/core/record_manager.rs
@@ -241,8 +241,11 @@ mod tests {
 
     use super::*;
     use crate::core::{
-        ColumnSchema, TableKeyBound, TableKeyRange, TupleSchema, catalog_manager::CatalogManager,
-        cursor::IndexCursor, index_manager::IndexManager, pager::Pager,
+        ColumnSchema, TableKeyBound, TableKeyRange, TupleSchema,
+        catalog_manager::CatalogManager,
+        cursor::{IndexCursor, encode_index_entry_key},
+        index_manager::IndexManager,
+        pager::Pager,
     };
 
     fn open(path: impl AsRef<std::path::Path>) -> StorageResult<(CatalogManager, RecordManager)> {
@@ -285,6 +288,10 @@ mod tests {
         Tuple::new(vec![Value::String(name.to_owned())]).to_bytes().unwrap()
     }
 
+    fn name_entry_key(name: &str, table_key: TableKey) -> Vec<u8> {
+        encode_index_entry_key(&name_key(name), table_key)
+    }
+
     #[test]
     fn insert_table_row_persists_row_and_updates_secondary_indexes() {
         let file = NamedTempFile::new().unwrap();
@@ -303,7 +310,8 @@ mod tests {
         let mut users = catalog.table_cursor_by_name("users").unwrap();
         let stored = users.get(1).unwrap().expect("inserted row should be stored");
         let mut index: IndexCursor = catalog.index_cursor_by_name("idx_users_name").unwrap();
-        let entry = index.get(&name_key("Ada")).unwrap().expect("index should track inserted row");
+        let entry =
+            index.get(&name_entry_key("Ada", 1)).unwrap().expect("index should track inserted row");
 
         assert_eq!(inserted.table_key, 1);
         assert_eq!(
@@ -341,8 +349,121 @@ mod tests {
         assert_eq!(users.current_owned_record().unwrap().unwrap().table_key, -5);
 
         let mut index: IndexCursor = catalog.index_cursor_by_name("idx_users_name").unwrap();
-        assert_eq!(index.get(&name_key("Ada")).unwrap().unwrap().table_key, -5);
-        assert_eq!(index.get(&name_key("Grace")).unwrap().unwrap().table_key, 20);
+        assert_eq!(index.get(&name_entry_key("Ada", -5)).unwrap().unwrap().table_key, -5);
+        assert_eq!(index.get(&name_entry_key("Grace", 20)).unwrap().unwrap().table_key, 20);
+    }
+
+    #[test]
+    fn insert_table_row_allows_duplicate_secondary_index_values() {
+        let file = NamedTempFile::new().unwrap();
+        let (catalog, records) = open(file.path()).unwrap();
+        let indexes = IndexManager::new(catalog.clone());
+        let table = catalog.create_table("users", users_schema()).unwrap();
+        indexes.create_index("idx_users_name", "users", &["name"]).unwrap();
+
+        records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(1),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(true),
+                ],
+            )
+            .unwrap();
+        records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(2),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(false),
+                ],
+            )
+            .unwrap();
+
+        let mut index = catalog.index_cursor_by_name("idx_users_name").unwrap();
+        assert_eq!(index.get(&name_entry_key("Engineering", 1)).unwrap().unwrap().table_key, 1);
+        assert_eq!(index.get(&name_entry_key("Engineering", 2)).unwrap().unwrap().table_key, 2);
+    }
+
+    #[test]
+    fn delete_table_row_removes_only_one_duplicate_secondary_index_entry() {
+        let file = NamedTempFile::new().unwrap();
+        let (catalog, records) = open(file.path()).unwrap();
+        let indexes = IndexManager::new(catalog.clone());
+        let table = catalog.create_table("users", users_schema()).unwrap();
+        indexes.create_index("idx_users_name", "users", &["name"]).unwrap();
+
+        let first = records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(1),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(true),
+                ],
+            )
+            .unwrap();
+        records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(2),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(false),
+                ],
+            )
+            .unwrap();
+
+        records.delete_table_row(&table, &first).unwrap();
+
+        let mut index = catalog.index_cursor_by_name("idx_users_name").unwrap();
+        assert!(index.get(&name_entry_key("Engineering", 1)).unwrap().is_none());
+        assert_eq!(index.get(&name_entry_key("Engineering", 2)).unwrap().unwrap().table_key, 2);
+    }
+
+    #[test]
+    fn update_table_row_refreshes_only_one_duplicate_secondary_index_entry() {
+        let file = NamedTempFile::new().unwrap();
+        let (catalog, records) = open(file.path()).unwrap();
+        let indexes = IndexManager::new(catalog.clone());
+        let table = catalog.create_table("users", users_schema()).unwrap();
+        indexes.create_index("idx_users_name", "users", &["name"]).unwrap();
+
+        let first = records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(1),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(true),
+                ],
+            )
+            .unwrap();
+        records
+            .insert_table_row(
+                &table,
+                vec![
+                    Value::Integer(2),
+                    Value::String("Engineering".to_owned()),
+                    Value::Boolean(false),
+                ],
+            )
+            .unwrap();
+
+        records
+            .update_table_row(
+                &table,
+                &first,
+                vec![Value::Integer(1), Value::String("Sales".to_owned()), Value::Boolean(true)],
+            )
+            .unwrap();
+
+        let mut index = catalog.index_cursor_by_name("idx_users_name").unwrap();
+        assert!(index.get(&name_entry_key("Engineering", 1)).unwrap().is_none());
+        assert_eq!(index.get(&name_entry_key("Engineering", 2)).unwrap().unwrap().table_key, 2);
+        assert_eq!(index.get(&name_entry_key("Sales", 1)).unwrap().unwrap().table_key, 1);
     }
 
     #[test]

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -272,10 +272,10 @@ impl<'db> Executor<'db> {
                     .map(|record| record.map_err(Into::into));
                 Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
             }
-            PhysicalPlan::SecondaryIndexScan { table, index, key, .. } => {
+            PhysicalPlan::SecondaryIndexScan { scan } => {
                 let rows = self
                     .database
-                    .scan_index(&table, &index, key)?
+                    .scan_index(&scan.table, &scan.index, scan.key_range)?
                     .map(|record| record.map_err(Into::into));
                 Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
             }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -272,6 +272,13 @@ impl<'db> Executor<'db> {
                     .map(|record| record.map_err(Into::into));
                 Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
             }
+            PhysicalPlan::SecondaryIndexScan { table, index, key, .. } => {
+                let rows = self
+                    .database
+                    .scan_index(&table, &index, key)?
+                    .map(|record| record.map_err(Into::into));
+                Ok(ExecutionOutput::Rows { rows: Box::new(rows) })
+            }
             PhysicalPlan::Filter { input, predicate } => {
                 let output_inner = self.execute(*input)?;
                 let rows = output_inner.into_rows("FILTER")?.filter_map(move |row| match row {

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::{
     core::{
         ColumnSchema, DataType, PAGE_SIZE, TableKey, Tuple, TupleSchema,
+        cursor::encode_index_entry_key,
         error::{ConstraintError, InternalError, InvariantViolation, StorageError},
     },
     error::DatabaseError,
@@ -161,7 +162,7 @@ fn assert_user_row(database: &Database, table_key: TableKey, expected_name: &str
 
 fn assert_name_index_entry(database: &Database, name: &str, table_key: TableKey) {
     let mut index = database.index_cursor_by_name("idx_users_name").unwrap();
-    let key = Tuple::new(vec![Value::String(name.to_owned())]).to_bytes().unwrap();
+    let key = name_index_entry_key(name, table_key);
     let entry = index.get(&key).unwrap().expect("index entry should exist");
     assert_eq!(entry.table_key, table_key);
 }
@@ -174,7 +175,19 @@ fn assert_user_row_absent(database: &Database, table_key: TableKey) {
 fn assert_name_index_absent(database: &Database, name: &str) {
     let mut index = database.index_cursor_by_name("idx_users_name").unwrap();
     let key = Tuple::new(vec![Value::String(name.to_owned())]).to_bytes().unwrap();
-    assert!(index.get(&key).unwrap().is_none());
+    assert_index_prefix_absent(&mut index, &key);
+}
+
+fn assert_index_prefix_absent(index: &mut crate::core::cursor::IndexCursor, key: &[u8]) {
+    assert!(
+        !index.seek_to_key(key).unwrap()
+            || !index.current_owned_entry().unwrap().unwrap().key.starts_with(key)
+    );
+}
+
+fn name_index_entry_key(name: &str, table_key: TableKey) -> Vec<u8> {
+    let key = Tuple::new(vec![Value::String(name.to_owned())]).to_bytes().unwrap();
+    encode_index_entry_key(&key, table_key)
 }
 
 #[test]
@@ -797,7 +810,7 @@ fn failed_multi_row_insert_in_explicit_transaction_rolls_back_statement_before_c
     let mut users = reopened.table_cursor_by_name("users").unwrap();
     let mut index = reopened.index_cursor_by_name("idx_users_name").unwrap();
     let ada = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
-    let linus = Tuple::new(vec![Value::String("Linus".to_owned())]).to_bytes().unwrap();
+    let linus = name_index_entry_key("Linus", 2);
     let row = users.get(2).unwrap().expect("successful statement should commit");
 
     assert_eq!(
@@ -805,7 +818,7 @@ fn failed_multi_row_insert_in_explicit_transaction_rolls_back_statement_before_c
         vec![Value::Integer(2), Value::String("Linus".to_owned()), Value::Boolean(true)]
     );
     assert!(users.get(1).unwrap().is_none());
-    assert!(index.get(&ada).unwrap().is_none());
+    assert_index_prefix_absent(&mut index, &ada);
     assert_eq!(index.get(&linus).unwrap().unwrap().table_key, 2);
 }
 
@@ -872,7 +885,7 @@ fn create_index_backfills_existing_table_rows() {
     executor.execute(create_index_plan.physical).unwrap();
 
     let mut index = database.index_cursor_by_name("idx_users_name").unwrap();
-    let key = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
+    let key = name_index_entry_key("Ada", 1);
     let entry = index.get(&key).unwrap().expect("index entry should be backfilled");
 
     assert_eq!(entry.table_key, 1);
@@ -895,10 +908,32 @@ fn insert_values_updates_existing_secondary_indexes() {
     executor.execute(insert_plan.physical).unwrap();
 
     let mut index = database.index_cursor_by_name("idx_users_name").unwrap();
-    let key = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
+    let key = name_index_entry_key("Ada", 1);
     let entry = index.get(&key).unwrap().expect("index entry should track inserted row");
 
     assert_eq!(entry.table_key, 1);
+}
+
+#[test]
+fn secondary_indexes_allow_duplicate_values_and_persist_entries() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.db");
+    let database = Database::create(&path).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Engineering', TRUE), (2, 'Engineering', FALSE);",
+    )
+    .unwrap();
+    database.flush().unwrap();
+    drop(database);
+
+    let reopened = Database::open(&path).unwrap();
+    assert_name_index_entry(&reopened, "Engineering", 1);
+    assert_name_index_entry(&reopened, "Engineering", 2);
 }
 
 #[test]
@@ -1585,7 +1620,7 @@ fn failed_indexed_multi_row_insert_rolls_back_after_reopen() {
     let ada = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
 
     assert!(users.get(1).unwrap().is_none());
-    assert!(index.get(&ada).unwrap().is_none());
+    assert_index_prefix_absent(&mut index, &ada);
 }
 
 #[test]
@@ -1623,7 +1658,7 @@ fn uncommitted_flushed_insert_is_undone_during_recovery() {
     let ada = Tuple::new(vec![Value::String("Ada".to_owned())]).to_bytes().unwrap();
 
     assert!(users.get(1).unwrap().is_none());
-    assert!(index.get(&ada).unwrap().is_none());
+    assert_index_prefix_absent(&mut index, &ada);
 }
 
 #[test]

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -631,6 +631,72 @@ fn select_with_primary_key_range_returns_only_matching_rows() {
 }
 
 #[test]
+fn select_with_secondary_index_equality_returns_matching_rows() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Engineering', TRUE), (2, 'Engineering', FALSE), (3, 'Sales', TRUE);",
+    )
+    .unwrap();
+
+    let output =
+        execute_sql(&database, "SELECT id FROM users WHERE name == 'Engineering';").unwrap();
+
+    let rows = collect_rows(output).unwrap();
+    assert_eq!(rows.iter().map(|row| row.table_key).collect::<Vec<_>>(), vec![1, 2]);
+    assert_eq!(
+        rows.iter().map(values).collect::<Vec<_>>(),
+        vec![vec![Value::Integer(1)], vec![Value::Integer(2)]]
+    );
+}
+
+#[test]
+fn select_with_secondary_index_equality_applies_residual_filter() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Engineering', TRUE), (2, 'Engineering', FALSE), (3, 'Sales', FALSE);",
+    )
+    .unwrap();
+
+    let output = execute_sql(
+        &database,
+        "SELECT id FROM users WHERE name == 'Engineering' AND active == FALSE;",
+    )
+    .unwrap();
+
+    let rows = collect_rows(output).unwrap();
+    assert_eq!(rows.iter().map(|row| row.table_key).collect::<Vec<_>>(), vec![2]);
+    assert_eq!(rows.iter().map(values).collect::<Vec<_>>(), vec![vec![Value::Integer(2)]]);
+}
+
+#[test]
+fn explain_select_reports_secondary_index_scan_choice() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+
+    let output =
+        execute_sql(&database, "EXPLAIN SELECT id FROM users WHERE name == 'Ada';").unwrap();
+
+    let ExecutionOutput::Explain(plan) = output else {
+        panic!("expected explain output");
+    };
+    assert!(plan.contains(
+        "SecondaryIndexScan table=users index=idx_users_name column=users.name value=Ada"
+    ));
+}
+
+#[test]
 fn insert_values_uses_primary_keys_and_persists_rows() {
     let dir = tempdir().unwrap();
     let database = Database::create(dir.path().join("test.db")).unwrap();
@@ -1024,6 +1090,29 @@ fn delete_removes_secondary_index_entries() {
 }
 
 #[test]
+fn delete_where_can_use_secondary_index_scan() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Engineering', TRUE), (2, 'Engineering', TRUE), (3, 'Sales', TRUE);",
+    )
+    .unwrap();
+
+    let output = execute_sql(&database, "DELETE FROM users WHERE name == 'Engineering';").unwrap();
+
+    assert!(matches!(output, ExecutionOutput::RowsAffected(2)));
+    assert_user_row_absent(&database, 1);
+    assert_user_row_absent(&database, 2);
+    assert_user_row(&database, 3, "Sales");
+    assert_name_index_absent(&database, "Engineering");
+    assert_name_index_entry(&database, "Sales", 3);
+}
+
+#[test]
 fn delete_with_non_boolean_where_does_not_delete_rows() {
     let dir = tempdir().unwrap();
     let database = Database::create(dir.path().join("test.db")).unwrap();
@@ -1205,6 +1294,45 @@ fn update_refreshes_secondary_index_entries() {
     assert_name_index_absent(&database, "Ada");
     assert_name_index_entry(&database, "Linus", 1);
     assert_name_index_entry(&database, "Grace", 2);
+}
+
+#[test]
+fn update_where_can_use_secondary_index_scan() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Engineering', TRUE), (2, 'Engineering', FALSE), (3, 'Sales', TRUE);",
+    )
+    .unwrap();
+
+    let output =
+        execute_sql(&database, "UPDATE users SET active = FALSE WHERE name == 'Engineering';")
+            .unwrap();
+
+    assert!(matches!(output, ExecutionOutput::RowsAffected(2)));
+    let mut users = database.table_cursor_by_name("users").unwrap();
+    let first = users.get(1).unwrap().expect("updated row should exist");
+    let second = users.get(2).unwrap().expect("updated row should exist");
+    let third = users.get(3).unwrap().expect("untouched row should exist");
+    assert_eq!(
+        values(&first),
+        vec![Value::Integer(1), Value::String("Engineering".to_owned()), Value::Boolean(false)]
+    );
+    assert_eq!(
+        values(&second),
+        vec![Value::Integer(2), Value::String("Engineering".to_owned()), Value::Boolean(false)]
+    );
+    assert_eq!(
+        values(&third),
+        vec![Value::Integer(3), Value::String("Sales".to_owned()), Value::Boolean(true)]
+    );
+    assert_name_index_entry(&database, "Engineering", 1);
+    assert_name_index_entry(&database, "Engineering", 2);
+    assert_name_index_entry(&database, "Sales", 3);
 }
 
 #[test]

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -679,6 +679,80 @@ fn select_with_secondary_index_equality_applies_residual_filter() {
 }
 
 #[test]
+fn select_with_text_index_range_returns_matching_rows() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Zoe', TRUE), \
+         (2, 'Amy', TRUE), \
+         (3, 'Ada', TRUE), \
+         (4, 'Charlotte', TRUE), \
+         (5, 'Bob', TRUE);",
+    )
+    .unwrap();
+
+    let output =
+        execute_sql(&database, "SELECT id FROM users WHERE name >= 'Amy' AND name <= 'Charlotte';")
+            .unwrap();
+
+    let rows = collect_rows(output).unwrap();
+    assert_eq!(rows.iter().map(|row| row.table_key).collect::<Vec<_>>(), vec![2, 4, 5]);
+    assert_eq!(
+        rows.iter().map(values).collect::<Vec<_>>(),
+        vec![vec![Value::Integer(2)], vec![Value::Integer(4)], vec![Value::Integer(5)]]
+    );
+}
+
+#[test]
+fn select_with_text_index_exclusive_range_excludes_boundary_values() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Amy', TRUE), (2, 'Bob', TRUE), (3, 'Charlotte', TRUE);",
+    )
+    .unwrap();
+
+    let output =
+        execute_sql(&database, "SELECT id FROM users WHERE name > 'Amy' AND name < 'Charlotte';")
+            .unwrap();
+
+    let rows = collect_rows(output).unwrap();
+    assert_eq!(rows.iter().map(|row| row.table_key).collect::<Vec<_>>(), vec![2]);
+    assert_eq!(rows.iter().map(values).collect::<Vec<_>>(), vec![vec![Value::Integer(2)]]);
+}
+
+#[test]
+fn select_with_text_index_range_does_not_skip_short_matching_values() {
+    let dir = tempdir().unwrap();
+    let database = Database::create(dir.path().join("test.db")).unwrap();
+    database.create_table("users", users_schema()).unwrap();
+    execute_sql(&database, "CREATE INDEX idx_users_name ON users (name);").unwrap();
+    execute_sql(
+        &database,
+        "INSERT INTO users (id, name, active) VALUES \
+         (1, 'Bob', TRUE), (2, 'Zo', TRUE), (3, 'Charlie', TRUE);",
+    )
+    .unwrap();
+
+    let output = execute_sql(&database, "SELECT id FROM users WHERE name > 'Bob';").unwrap();
+
+    let rows = collect_rows(output).unwrap();
+    assert_eq!(rows.iter().map(|row| row.table_key).collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(
+        rows.iter().map(values).collect::<Vec<_>>(),
+        vec![vec![Value::Integer(2)], vec![Value::Integer(3)]]
+    );
+}
+
+#[test]
 fn explain_select_reports_secondary_index_scan_choice() {
     let dir = tempdir().unwrap();
     let database = Database::create(dir.path().join("test.db")).unwrap();
@@ -692,7 +766,7 @@ fn explain_select_reports_secondary_index_scan_choice() {
         panic!("expected explain output");
     };
     assert!(plan.contains(
-        "SecondaryIndexScan table=users index=idx_users_name column=users.name value=Ada"
+        "SecondaryIndexScan table=users index=idx_users_name column=users.name range=[lower=Ada inclusive upper=Ada inclusive]"
     ));
 }
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -16,9 +16,10 @@ use thiserror::Error;
 
 use crate::{
     core::{
-        ColumnSchema, DataType, Database, IndexSchema, TableKey, TableKeyBound, TableKeyRange,
-        TableSchema, Tuple, TupleSchema, Value,
+        ColumnSchema, DataType, Database, IndexKeyBound, IndexKeyRange, IndexSchema, TableKey,
+        TableKeyBound, TableKeyRange, TableSchema, Tuple, TupleSchema, Value,
         access::SchemaAccess,
+        cursor::encode_index_entry_key,
         error::{InvalidArgumentError, StorageError},
     },
     sql_parser::{
@@ -166,18 +167,10 @@ pub enum PhysicalPlan {
         /// Primary-key range to scan.
         range: TableKeyRange,
     },
-    /// Scan rows from a table through an exact secondary-index key lookup.
+    /// Scan rows from a table through a secondary-index key range.
     SecondaryIndexScan {
-        /// Table to fetch rows from.
-        table: TableSchema,
-        /// Secondary index to scan.
-        index: IndexSchema,
-        /// Bound table column matched by the index lookup.
-        column: BoundColumn,
-        /// Literal value encoded into `key`.
-        value: Value,
-        /// Encoded index-key prefix to seek.
-        key: Vec<u8>,
+        /// Scan metadata and key bounds.
+        scan: Box<SecondaryIndexScanPlan>,
     },
     /// Filter rows from an input physical operator.
     Filter {
@@ -214,6 +207,21 @@ pub enum PhysicalPlan {
         /// Maximum number of rows to emit.
         limit: u32,
     },
+}
+
+/// Metadata needed to scan a table through a secondary index.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SecondaryIndexScanPlan {
+    /// Table to fetch rows from.
+    pub table: TableSchema,
+    /// Secondary index to scan.
+    pub index: IndexSchema,
+    /// Bound table column matched by the index lookup.
+    pub column: BoundColumn,
+    /// Human-readable indexed value range.
+    pub value_range: IndexValueRange,
+    /// Encoded index-key range to scan.
+    pub key_range: IndexKeyRange,
 }
 
 impl fmt::Display for PhysicalPlan {
@@ -292,9 +300,9 @@ fn physical_plan_label(plan: &PhysicalPlan) -> String {
         PhysicalPlan::PrimaryKeyRangeScan { table, range } => {
             format!("PrimaryKeyRangeScan table={} range=[{}]", table.name, range)
         }
-        PhysicalPlan::SecondaryIndexScan { table, index, column, value, .. } => format!(
-            "SecondaryIndexScan table={} index={} column={} value={}",
-            table.name, index.name, column, value
+        PhysicalPlan::SecondaryIndexScan { scan } => format!(
+            "SecondaryIndexScan table={} index={} column={} range=[{}]",
+            scan.table.name, scan.index.name, scan.column, scan.value_range
         ),
         PhysicalPlan::Filter { predicate, .. } => format!("Filter predicate={predicate}"),
         PhysicalPlan::Sort { terms, .. } => format!("Sort terms=[{}]", display_list(terms)),
@@ -350,6 +358,44 @@ pub struct BoundColumn {
     pub ordinal: usize,
     /// Storage type recorded for the column.
     pub data_type: DataType,
+}
+
+/// Inclusive or exclusive display bound for a secondary-index scan value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IndexValueBound {
+    /// The scan includes this value.
+    Inclusive(Value),
+    /// The scan excludes this value.
+    Exclusive(Value),
+}
+
+impl fmt::Display for IndexValueBound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inclusive(value) => write!(f, "{value} inclusive"),
+            Self::Exclusive(value) => write!(f, "{value} exclusive"),
+        }
+    }
+}
+
+/// Human-readable range over values in a single-column secondary index.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct IndexValueRange {
+    /// Optional lower value bound.
+    pub lower: Option<IndexValueBound>,
+    /// Optional upper value bound.
+    pub upper: Option<IndexValueBound>,
+}
+
+impl fmt::Display for IndexValueRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.lower, &self.upper) {
+            (None, None) => write!(f, "unbounded"),
+            (Some(lower), None) => write!(f, "lower={lower}"),
+            (None, Some(upper)) => write!(f, "upper={upper}"),
+            (Some(lower), Some(upper)) => write!(f, "lower={lower} upper={upper}"),
+        }
+    }
 }
 
 impl fmt::Display for BoundColumn {
@@ -697,11 +743,13 @@ impl<'db> Planner<'db> {
                         None => match self.secondary_index_predicate(table, predicate)? {
                             Some(index_predicate) => Ok(PhysicalPlan::Filter {
                                 input: Box::new(PhysicalPlan::SecondaryIndexScan {
-                                    table: table.clone(),
-                                    index: index_predicate.index,
-                                    column: index_predicate.column,
-                                    value: index_predicate.value,
-                                    key: index_predicate.key,
+                                    scan: Box::new(SecondaryIndexScanPlan {
+                                        table: table.clone(),
+                                        index: index_predicate.index,
+                                        column: index_predicate.column,
+                                        value_range: index_predicate.value_range,
+                                        key_range: index_predicate.key_range,
+                                    }),
                                 }),
                                 predicate: predicate.clone(),
                             }),
@@ -839,8 +887,8 @@ struct RangePredicate {
 struct IndexPredicate {
     index: IndexSchema,
     column: BoundColumn,
-    value: Value,
-    key: Vec<u8>,
+    value_range: IndexValueRange,
+    key_range: IndexKeyRange,
 }
 
 fn primary_key_range_predicate(
@@ -860,28 +908,115 @@ fn secondary_index_predicate(
     predicate: &PlannedExpression,
     indexes: &[IndexSchema],
 ) -> Option<IndexPredicate> {
-    match predicate {
+    let mut conjuncts = Vec::new();
+    flatten_conjuncts(predicate, &mut conjuncts);
+
+    for conjunct in &conjuncts {
+        let Some(candidate) = secondary_index_comparison(table, conjunct, indexes) else {
+            continue;
+        };
+        let mut value_range = IndexValueRange::default();
+        let mut key_range = IndexKeyRange::default();
+
+        for conjunct in &conjuncts {
+            if let Some(comparison) =
+                index_comparison_for_column(table, conjunct, &candidate.column)
+            {
+                combine_index_ranges(
+                    &mut value_range,
+                    &mut key_range,
+                    comparison.value,
+                    comparison.kind,
+                )?;
+            }
+        }
+
+        return Some(IndexPredicate {
+            index: candidate.index,
+            column: candidate.column,
+            value_range,
+            key_range,
+        });
+    }
+
+    None
+}
+
+fn flatten_conjuncts<'a>(
+    expression: &'a PlannedExpression,
+    conjuncts: &mut Vec<&'a PlannedExpression>,
+) {
+    match expression {
         PlannedExpression::Binary { left, op: Op::And, right } => {
-            secondary_index_predicate(table, left, indexes)
-                .or_else(|| secondary_index_predicate(table, right, indexes))
+            flatten_conjuncts(left, conjuncts);
+            flatten_conjuncts(right, conjuncts);
         }
-        PlannedExpression::Binary { left, op: Op::EqualsEquals, right } => {
-            secondary_index_from_comparison(table, left, right, indexes)
-                .or_else(|| secondary_index_from_comparison(table, right, left, indexes))
-        }
-        PlannedExpression::Binary { .. }
-        | PlannedExpression::Literal(_)
-        | PlannedExpression::Column(_)
-        | PlannedExpression::Unary { .. } => None,
+        _ => conjuncts.push(expression),
     }
 }
 
-fn secondary_index_from_comparison(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexComparisonKind {
+    Equals,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+}
+
+struct IndexComparison<'a> {
+    column: BoundColumn,
+    value: &'a Value,
+    kind: IndexComparisonKind,
+}
+
+struct SecondaryIndexCandidate<'a> {
+    index: IndexSchema,
+    column: BoundColumn,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+fn secondary_index_comparison<'a>(
+    table: &TableSchema,
+    comparison: &'a PlannedExpression,
+    indexes: &[IndexSchema],
+) -> Option<SecondaryIndexCandidate<'a>> {
+    let comparison = index_comparison(table, comparison)?;
+    let index =
+        indexes.iter().find(|index| exact_single_column_index(index, table, &comparison.column))?;
+    Some(SecondaryIndexCandidate {
+        index: index.clone(),
+        column: comparison.column,
+        _marker: std::marker::PhantomData,
+    })
+}
+
+fn index_comparison_for_column<'a>(
+    table: &TableSchema,
+    comparison: &'a PlannedExpression,
+    column: &BoundColumn,
+) -> Option<IndexComparison<'a>> {
+    let comparison = index_comparison(table, comparison)?;
+    (comparison.column == *column).then_some(comparison)
+}
+
+fn index_comparison<'a>(
+    table: &TableSchema,
+    comparison: &'a PlannedExpression,
+) -> Option<IndexComparison<'a>> {
+    let PlannedExpression::Binary { left, op, right } = comparison else {
+        return None;
+    };
+    index_comparison_from_operands(table, left, *op, right)
+        .or_else(|| index_comparison_from_reversed_operands(table, left, *op, right))
+}
+
+fn index_comparison_from_operands<'a>(
     table: &TableSchema,
     column: &PlannedExpression,
-    value: &PlannedExpression,
-    indexes: &[IndexSchema],
-) -> Option<IndexPredicate> {
+    op: Op,
+    value: &'a PlannedExpression,
+) -> Option<IndexComparison<'a>> {
     let PlannedExpression::Column(column) = column else {
         return None;
     };
@@ -892,9 +1027,155 @@ fn secondary_index_from_comparison(
         return None;
     }
 
-    let index = indexes.iter().find(|index| exact_single_column_index(index, table, column))?;
-    let key = Tuple::new(vec![value.clone()]).to_bytes().ok()?;
-    Some(IndexPredicate { index: index.clone(), column: column.clone(), value: value.clone(), key })
+    let kind = match op {
+        Op::EqualsEquals => IndexComparisonKind::Equals,
+        Op::GreaterThan => IndexComparisonKind::GreaterThan,
+        Op::GreaterThanOrEqual => IndexComparisonKind::GreaterThanOrEqual,
+        Op::LessThan => IndexComparisonKind::LessThan,
+        Op::LessThanOrEqual => IndexComparisonKind::LessThanOrEqual,
+        Op::And | Op::Or | Op::NotEquals | Op::Not | Op::Add | Op::Sub | Op::Mul | Op::Div => {
+            return None;
+        }
+    };
+
+    if !secondary_index_comparison_is_order_compatible(column.data_type, kind) {
+        return None;
+    }
+
+    Some(IndexComparison { column: column.clone(), value, kind })
+}
+
+fn index_comparison_from_reversed_operands<'a>(
+    table: &TableSchema,
+    value: &'a PlannedExpression,
+    op: Op,
+    column: &PlannedExpression,
+) -> Option<IndexComparison<'a>> {
+    let reversed = reverse_comparison_op(op)?;
+    index_comparison_from_operands(table, column, reversed, value)
+}
+
+fn reverse_comparison_op(op: Op) -> Option<Op> {
+    match op {
+        Op::EqualsEquals => Some(Op::EqualsEquals),
+        Op::GreaterThan => Some(Op::LessThan),
+        Op::GreaterThanOrEqual => Some(Op::LessThanOrEqual),
+        Op::LessThan => Some(Op::GreaterThan),
+        Op::LessThanOrEqual => Some(Op::GreaterThanOrEqual),
+        Op::And | Op::Or | Op::NotEquals | Op::Not | Op::Add | Op::Sub | Op::Mul | Op::Div => None,
+    }
+}
+
+fn secondary_index_comparison_is_order_compatible(
+    data_type: DataType,
+    kind: IndexComparisonKind,
+) -> bool {
+    kind == IndexComparisonKind::Equals || data_type != DataType::Text
+}
+
+fn combine_index_ranges(
+    value_range: &mut IndexValueRange,
+    key_range: &mut IndexKeyRange,
+    value: &Value,
+    kind: IndexComparisonKind,
+) -> Option<()> {
+    match kind {
+        IndexComparisonKind::Equals => {
+            combine_index_lower_bound(value_range, key_range, value.clone(), true)?;
+            combine_index_upper_bound(value_range, key_range, value.clone(), true)?;
+        }
+        IndexComparisonKind::GreaterThan => {
+            combine_index_lower_bound(value_range, key_range, value.clone(), false)?;
+        }
+        IndexComparisonKind::GreaterThanOrEqual => {
+            combine_index_lower_bound(value_range, key_range, value.clone(), true)?;
+        }
+        IndexComparisonKind::LessThan => {
+            combine_index_upper_bound(value_range, key_range, value.clone(), false)?;
+        }
+        IndexComparisonKind::LessThanOrEqual => {
+            combine_index_upper_bound(value_range, key_range, value.clone(), true)?;
+        }
+    }
+    Some(())
+}
+
+fn combine_index_lower_bound(
+    value_range: &mut IndexValueRange,
+    key_range: &mut IndexKeyRange,
+    value: Value,
+    inclusive: bool,
+) -> Option<()> {
+    let key = index_lower_key(&value, inclusive)?;
+    let value_bound = if inclusive {
+        IndexValueBound::Inclusive(value)
+    } else {
+        IndexValueBound::Exclusive(value)
+    };
+    let key_bound =
+        if inclusive { IndexKeyBound::Inclusive(key) } else { IndexKeyBound::Exclusive(key) };
+
+    if index_lower_is_tighter(key_range.lower.as_ref(), &key_bound) {
+        value_range.lower = Some(value_bound);
+        key_range.lower = Some(key_bound);
+    }
+    Some(())
+}
+
+fn combine_index_upper_bound(
+    value_range: &mut IndexValueRange,
+    key_range: &mut IndexKeyRange,
+    value: Value,
+    inclusive: bool,
+) -> Option<()> {
+    let key = index_upper_key(&value, inclusive)?;
+    let value_bound = if inclusive {
+        IndexValueBound::Inclusive(value)
+    } else {
+        IndexValueBound::Exclusive(value)
+    };
+    let key_bound =
+        if inclusive { IndexKeyBound::Inclusive(key) } else { IndexKeyBound::Exclusive(key) };
+
+    if index_upper_is_tighter(key_range.upper.as_ref(), &key_bound) {
+        value_range.upper = Some(value_bound);
+        key_range.upper = Some(key_bound);
+    }
+    Some(())
+}
+
+fn index_lower_key(value: &Value, inclusive: bool) -> Option<Vec<u8>> {
+    let prefix = Tuple::new(vec![value.clone()]).to_bytes().ok()?;
+    let table_key = if inclusive { TableKey::MIN } else { TableKey::MAX };
+    Some(encode_index_entry_key(&prefix, table_key))
+}
+
+fn index_upper_key(value: &Value, inclusive: bool) -> Option<Vec<u8>> {
+    let prefix = Tuple::new(vec![value.clone()]).to_bytes().ok()?;
+    let table_key = if inclusive { TableKey::MAX } else { TableKey::MIN };
+    Some(encode_index_entry_key(&prefix, table_key))
+}
+
+fn index_lower_is_tighter(current: Option<&IndexKeyBound>, candidate: &IndexKeyBound) -> bool {
+    match current {
+        None => true,
+        Some(current) => {
+            candidate.key() > current.key()
+                || (candidate.key() == current.key()
+                    && matches!(candidate, IndexKeyBound::Exclusive(_)))
+        }
+    }
+}
+
+fn index_upper_is_tighter(current: Option<&IndexKeyBound>, candidate: &IndexKeyBound) -> bool {
+    match current {
+        None => true,
+        Some(current) => {
+            candidate.key() < current.key()
+                || (candidate.key() == current.key()
+                    && matches!(candidate, IndexKeyBound::Exclusive(_)))
+        }
+    }
 }
 
 fn exact_single_column_index(
@@ -1617,11 +1898,11 @@ mod tests {
     }
 
     #[test]
-    fn select_secondary_index_column_range_stays_full_table_scan() {
+    fn select_secondary_index_integer_column_range_uses_index_scan() {
         let (_dir, database) = database_with_users();
-        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        database.create_index("idx_users_age", "users", &["age"]).unwrap();
         let planner = Planner::new(&database);
-        let statement = parse("SELECT name FROM users WHERE 'Ada' <= name AND name < 'Linus';");
+        let statement = parse("SELECT name FROM users WHERE 18 <= age AND age < 65;");
 
         let plan = planner.plan_statement(&statement).unwrap();
 
@@ -1631,8 +1912,16 @@ mod tests {
         let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
             panic!("expected filter under project: {plan:?}");
         };
-        assert!(
-            matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")
+        let PhysicalPlan::SecondaryIndexScan { scan } = input.as_ref() else {
+            panic!("expected secondary index scan under residual filter: {plan:?}");
+        };
+        assert_eq!(scan.index.name, "idx_users_age");
+        assert_eq!(
+            &scan.value_range,
+            &IndexValueRange {
+                lower: Some(IndexValueBound::Inclusive(Value::Integer(18))),
+                upper: Some(IndexValueBound::Exclusive(Value::Integer(65))),
+            }
         );
     }
 
@@ -1664,14 +1953,19 @@ mod tests {
                 right: Box::new(PlannedExpression::Literal(Value::String("Ada".to_owned()))),
             }
         );
-        let PhysicalPlan::SecondaryIndexScan { table, index, column, value, .. } = input.as_ref()
-        else {
+        let PhysicalPlan::SecondaryIndexScan { scan } = input.as_ref() else {
             panic!("expected secondary index scan under residual filter: {plan:?}");
         };
-        assert_eq!(table.name, "users");
-        assert_eq!(index.name, "idx_users_name");
-        assert_eq!(column.name, "name");
-        assert_eq!(value, &Value::String("Ada".to_owned()));
+        assert_eq!(scan.table.name, "users");
+        assert_eq!(scan.index.name, "idx_users_name");
+        assert_eq!(scan.column.name, "name");
+        assert_eq!(
+            &scan.value_range,
+            &IndexValueRange {
+                lower: Some(IndexValueBound::Inclusive(Value::String("Ada".to_owned()))),
+                upper: Some(IndexValueBound::Inclusive(Value::String("Ada".to_owned()))),
+            }
+        );
     }
 
     #[test]
@@ -1702,6 +1996,67 @@ mod tests {
     }
 
     #[test]
+    fn select_text_secondary_index_range_stays_full_table_scan() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement =
+            parse("SELECT name FROM users WHERE name >= 'Amy' AND name <= 'Charlotte';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        assert!(
+            matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")
+        );
+    }
+
+    #[test]
+    fn select_reversed_text_secondary_index_range_stays_full_table_scan() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE 'Amy' < name AND 'Charlotte' >= name;");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        assert!(
+            matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")
+        );
+    }
+
+    #[test]
+    fn secondary_index_selection_skips_text_range_conjuncts() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE age == 7 AND name >= 'Amy';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        assert!(
+            matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")
+        );
+    }
+
+    #[test]
     fn leftmost_usable_secondary_index_predicate_wins() {
         let (_dir, database) = database_with_users();
         database.create_index("idx_users_name", "users", &["name"]).unwrap();
@@ -1717,12 +2072,18 @@ mod tests {
         let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
             panic!("expected residual filter under project: {plan:?}");
         };
-        let PhysicalPlan::SecondaryIndexScan { index, column, value, .. } = input.as_ref() else {
+        let PhysicalPlan::SecondaryIndexScan { scan } = input.as_ref() else {
             panic!("expected secondary index scan under residual filter: {plan:?}");
         };
-        assert_eq!(index.name, "idx_users_age");
-        assert_eq!(column.name, "age");
-        assert_eq!(value, &Value::Integer(7));
+        assert_eq!(scan.index.name, "idx_users_age");
+        assert_eq!(scan.column.name, "age");
+        assert_eq!(
+            &scan.value_range,
+            &IndexValueRange {
+                lower: Some(IndexValueBound::Inclusive(Value::Integer(7))),
+                upper: Some(IndexValueBound::Inclusive(Value::Integer(7))),
+            }
+        );
     }
 
     #[test]
@@ -1741,10 +2102,10 @@ mod tests {
         let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
             panic!("expected residual filter under project: {plan:?}");
         };
-        let PhysicalPlan::SecondaryIndexScan { index, .. } = input.as_ref() else {
+        let PhysicalPlan::SecondaryIndexScan { scan } = input.as_ref() else {
             panic!("expected secondary index scan under residual filter: {plan:?}");
         };
-        assert_eq!(index.name, "idx_users_name_first");
+        assert_eq!(scan.index.name, "idx_users_name_first");
     }
 
     #[test]

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -16,8 +16,8 @@ use thiserror::Error;
 
 use crate::{
     core::{
-        ColumnSchema, DataType, Database, TableKey, TableKeyBound, TableKeyRange, TableSchema,
-        TupleSchema, Value,
+        ColumnSchema, DataType, Database, IndexSchema, TableKey, TableKeyBound, TableKeyRange,
+        TableSchema, Tuple, TupleSchema, Value,
         access::SchemaAccess,
         error::{InvalidArgumentError, StorageError},
     },
@@ -166,6 +166,19 @@ pub enum PhysicalPlan {
         /// Primary-key range to scan.
         range: TableKeyRange,
     },
+    /// Scan rows from a table through an exact secondary-index key lookup.
+    SecondaryIndexScan {
+        /// Table to fetch rows from.
+        table: TableSchema,
+        /// Secondary index to scan.
+        index: IndexSchema,
+        /// Bound table column matched by the index lookup.
+        column: BoundColumn,
+        /// Literal value encoded into `key`.
+        value: Value,
+        /// Encoded index-key prefix to seek.
+        key: Vec<u8>,
+    },
     /// Filter rows from an input physical operator.
     Filter {
         /// Input operator.
@@ -249,7 +262,8 @@ fn physical_plan_input(plan: &PhysicalPlan) -> Option<&PhysicalPlan> {
         | PhysicalPlan::InsertValues { .. }
         | PhysicalPlan::OneRow
         | PhysicalPlan::FullTableScan { .. }
-        | PhysicalPlan::PrimaryKeyRangeScan { .. } => None,
+        | PhysicalPlan::PrimaryKeyRangeScan { .. }
+        | PhysicalPlan::SecondaryIndexScan { .. } => None,
     }
 }
 
@@ -278,6 +292,10 @@ fn physical_plan_label(plan: &PhysicalPlan) -> String {
         PhysicalPlan::PrimaryKeyRangeScan { table, range } => {
             format!("PrimaryKeyRangeScan table={} range=[{}]", table.name, range)
         }
+        PhysicalPlan::SecondaryIndexScan { table, index, column, value, .. } => format!(
+            "SecondaryIndexScan table={} index={} column={} value={}",
+            table.name, index.name, column, value
+        ),
         PhysicalPlan::Filter { predicate, .. } => format!("Filter predicate={predicate}"),
         PhysicalPlan::Sort { terms, .. } => format!("Sort terms=[{}]", display_list(terms)),
         PhysicalPlan::Project { expressions, .. } => {
@@ -676,10 +694,22 @@ impl<'db> Planner<'db> {
                                 None => Ok(scan),
                             }
                         }
-                        None => Ok(PhysicalPlan::Filter {
-                            input: Box::new(self.physical_plan(input)?),
-                            predicate: predicate.clone(),
-                        }),
+                        None => match self.secondary_index_predicate(table, predicate)? {
+                            Some(index_predicate) => Ok(PhysicalPlan::Filter {
+                                input: Box::new(PhysicalPlan::SecondaryIndexScan {
+                                    table: table.clone(),
+                                    index: index_predicate.index,
+                                    column: index_predicate.column,
+                                    value: index_predicate.value,
+                                    key: index_predicate.key,
+                                }),
+                                predicate: predicate.clone(),
+                            }),
+                            None => Ok(PhysicalPlan::Filter {
+                                input: Box::new(self.physical_plan(input)?),
+                                predicate: predicate.clone(),
+                            }),
+                        },
                     }
                 }
                 _ => Ok(PhysicalPlan::Filter {
@@ -704,6 +734,15 @@ impl<'db> Planner<'db> {
                 limit: *limit,
             }),
         }
+    }
+
+    fn secondary_index_predicate(
+        &self,
+        table: &TableSchema,
+        predicate: &PlannedExpression,
+    ) -> PlannerResult<Option<IndexPredicate>> {
+        let indexes = self.schema.index_schemas_for_table(table)?;
+        Ok(secondary_index_predicate(table, predicate, &indexes))
     }
 
     fn bind_projection(
@@ -796,6 +835,14 @@ struct RangePredicate {
     residual: Option<PlannedExpression>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct IndexPredicate {
+    index: IndexSchema,
+    column: BoundColumn,
+    value: Value,
+    key: Vec<u8>,
+}
+
 fn primary_key_range_predicate(
     table: &TableSchema,
     predicate: &PlannedExpression,
@@ -806,6 +853,69 @@ fn primary_key_range_predicate(
     }
 
     range_predicate_from_expression(table, predicate)
+}
+
+fn secondary_index_predicate(
+    table: &TableSchema,
+    predicate: &PlannedExpression,
+    indexes: &[IndexSchema],
+) -> Option<IndexPredicate> {
+    match predicate {
+        PlannedExpression::Binary { left, op: Op::And, right } => {
+            secondary_index_predicate(table, left, indexes)
+                .or_else(|| secondary_index_predicate(table, right, indexes))
+        }
+        PlannedExpression::Binary { left, op: Op::EqualsEquals, right } => {
+            secondary_index_from_comparison(table, left, right, indexes)
+                .or_else(|| secondary_index_from_comparison(table, right, left, indexes))
+        }
+        PlannedExpression::Binary { .. }
+        | PlannedExpression::Literal(_)
+        | PlannedExpression::Column(_)
+        | PlannedExpression::Unary { .. } => None,
+    }
+}
+
+fn secondary_index_from_comparison(
+    table: &TableSchema,
+    column: &PlannedExpression,
+    value: &PlannedExpression,
+    indexes: &[IndexSchema],
+) -> Option<IndexPredicate> {
+    let PlannedExpression::Column(column) = column else {
+        return None;
+    };
+    let PlannedExpression::Literal(value) = value else {
+        return None;
+    };
+    if column.table != table.name || !value_matches_data_type(value, column.data_type) {
+        return None;
+    }
+
+    let index = indexes.iter().find(|index| exact_single_column_index(index, table, column))?;
+    let key = Tuple::new(vec![value.clone()]).to_bytes().ok()?;
+    Some(IndexPredicate { index: index.clone(), column: column.clone(), value: value.clone(), key })
+}
+
+fn exact_single_column_index(
+    index: &IndexSchema,
+    table: &TableSchema,
+    column: &BoundColumn,
+) -> bool {
+    index.table_id == table.table_id
+        && index.columns.len() == 1
+        && index.columns[0].source_column_ordinal as usize == column.ordinal
+}
+
+fn value_matches_data_type(value: &Value, data_type: DataType) -> bool {
+    matches!(
+        (value, data_type),
+        (Value::String(_), DataType::Text)
+            | (Value::Boolean(_), DataType::Boolean)
+            | (Value::Integer(_), DataType::Integer)
+            | (Value::Float(_), DataType::Float)
+            | (Value::UnsignedInteger(_), DataType::UnsignedInteger)
+    )
 }
 
 fn range_predicate_from_expression(
@@ -1512,6 +1622,137 @@ mod tests {
         database.create_index("idx_users_name", "users", &["name"]).unwrap();
         let planner = Planner::new(&database);
         let statement = parse("SELECT name FROM users WHERE 'Ada' <= name AND name < 'Linus';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected filter under project: {plan:?}");
+        };
+        assert!(
+            matches!(input.as_ref(), PhysicalPlan::FullTableScan { table } if table.name == "users")
+        );
+    }
+
+    #[test]
+    fn select_secondary_index_equality_uses_index_scan_with_residual_filter() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE name == 'Ada';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, predicate } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        assert_eq!(
+            predicate,
+            &PlannedExpression::Binary {
+                left: Box::new(PlannedExpression::Column(bound(
+                    "users",
+                    "name",
+                    1,
+                    DataType::Text
+                ))),
+                op: Op::EqualsEquals,
+                right: Box::new(PlannedExpression::Literal(Value::String("Ada".to_owned()))),
+            }
+        );
+        let PhysicalPlan::SecondaryIndexScan { table, index, column, value, .. } = input.as_ref()
+        else {
+            panic!("expected secondary index scan under residual filter: {plan:?}");
+        };
+        assert_eq!(table.name, "users");
+        assert_eq!(index.name, "idx_users_name");
+        assert_eq!(column.name, "name");
+        assert_eq!(value, &Value::String("Ada".to_owned()));
+    }
+
+    #[test]
+    fn primary_key_scan_wins_over_secondary_index_scan() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE id == 1 AND name == 'Ada';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        assert!(matches!(
+            input.as_ref(),
+            PhysicalPlan::PrimaryKeyRangeScan {
+                range: TableKeyRange {
+                    lower: Some(TableKeyBound::Inclusive(1)),
+                    upper: Some(TableKeyBound::Inclusive(1)),
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn leftmost_usable_secondary_index_predicate_wins() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        database.create_index("idx_users_age", "users", &["age"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE age == 7 AND name == 'Ada';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        let PhysicalPlan::SecondaryIndexScan { index, column, value, .. } = input.as_ref() else {
+            panic!("expected secondary index scan under residual filter: {plan:?}");
+        };
+        assert_eq!(index.name, "idx_users_age");
+        assert_eq!(column.name, "age");
+        assert_eq!(value, &Value::Integer(7));
+    }
+
+    #[test]
+    fn earliest_created_exact_secondary_index_wins_for_same_column() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name_first", "users", &["name"]).unwrap();
+        database.create_index("idx_users_name_second", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE name == 'Ada';");
+
+        let plan = planner.plan_statement(&statement).unwrap();
+
+        let PhysicalPlan::Project { input, .. } = &plan.physical else {
+            panic!("expected project root: {plan:?}");
+        };
+        let PhysicalPlan::Filter { input, .. } = input.as_ref() else {
+            panic!("expected residual filter under project: {plan:?}");
+        };
+        let PhysicalPlan::SecondaryIndexScan { index, .. } = input.as_ref() else {
+            panic!("expected secondary index scan under residual filter: {plan:?}");
+        };
+        assert_eq!(index.name, "idx_users_name_first");
+    }
+
+    #[test]
+    fn unindexed_equality_stays_full_table_scan() {
+        let (_dir, database) = database_with_users();
+        database.create_index("idx_users_name", "users", &["name"]).unwrap();
+        let planner = Planner::new(&database);
+        let statement = parse("SELECT name FROM users WHERE age == 7;");
 
         let plan = planner.plan_statement(&statement).unwrap();
 


### PR DESCRIPTION
This PR introduces rudimentary support for index scans for query execution. We have not yet started work on any real query optimization, meaning that all queries go directly from planning to execution. Because of this, the query planner will currently plan full table scans for queries which could easily be planned as far more efficient primary or secondary index scans. Efficient query planning and execution is, of course, a work-in-progress.